### PR TITLE
Refactor WASB training to Hydra

### DIFF
--- a/src/wasb/README.md
+++ b/src/wasb/README.md
@@ -4,6 +4,18 @@ This directory contains utilities and models built around the WASB-SBDT codebase
 semi-automatic tennis ball annotation and dataset expansion, primarily to train
 transformer-based models such as `hrcnet`.
 
+## Training entrypoints
+
+The WASB training script now uses [Hydra](https://hydra.cc/) for configuration. You can
+launch training with grouped defaults and CLI overrides, for example:
+
+```bash
+python -m src.wasb.scripts.train training.max_epochs=50 data.batch_size=32
+```
+
+Configuration files live under `src/wasb/configs`, with grouped defaults for `data/`,
+`training/`, `logging/`, `metrics/`, and model variants under `model/`.
+
 ## High-level Goal
 
 Extend the original WASB tennis dataset (`data/tennis/game1..10`) with additional

--- a/src/wasb/configs/data/default.yaml
+++ b/src/wasb/configs/data/default.yaml
@@ -1,0 +1,16 @@
+root_dir: data/tennis
+train_matches: ["game1", "game2", "game3", "game4", "game5", "game6", "game7", "game11", "game12", "game13", "game15", "game16"]
+val_matches: ["game8", "game9", "game14"]
+test_matches: ["game10"]
+frames_in: 1
+frames_out: 1
+step: 1
+visibility_mode: all_visible
+image_ext: ".jpg"
+csv_filename: Label.csv
+batch_size: 4
+num_workers: 4
+resize_hw: [288, 512]
+heatmap_hw: [288, 512]
+heatmap_sigma: 2.0
+pin_memory: true

--- a/src/wasb/configs/logging/default.yaml
+++ b/src/wasb/configs/logging/default.yaml
@@ -1,0 +1,3 @@
+level: INFO
+fmt: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+datefmt: "%Y-%m-%d %H:%M:%S"

--- a/src/wasb/configs/metrics/default.yaml
+++ b/src/wasb/configs/metrics/default.yaml
@@ -1,0 +1,3 @@
+target_rmse_px: 5.0
+target_detection_rate: 0.9
+accuracy_thresh_px: 10.0

--- a/src/wasb/configs/run/default.yaml
+++ b/src/wasb/configs/run/default.yaml
@@ -1,0 +1,5 @@
+output_dir: outputs/wasb
+seed: 42
+gpus: 1
+fast_dev_run: false
+dry_run: false

--- a/src/wasb/configs/schema.py
+++ b/src/wasb/configs/schema.py
@@ -1,0 +1,113 @@
+"""Structured configuration schemas for WASB training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from hydra.core.config_store import ConfigStore
+
+
+@dataclass
+class ResumeConfig:
+    enabled: bool = False
+    ckpt_path: str | None = None
+    auto_last: bool = True
+
+
+@dataclass
+class TrainingConfig:
+    max_epochs: int = 20
+    freeze_backbone_epochs: int = 10
+    learning_rate: float = 1e-4
+    backbone_learning_rate: float = 1e-5
+    weight_decay: float = 1e-4
+    warmup_steps: int = 1000
+    min_lr: float = 1e-6
+    bce_weight: float = 1.0
+    mse_weight: float = 1.0
+    precision: str = "bf16-mixed"
+    resume: ResumeConfig = field(default_factory=ResumeConfig)
+
+
+@dataclass
+class DataConfig:
+    root_dir: str = "data/tennis"
+    train_matches: list[str] = field(
+        default_factory=lambda: [
+            "game1",
+            "game2",
+            "game3",
+            "game4",
+            "game5",
+            "game6",
+            "game7",
+            "game11",
+            "game12",
+            "game13",
+            "game15",
+            "game16",
+        ]
+    )
+    val_matches: list[str] = field(
+        default_factory=lambda: ["game8", "game9", "game14"]
+    )
+    test_matches: list[str] = field(default_factory=lambda: ["game10"])
+    frames_in: int = 1
+    frames_out: int = 1
+    step: int = 1
+    visibility_mode: str = "all_visible"
+    image_ext: str = ".jpg"
+    csv_filename: str = "Label.csv"
+    batch_size: int = 4
+    num_workers: int = 4
+    resize_hw: list[int] | None = field(default_factory=lambda: [288, 512])
+    heatmap_hw: list[int] | None = field(default_factory=lambda: [288, 512])
+    heatmap_sigma: float | None = 2.0
+    pin_memory: bool = True
+
+
+@dataclass
+class MetricsConfig:
+    target_rmse_px: float = 5.0
+    target_detection_rate: float = 0.9
+    accuracy_thresh_px: float = 10.0
+
+
+@dataclass
+class LoggingConfig:
+    level: str = "INFO"
+    fmt: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    datefmt: str = "%Y-%m-%d %H:%M:%S"
+
+
+@dataclass
+class RunConfig:
+    output_dir: str = "outputs/wasb"
+    seed: int = 42
+    gpus: int = 1
+    fast_dev_run: bool = False
+    dry_run: bool = False
+
+
+@dataclass
+class WasbTrainConfig:
+    data: DataConfig = field(default_factory=DataConfig)
+    training: TrainingConfig = field(default_factory=TrainingConfig)
+    logging: LoggingConfig = field(default_factory=LoggingConfig)
+    metrics: MetricsConfig = field(default_factory=MetricsConfig)
+    run: RunConfig = field(default_factory=RunConfig)
+    model: dict[str, Any] = field(default_factory=dict)
+
+
+def register_configs() -> None:
+    """Register structured configs for Hydra validation and tab completion."""
+
+    cs = ConfigStore.instance()
+    cs.store(name="wasb_train_config", node=WasbTrainConfig)
+    cs.store(group="training", name="default", node=TrainingConfig())
+    cs.store(group="data", name="default", node=DataConfig())
+    cs.store(group="logging", name="default", node=LoggingConfig())
+    cs.store(group="metrics", name="default", node=MetricsConfig())
+    cs.store(group="run", name="default", node=RunConfig())
+

--- a/src/wasb/configs/train.yaml
+++ b/src/wasb/configs/train.yaml
@@ -1,0 +1,14 @@
+defaults:
+  - data: default
+  - training: default
+  - logging: default
+  - metrics: default
+  - run: default
+  - model: dinov3_heatmap
+  - _self_
+
+hydra:
+  run:
+    dir: .
+  job:
+    chdir: false

--- a/src/wasb/configs/training/default.yaml
+++ b/src/wasb/configs/training/default.yaml
@@ -1,0 +1,14 @@
+max_epochs: 20
+freeze_backbone_epochs: 10
+learning_rate: 1e-4
+backbone_learning_rate: 1e-5
+weight_decay: 1e-4
+warmup_steps: 1000
+min_lr: 1e-6
+bce_weight: 1.0
+mse_weight: 1.0
+precision: "bf16-mixed"
+resume:
+  enabled: false
+  ckpt_path: null
+  auto_last: true

--- a/src/wasb/scripts/train.py
+++ b/src/wasb/scripts/train.py
@@ -1,88 +1,36 @@
-"""Training script for WASB tennis models."""
+"""Training script for WASB tennis models.
+
+Run with Hydra-style overrides, for example:
+
+```
+python -m src.wasb.scripts.train training.max_epochs=50 data.batch_size=32
+```
+"""
 
 from __future__ import annotations
 
-import argparse
 import logging
 from pathlib import Path
 
+import hydra
 import pytorch_lightning as pl
 import torch
-from omegaconf import OmegaConf
+from hydra.core.hydra_config import HydraConfig
+from omegaconf import DictConfig, OmegaConf
 from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
 from torch.nn import functional as F
 from torchvision.utils import save_image
 
+from src.wasb.configs.schema import register_configs
 from src.wasb.data.datamodule import TennisDataModule
 from src.wasb.models import build_model
 from src.wasb.training.lightning_module import WASBLightningModule
 from src.wasb.utils.checkpoint import resolve_resume_ckpt_path
-from src.wasb.utils.config import load_config, merge_configs, resolve_model_name
+from src.wasb.utils.config import resolve_model_name
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Train WASB tennis model")
-    parser.add_argument(
-        "--config",
-        type=str,
-        default=str(Path(__file__).parents[1] / "configs" / "default.yaml"),
-        help="Path to YAML config",
-    )
-    parser.add_argument(
-        "--output-dir",
-        type=str,
-        default="outputs/wasb",
-        help="Directory to save checkpoints and logs",
-    )
-    parser.add_argument("--epochs", type=int, default=None, help="Max epochs override")
-    parser.add_argument("--batch-size", type=int, default=None, help="Batch size override")
-    parser.add_argument("--lr", type=float, default=None, help="Learning rate override")
-    parser.add_argument(
-        "--backbone-lr", type=float, default=None, help="Backbone learning rate override"
-    )
-    parser.add_argument("--seed", type=int, default=42, help="Random seed")
-    parser.add_argument("--gpus", type=int, default=1, help="Number of GPUs (0 for CPU)")
-    parser.add_argument(
-        "--fast-dev-run",
-        action="store_true",
-        help="Run a quick test with a single batch",
-    )
-    parser.add_argument(
-        "--resume",
-        type=str,
-        default=None,
-        help="Path to checkpoint to resume from",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Load config and data, fetch one batch, then exit without training.",
-    )
-    return parser.parse_args()
-
-
-def build_config(args: argparse.Namespace) -> OmegaConf:
-    default_config = load_config(args.config)
-    config = default_config
-
-    overrides = {}
-    if args.epochs is not None:
-        overrides.setdefault("training", {})["max_epochs"] = args.epochs
-    if args.batch_size is not None:
-        overrides.setdefault("data", {})["batch_size"] = args.batch_size
-    if args.lr is not None:
-        overrides.setdefault("training", {})["learning_rate"] = args.lr
-    if args.backbone_lr is not None:
-        overrides.setdefault("training", {})["backbone_learning_rate"] = args.backbone_lr
-
-    if overrides:
-        config = merge_configs(config, overrides)
-
-    return config
-
-
-def _setup_logging(config: OmegaConf) -> None:
+def _setup_logging(config: DictConfig) -> None:
     """Initialize Python logging from the config.
 
     Expects a ``logging`` section in the root config with keys:
@@ -148,7 +96,7 @@ def _save_sample_visuals(batch: dict, out_dir: Path) -> None:
         (out_dir / "frame_paths.txt").write_text("\n".join(selected_paths))
 
 
-def run_dry_run(config: OmegaConf, output_dir: Path) -> None:
+def run_dry_run(config: DictConfig, output_dir: Path) -> None:
     """Verify config and dataloader by loading a single batch."""
     print("Running dry run (no training)...")
     # Force CPU-only to avoid CUDA init failures in restricted environments.
@@ -211,26 +159,30 @@ def run_dry_run(config: OmegaConf, output_dir: Path) -> None:
     trainer.fit(lightning_module, datamodule=datamodule)
 
 
-def main() -> None:
-    args = parse_args()
-    pl.seed_everything(args.seed)
 
-    config = build_config(args)
+register_configs()
+
+
+@hydra.main(config_path="../configs", config_name="train", version_base="1.3")
+def main(config: DictConfig) -> None:
+    pl.seed_everything(config.run.seed)
+
     _setup_logging(config)
     print("Configuration:")
     print(OmegaConf.to_yaml(config))
 
-    model_name = resolve_model_name(config, args.config)
-    output_dir = Path(args.output_dir) / model_name
+    cfg_name = HydraConfig.get().job.get("config_name", "train")
+    model_name = resolve_model_name(config, cfg_name)
+    output_dir = Path(config.run.output_dir) / model_name
     output_dir.mkdir(parents=True, exist_ok=True)
     OmegaConf.save(config, output_dir / "config.yaml")
 
-    if args.dry_run:
+    if config.run.dry_run:
         run_dry_run(config, output_dir)
         return
 
     resume_ckpt = resolve_resume_ckpt_path(
-        args_resume=args.resume,
+        args_resume=None,
         config=config,
         output_dir=output_dir,
     )
@@ -271,17 +223,17 @@ def main() -> None:
 
     trainer = pl.Trainer(
         max_epochs=config.training.max_epochs,
-        accelerator="gpu" if args.gpus > 0 else "cpu",
-        devices=args.gpus if args.gpus > 0 else 1,
+        accelerator="gpu" if config.run.gpus > 0 else "cpu",
+        devices=config.run.gpus if config.run.gpus > 0 else 1,
         callbacks=callbacks,
         logger=logger,
-        fast_dev_run=args.fast_dev_run,
-        precision=config.training.precision
+        fast_dev_run=config.run.fast_dev_run,
+        precision=config.training.precision,
     )
 
     trainer.fit(lightning_module, datamodule=datamodule, ckpt_path=resume_ckpt)
 
-    if not args.fast_dev_run:
+    if not config.run.fast_dev_run:
         trainer.test(lightning_module, datamodule=datamodule)
 
     print(f"Training complete. Outputs saved to {output_dir}")

--- a/src/wasb/scripts/train_trajectory.py
+++ b/src/wasb/scripts/train_trajectory.py
@@ -15,7 +15,7 @@ from pytorch_lightning.loggers import TensorBoardLogger
 from src.wasb.data.trajectory_datamodule import TrajectoryDataModule
 from src.wasb.training.trajectory_lightning_module import TrajectoryLightningModule
 from src.wasb.utils.checkpoint import resolve_resume_ckpt_path
-from src.wasb.utils.config import load_config, merge_configs, resolve_model_name
+from src.wasb.utils.config import load_config, resolve_model_name
 
 
 def parse_args() -> argparse.Namespace:
@@ -57,21 +57,15 @@ def parse_args() -> argparse.Namespace:
 
 
 def build_config(args: argparse.Namespace) -> OmegaConf:
-    default_config = load_config(args.config)
-    config = default_config
-
-    overrides: dict = {}
+    overrides = []
     if args.epochs is not None:
-        overrides.setdefault("training", {})["max_epochs"] = args.epochs
+        overrides.append(f"training.max_epochs={args.epochs}")
     if args.batch_size is not None:
-        overrides.setdefault("data", {})["batch_size"] = args.batch_size
+        overrides.append(f"data.batch_size={args.batch_size}")
     if args.lr is not None:
-        overrides.setdefault("training", {})["learning_rate"] = args.lr
+        overrides.append(f"training.learning_rate={args.lr}")
 
-    if overrides:
-        config = merge_configs(config, overrides)
-
-    return config
+    return load_config(args.config, overrides=overrides)
 
 
 def _setup_logging(config: OmegaConf) -> None:

--- a/src/wasb/utils/config.py
+++ b/src/wasb/utils/config.py
@@ -1,58 +1,25 @@
-"""Configuration utilities for WASB tennis training."""
+"""Configuration utilities leveraging Hydra composition."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
-from omegaconf import DictConfig, OmegaConf
-
-
-def _apply_defaults(cfg: DictConfig, base_dir: Path) -> DictConfig:
-    """Resolve Hydra-like defaults by loading referenced config files."""
-    defaults = cfg.pop("defaults", [])
-    merged: DictConfig = OmegaConf.create()
-
-    for item in defaults:
-        if isinstance(item, (dict, DictConfig)):
-            for group, name in item.items():
-                cfg_path = base_dir / group / f"{name}.yaml"
-                if not cfg_path.exists():
-                    raise FileNotFoundError(f"Default config file not found: {cfg_path}")
-                part = OmegaConf.load(cfg_path)
-                # Merge each part under its group key, e.g. merged[group] <- merged[group] + part
-                existing_group_cfg = merged.get(group, OmegaConf.create())
-                merged[group] = OmegaConf.merge(existing_group_cfg, part)
-        else:
-            raise ValueError(f"Unsupported defaults entry: {item}")
-
-    return OmegaConf.merge(merged, cfg)
+from hydra import compose, initialize_config_dir
+from omegaconf import DictConfig
 
 
-def load_config(path: str | Path) -> DictConfig:
-    """Load a YAML configuration file, resolving `defaults` includes."""
-    config_path = Path(path)
-    if not config_path.exists():
-        raise FileNotFoundError(f"Config file not found: {config_path}")
+def load_config(path: str | Path, overrides: list[str] | None = None) -> DictConfig:
+    """Load a Hydra config file with optional CLI-style overrides."""
 
-    cfg = OmegaConf.load(config_path)  # type: ignore[assignment]
-    if cfg is None:
-        raise ValueError(f"Config file is empty or invalid: {config_path}")
-
-    if "defaults" in cfg:
-        cfg = _apply_defaults(cfg, config_path.parent)
-
-    return cfg
+    cfg_path = Path(path)
+    overrides = overrides or []
+    with initialize_config_dir(
+        config_dir=str(cfg_path.parent), job_name="load_config", version_base="1.3"
+    ):
+        return compose(config_name=cfg_path.stem, overrides=overrides)
 
 
-def merge_configs(*configs: DictConfig | dict[str, Any]) -> DictConfig:
-    """Merge multiple configurations; later entries override earlier ones."""
-    if not configs:
-        raise ValueError("At least one config must be provided to merge_configs.")
-    return OmegaConf.merge(*configs)  # type: ignore[return-value]
-
-
-def resolve_model_name(config: DictConfig, config_path: str | Path) -> str:
+def resolve_model_name(config: DictConfig, config_path: str | Path | None) -> str:
     model_cfg = None
     if hasattr(config, "get"):
         model_cfg = config.get("model")
@@ -69,4 +36,7 @@ def resolve_model_name(config: DictConfig, config_path: str | Path) -> str:
     if name is not None and str(name).strip() != "":
         return str(name).strip()
 
+    if config_path is None:
+        return "wasb"
     return Path(config_path).stem
+

--- a/tests/unit/wasb/test_train_trajectory_output_dir.py
+++ b/tests/unit/wasb/test_train_trajectory_output_dir.py
@@ -17,7 +17,7 @@ def test_resolve_model_name_from_defaults() -> None:
 
 def test_resolve_model_name_from_wasb_default_config() -> None:
     repo_root = Path(__file__).resolve().parents[3]
-    config_path = repo_root / "src" / "wasb" / "configs" / "default.yaml"
+    config_path = repo_root / "src" / "wasb" / "configs" / "train.yaml"
     config = load_config(config_path)
 
     assert resolve_model_name(config, config_path) == str(config.model.name)


### PR DESCRIPTION
## Summary
- replace the WASB training entrypoint with a Hydra-powered configuration flow
- add grouped Hydra config defaults for data, training, logging, metrics, runtime, and models
- simplify configuration utilities and update tests/docs to use Hydra-style overrides

## Testing
- pytest tests/unit/wasb/test_train_trajectory_output_dir.py *(fails: pytest-cov options unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cb9629b188329a75e4ce3cfb95d61)