### PR TITLE
Remove coverage threshold enforcement from pytest and coverage config…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,6 @@ exclude_lines = [
 ]
 show_missing = true
 precision = 2
-fail_under = 75
 
 [tool.coverage.html]
 directory = "htmlcov"
@@ -239,7 +238,6 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=html:htmlcov",
     "--cov-report=xml",
-    "--cov-fail-under=75",
     "--strict-markers",
     "--disable-warnings",
     # Enable doctest for docstring Examples (turn on when examples are stable)


### PR DESCRIPTION
…urations

Delete fail_under=75 from [tool.coverage.run] and --cov-fail-under=75 from pytest addopts to allow builds to pass regardless of coverage percentage while still generating coverage reports.