### PR TITLE
Add data augmentation pipeline with configurable transforms for training

### DIFF
--- a/src/wasb/configs/data/default.yaml
+++ b/src/wasb/configs/data/default.yaml
@@ -2,7 +2,7 @@ root_dir: data/tennis
 train_matches: ["game1", "game2", "game3", "game4", "game5", "game6", "game7", "game11", "game12", "game13", "game15", "game16"]
 val_matches: ["game8", "game9", "game14"]
 test_matches: ["game10"]
-frames_in: 1
+frames_in: 3
 frames_out: 1
 step: 1
 visibility_mode: all_visible
@@ -14,3 +14,23 @@ resize_hw: [288, 512]
 heatmap_hw: [288, 512]
 heatmap_sigma: 2.0
 pin_memory: true
+augment:
+  enabled: true
+  color_jitter:
+    prob: 0.8
+    brightness: 0.2
+    contrast: 0.2
+    saturation: 0.1
+    hue: 0.05
+  random_grayscale:
+    prob: 0.1
+  gaussian_blur:
+    prob: 0.1
+    kernel_size: 3
+    sigma_min: 0.1
+    sigma_max: 1.0
+  random_erasing:
+    prob: 0.2
+    scale: [0.02, 0.15]
+    ratio: [0.3, 3.3]
+    value: 0

--- a/src/wasb/data/datamodule.py
+++ b/src/wasb/data/datamodule.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Sequence
 
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader
+from torchvision import transforms
 
 from src.wasb.data.dataset import (
     TennisSequenceDataset,
@@ -39,9 +41,80 @@ class TennisDataModule(pl.LightningDataModule):
         self.heatmap_sigma = data_cfg.get("heatmap_sigma")
         self.pin_memory = data_cfg.get("pin_memory", True)
 
+        self.augment_cfg = data_cfg.get("augment", {})
+
         self.train_dataset: TennisSequenceDataset | None = None
         self.val_dataset: TennisSequenceDataset | None = None
         self.test_dataset: TennisSequenceDataset | None = None
+
+    def _build_transform(self, train: bool) -> Callable:
+        data_aug = self.augment_cfg or {}
+        enabled = bool(data_aug.get("enabled", False)) and train
+
+        ops: list[Callable] = []
+        if self.resize_hw is not None:
+            ops.append(transforms.Resize(self.resize_hw))
+
+        if enabled:
+            cj = data_aug.get("color_jitter", {})
+            cj_prob = float(cj.get("prob", 0.0))
+            if cj_prob > 0:
+                ops.append(
+                    transforms.RandomApply(
+                        [
+                            transforms.ColorJitter(
+                                brightness=float(cj.get("brightness", 0.0)),
+                                contrast=float(cj.get("contrast", 0.0)),
+                                saturation=float(cj.get("saturation", 0.0)),
+                                hue=float(cj.get("hue", 0.0)),
+                            )
+                        ],
+                        p=cj_prob,
+                    )
+                )
+
+            gs = data_aug.get("random_grayscale", {})
+            gs_prob = float(gs.get("prob", 0.0))
+            if gs_prob > 0:
+                ops.append(transforms.RandomGrayscale(p=gs_prob))
+
+            gb = data_aug.get("gaussian_blur", {})
+            gb_prob = float(gb.get("prob", 0.0))
+            if gb_prob > 0:
+                kernel_size = int(gb.get("kernel_size", 3))
+                sigma_min = float(gb.get("sigma_min", 0.1))
+                sigma_max = float(gb.get("sigma_max", 2.0))
+                ops.append(
+                    transforms.RandomApply(
+                        [
+                            transforms.GaussianBlur(
+                                kernel_size=kernel_size,
+                                sigma=(sigma_min, sigma_max),
+                            )
+                        ],
+                        p=gb_prob,
+                    )
+                )
+
+        ops.append(transforms.ToTensor())
+
+        if enabled:
+            re_cfg = data_aug.get("random_erasing", {})
+            re_prob = float(re_cfg.get("prob", 0.0))
+            if re_prob > 0:
+                scale = re_cfg.get("scale", [0.02, 0.2])
+                ratio = re_cfg.get("ratio", [0.3, 3.3])
+                value = re_cfg.get("value", 0)
+                ops.append(
+                    transforms.RandomErasing(
+                        p=re_prob,
+                        scale=(float(scale[0]), float(scale[1])),
+                        ratio=(float(ratio[0]), float(ratio[1])),
+                        value=value,
+                    )
+                )
+
+        return transforms.Compose(ops)
 
     def setup(self, stage: str | None = None) -> None:
         if stage in (None, "fit"):
@@ -54,6 +127,7 @@ class TennisDataModule(pl.LightningDataModule):
                 visibility_mode=self.visibility_mode,
                 image_ext=self.image_ext,
                 csv_filename=self.csv_filename,
+                transform=self._build_transform(train=True),
                 resize_hw=self.resize_hw,
                 heatmap_hw=self.heatmap_hw,
                 heatmap_sigma=self.heatmap_sigma,
@@ -67,6 +141,7 @@ class TennisDataModule(pl.LightningDataModule):
                 visibility_mode=self.visibility_mode,
                 image_ext=self.image_ext,
                 csv_filename=self.csv_filename,
+                transform=self._build_transform(train=False),
                 resize_hw=self.resize_hw,
                 heatmap_hw=self.heatmap_hw,
                 heatmap_sigma=self.heatmap_sigma,
@@ -82,6 +157,7 @@ class TennisDataModule(pl.LightningDataModule):
                 visibility_mode=self.visibility_mode,
                 image_ext=self.image_ext,
                 csv_filename=self.csv_filename,
+                transform=self._build_transform(train=False),
                 resize_hw=self.resize_hw,
                 heatmap_hw=self.heatmap_hw,
                 heatmap_sigma=self.heatmap_sigma,


### PR DESCRIPTION
Add augmentation config section to default.yaml with color jitter, random grayscale, gaussian blur, and random erasing. Implement _build_transform() method in TennisDataModule to construct torchvision transform pipelines based on config, applying augmentations only during training. Update frames_in from 1 to 3 in default config. Pass train-specific and validation/test-specific transforms to TennisSequenceDataset instances during