### PR TITLE
Add curriculum sampling support for ball detection training with visi…

### DIFF
--- a/src/wasb/configs/data/ball_detection.yaml
+++ b/src/wasb/configs/data/ball_detection.yaml
@@ -35,3 +35,15 @@ augment:
     ratio: [0.3, 3.3]
     value: 0
 
+# Sampling strategy (curriculum).
+# - Warmup: standard shuffle sampling (as before).
+# - After `switch_step`: oversample so that vis=1 and vis=2 appear equally often.
+sampling:
+  curriculum:
+    enabled: false
+    switch_step: 0
+    balance_visibility: [1, 2]
+    target_ratio: [0.5, 0.5]
+    replacement: true
+    # Optional override for epoch length (defaults to dataset size).
+    num_samples_per_epoch: null

--- a/src/wasb/data/ball_detection_datamodule.py
+++ b/src/wasb/data/ball_detection_datamodule.py
@@ -7,13 +7,14 @@ from pathlib import Path
 from typing import Sequence
 
 import pytorch_lightning as pl
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Sampler
 from torchvision import transforms
 
 from src.wasb.data.ball_detection_dataset import (
     BallDetectionSequenceDataset,
     VisibilityMode,
 )
+from src.wasb.data.curriculum_sampling import VisibilityCurriculumSampler
 
 
 class BallDetectionDataModule(pl.LightningDataModule):
@@ -23,6 +24,9 @@ class BallDetectionDataModule(pl.LightningDataModule):
         super().__init__()
         cfg = config or {}
         data_cfg = cfg.get("data", {})
+
+        run_cfg = cfg.get("run", {}) if hasattr(cfg, "get") else {}
+        self.seed = int(run_cfg.get("seed", 0))
 
         self.root_dir = Path(data_cfg.get("root_dir", "data/tennis"))
         self.train_matches: Sequence[str] = data_cfg.get("train_matches", [])
@@ -43,9 +47,23 @@ class BallDetectionDataModule(pl.LightningDataModule):
 
         self.augment_cfg = data_cfg.get("augment", {})
 
+        sampling_cfg = data_cfg.get("sampling", {}) or {}
+        curriculum_cfg = sampling_cfg.get("curriculum", {}) or {}
+        self.curriculum_enabled = bool(curriculum_cfg.get("enabled", False))
+        self.curriculum_switch_step = int(curriculum_cfg.get("switch_step", 0))
+        self.curriculum_balance_visibility = curriculum_cfg.get(
+            "balance_visibility", [1, 2]
+        )
+        self.curriculum_target_ratio = curriculum_cfg.get("target_ratio", [0.5, 0.5])
+        self.curriculum_replacement = bool(curriculum_cfg.get("replacement", True))
+        self.curriculum_num_samples_per_epoch = curriculum_cfg.get(
+            "num_samples_per_epoch", None
+        )
+
         self.train_dataset: BallDetectionSequenceDataset | None = None
         self.val_dataset: BallDetectionSequenceDataset | None = None
         self.test_dataset: BallDetectionSequenceDataset | None = None
+        self.train_sampler: VisibilityCurriculumSampler | None = None
 
     def _build_transform(self, train: bool) -> Callable:
         data_aug = self.augment_cfg or {}
@@ -118,7 +136,7 @@ class BallDetectionDataModule(pl.LightningDataModule):
 
     def setup(self, stage: str | None = None) -> None:
         if stage in (None, "fit"):
-        self.train_dataset = BallDetectionSequenceDataset(
+            self.train_dataset = BallDetectionSequenceDataset(
                 root_dir=self.root_dir,
                 matches=self.train_matches,
                 frames_in=self.frames_in,
@@ -132,7 +150,7 @@ class BallDetectionDataModule(pl.LightningDataModule):
                 heatmap_hw=self.heatmap_hw,
                 heatmap_sigma=self.heatmap_sigma,
             )
-        self.val_dataset = BallDetectionSequenceDataset(
+            self.val_dataset = BallDetectionSequenceDataset(
                 root_dir=self.root_dir,
                 matches=self.val_matches or self.train_matches,
                 frames_in=self.frames_in,
@@ -146,9 +164,20 @@ class BallDetectionDataModule(pl.LightningDataModule):
                 heatmap_hw=self.heatmap_hw,
                 heatmap_sigma=self.heatmap_sigma,
             )
+            self.train_sampler = None
+            if self.curriculum_enabled:
+                self.train_sampler = VisibilityCurriculumSampler(
+                    visibilities=self.train_dataset.sample_visibilities,
+                    switch_step=self.curriculum_switch_step,
+                    balance_values=self.curriculum_balance_visibility,
+                    target_ratio=self.curriculum_target_ratio,
+                    replacement=self.curriculum_replacement,
+                    seed=self.seed,
+                    num_samples=self.curriculum_num_samples_per_epoch,
+                )
 
         if stage in (None, "test"):
-        self.test_dataset = BallDetectionSequenceDataset(
+            self.test_dataset = BallDetectionSequenceDataset(
                 root_dir=self.root_dir,
                 matches=self.test_matches or self.val_matches or self.train_matches,
                 frames_in=self.frames_in,
@@ -164,21 +193,27 @@ class BallDetectionDataModule(pl.LightningDataModule):
             )
 
     def _loader(
-        self, dataset: BallDetectionSequenceDataset | None, shuffle: bool
+        self,
+        dataset: BallDetectionSequenceDataset | None,
+        shuffle: bool,
+        sampler: Sampler[int] | None = None,
     ) -> DataLoader:
         if dataset is None:
             raise RuntimeError("Dataset is not initialized; call setup() first.")
         return DataLoader(
             dataset,
             batch_size=self.batch_size,
-            shuffle=shuffle,
+            shuffle=shuffle if sampler is None else False,
+            sampler=sampler,
             num_workers=self.num_workers,
             pin_memory=self.pin_memory,
             persistent_workers=self.num_workers > 0,
         )
 
     def train_dataloader(self) -> DataLoader:
-        return self._loader(self.train_dataset, shuffle=True)
+        return self._loader(
+            self.train_dataset, shuffle=True, sampler=self.train_sampler
+        )
 
     def val_dataloader(self) -> DataLoader:
         return self._loader(self.val_dataset, shuffle=False)

--- a/src/wasb/data/ball_detection_dataset.py
+++ b/src/wasb/data/ball_detection_dataset.py
@@ -27,6 +27,7 @@ class SequenceSample:
 
     frame_paths: list[Path]
     targets: list[TennisLabelRow]
+    target_visibility: int
     match: str
     clip: str
 
@@ -107,10 +108,17 @@ def build_sequence_index(
                     continue
 
                 frame_paths = [clip_dir / name for name in window]
+                # For curriculum sampling we track a single visibility label per
+                # sequence sample. When frames_out > 1, we treat a sample as
+                # "challenging" (vis=2) if any target frame is vis=2.
+                target_visibility = (
+                    int(max(t.visibility for t in targets)) if targets else 0
+                )
                 samples.append(
                     SequenceSample(
                         frame_paths=frame_paths,
                         targets=targets,
+                        target_visibility=target_visibility,
                         match=match,
                         clip=clip_dir.name,
                     )
@@ -183,6 +191,7 @@ class BallDetectionSequenceDataset(Dataset):
             image_ext=image_ext,
             csv_filename=csv_filename,
         )
+        self.sample_visibilities = [s.target_visibility for s in self.samples]
         if not self.samples:
             raise RuntimeError(f"No samples found under {self.root_dir}")
 

--- a/src/wasb/data/curriculum_sampling.py
+++ b/src/wasb/data/curriculum_sampling.py
@@ -1,0 +1,132 @@
+"""Curriculum sampling utilities for WASB datasets.
+
+This module provides a step-aware sampler that can switch sampling strategy
+mid-training, e.g. to balance visibility classes after a warmup phase.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterator, Sequence
+
+import pytorch_lightning as pl
+import torch
+from torch.utils.data import Sampler
+
+
+class VisibilityCurriculumSampler(Sampler[int]):
+    """Sampler that switches to visibility-balanced sampling after a step.
+
+    Notes:
+        - The switch is applied when the sampler is iterated. In Lightning this
+          typically happens at epoch boundaries (new dataloader iterator).
+        - Balancing is implemented via weighted sampling with replacement.
+    """
+
+    def __init__(
+        self,
+        *,
+        visibilities: Sequence[int],
+        switch_step: int,
+        balance_values: Sequence[int] = (1, 2),
+        target_ratio: Sequence[float] = (0.5, 0.5),
+        replacement: bool = True,
+        seed: int = 0,
+        num_samples: int | None = None,
+    ) -> None:
+        if len(balance_values) != len(target_ratio):
+            raise ValueError("balance_values and target_ratio must have same length")
+        if switch_step < 0:
+            raise ValueError("switch_step must be >= 0")
+        if any(r < 0 for r in target_ratio):
+            raise ValueError("target_ratio must be non-negative")
+        ratio_sum = float(sum(target_ratio))
+        if ratio_sum <= 0:
+            raise ValueError("target_ratio must sum to > 0")
+
+        self._visibilities = list(map(int, visibilities))
+        self._switch_step = int(switch_step)
+        self._balance_values = list(map(int, balance_values))
+        self._target_ratio = [float(r) / ratio_sum for r in target_ratio]
+        self._replacement = bool(replacement)
+        self._seed = int(seed)
+
+        self._num_samples = (
+            int(num_samples) if num_samples is not None else len(self._visibilities)
+        )
+        if self._num_samples <= 0:
+            raise ValueError("num_samples must be > 0")
+
+        self._epoch = 0
+        self._step = 0
+        self._balanced_weights = self._compute_balanced_weights()
+
+    def set_epoch(self, epoch: int) -> None:
+        self._epoch = int(epoch)
+
+    def set_step(self, step: int) -> None:
+        self._step = int(step)
+
+    def using_balanced_sampling(self) -> bool:
+        return self._step >= self._switch_step and self._balanced_weights is not None
+
+    def _compute_balanced_weights(self) -> torch.Tensor | None:
+        counts = Counter(self._visibilities)
+        missing = [v for v in self._balance_values if counts.get(v, 0) <= 0]
+        if missing:
+            return None
+
+        per_class_weight: dict[int, float] = {}
+        for v, r in zip(self._balance_values, self._target_ratio):
+            per_class_weight[v] = r / float(counts[v])
+
+        weights = torch.tensor(
+            [per_class_weight.get(v, 0.0) for v in self._visibilities],
+            dtype=torch.double,
+        )
+        if float(weights.sum().item()) <= 0.0:
+            return None
+        return weights
+
+    def __iter__(self) -> Iterator[int]:
+        generator = torch.Generator()
+        generator.manual_seed(self._seed + self._epoch)
+
+        n = len(self._visibilities)
+        if not self.using_balanced_sampling():
+            # Warmup phase: behave like a standard shuffle.
+            if self._num_samples <= n:
+                indices = torch.randperm(n, generator=generator)[: self._num_samples]
+                yield from indices.tolist()
+            else:
+                remaining = self._num_samples
+                while remaining > 0:
+                    perm = torch.randperm(n, generator=generator)
+                    take = min(remaining, n)
+                    yield from perm[:take].tolist()
+                    remaining -= take
+            return
+
+        assert self._balanced_weights is not None
+        sampled = torch.multinomial(
+            self._balanced_weights,
+            num_samples=self._num_samples,
+            replacement=self._replacement,
+            generator=generator,
+        )
+        yield from sampled.tolist()
+
+    def __len__(self) -> int:
+        return self._num_samples
+
+
+class CurriculumStepCallback(pl.Callback):
+    """Updates a step-aware sampler with Lightning's step/epoch counters."""
+
+    def __init__(self, sampler: VisibilityCurriculumSampler) -> None:
+        super().__init__()
+        self._sampler = sampler
+
+    def on_train_epoch_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:  # noqa: ARG002
+        self._sampler.set_epoch(trainer.current_epoch)
+        self._sampler.set_step(trainer.global_step)

--- a/src/wasb/scripts/train/ball_detection.py
+++ b/src/wasb/scripts/train/ball_detection.py
@@ -24,6 +24,7 @@ from torch.nn import functional as F
 from torchvision.utils import save_image
 
 from src.wasb.data.ball_detection_datamodule import BallDetectionDataModule
+from src.wasb.data.curriculum_sampling import CurriculumStepCallback
 from src.wasb.models import build_model
 from src.wasb.training import WASBLightningModule
 from src.wasb.utils.checkpoint import resolve_resume_ckpt_path
@@ -213,6 +214,8 @@ def main(config: DictConfig) -> None:
         ),
         LearningRateMonitor(logging_interval="step"),
     ]
+    if datamodule.train_sampler is not None:
+        callbacks.append(CurriculumStepCallback(datamodule.train_sampler))
 
     trainer = pl.Trainer(
         max_epochs=config.training.max_epochs,


### PR DESCRIPTION
…bility-based balancing

Introduce VisibilityCurriculumSampler that switches from standard shuffle sampling to visibility-balanced sampling after a configurable warmup step. Add curriculum config section to ball_detection.yaml with parameters for switch_step, balance_visibility classes, target_ratio, and optional epoch length override. Update BallDetectionDataModule to instantiate sampler when curriculum.enabled=true and pass to