### PR TITLE
Update trajectory completion training configuration to enable masking…

### DIFF
--- a/src/wasb/configs/data/trajectory.yaml
+++ b/src/wasb/configs/data/trajectory.yaml
@@ -7,11 +7,11 @@ step: 8
 min_visible_per_window: 4
 image_ext: ".jpg"
 csv_filename: Label.csv
-block_mask_min_len: 0
-block_mask_max_len: 0
-sparse_mask_prob: 0.0
-noise_prob: 0.5
-noise_std_px: 5.0
+block_mask_min_len: 3
+block_mask_max_len: 5
+sparse_mask_prob: 0.1
+noise_prob: 0.1
+noise_std_px: 3.0
 batch_size: 32
 num_workers: 4
 pin_memory: true

--- a/src/wasb/configs/train_trajectory.yaml
+++ b/src/wasb/configs/train_trajectory.yaml
@@ -3,7 +3,7 @@ defaults:
   - training: trajectory
   - logging: default
   - run: trajectory
-  - model: trajectory_refiner
+  - model: trajectory_bilstm
   - _self_
 
 hydra:

--- a/src/wasb/configs/training/trajectory.yaml
+++ b/src/wasb/configs/training/trajectory.yaml
@@ -3,8 +3,8 @@ learning_rate: 1.0e-3
 weight_decay: 1.0e-4
 warmup_steps: 1000
 min_lr: 1.0e-6
-lambda_block: 0
-lambda_sparse: 0
+lambda_block: 1.0
+lambda_sparse: 1.0
 lambda_noise: 1.0
 precision: "32"
 resume:

--- a/src/wasb/configs/visualize_trajectory.yaml
+++ b/src/wasb/configs/visualize_trajectory.yaml
@@ -3,7 +3,7 @@ defaults:
   - training: trajectory
   - logging: default
   - run: visualize_trajectory
-  - model: trajectory_refiner
+  - model: trajectory_bilstm
   - visualization: trajectory
   - _self_
 


### PR DESCRIPTION
… and use BiLSTM model

Enable block masking (min_len=3, max_len=5) and sparse masking (prob=0.1), reduce noise probability from 0.5 to 0.1 and noise_std_px from 5.0 to 3.0 in trajectory data config. Set lambda_block and lambda_sparse to 1.0 in training config to activate masking loss terms. Switch default model from trajectory_refiner to trajectory_bilstm in train_trajectory.yaml and visualize_trajectory.yaml.