### PR TITLE
Add README documentation for BLCS, PLCS, and WASB task modules with u…

### DIFF
--- a/src/blcs/README.md
+++ b/src/blcs/README.md
@@ -1,0 +1,40 @@
+# BLCS (Ball Localization in Court System)
+
+BLCS は、テニスコート座標系におけるボールの 3D 軌道を、2D のボール観測（画像座標）とコート情報から推定するためのタスク実装です。
+
+## 目的 / 想定入出力
+
+- 入力: 2D ボール観測（例: 各カメラのヒートマップ/検出点）＋コート幾何
+- 出力: コート座標系の 3D 位置（軌道）や、可視化・評価指標
+
+## ディレクトリ構成（要点）
+
+- `configs/`: Hydra 設定（学習・生成・可視化のエントリポイント YAML を含む）
+- `data/`: データセット I/O、DataModule、シーン生成（カメラ/投影など）
+- `simulation/`: 物理モデル（ボール運動）とショット/シーンのシミュレーション
+- `models/`: 推定モデル実装（例: `BLCSModel`）
+- `training/`: LightningModule、損失、メトリクス
+- `inference/`: 推論・可視化向けの Predictor / 補助ロジック
+- `scripts/`: 実行スクリプト（Hydra 前提）
+- `utils/`: BLCS 固有ユーティリティ（共通ロジックは `src/utils` を使用）
+
+## 代表的な実行コマンド（Hydra）
+
+データ生成:
+- `uv run python -m src.blcs.scripts.generate_dataset`
+- 例: `uv run python -m src.blcs.scripts.generate_dataset run.output_dir=data/blcs sampling.per_from_cell_samples=10`
+
+学習:
+- `uv run python -m src.blcs.scripts.train`
+- 例: `uv run python -m src.blcs.scripts.train training.max_epochs=5 run.gpus=0`
+
+可視化（必要に応じて予測も実行）:
+- `uv run python -m src.blcs.scripts.visualize`
+- 例: `uv run python -m src.blcs.scripts.visualize visualization.scene_path=data/blcs/scenes/scene_000000.npz visualization.info=true`
+- 例: `uv run python -m src.blcs.scripts.visualize visualization.mode=predict visualization.checkpoint=outputs/blcs/checkpoints/last.ckpt`
+
+## 設定の入口
+
+- 学習: `src/blcs/configs/train.yaml`
+- データ生成: `src/blcs/configs/generate_dataset.yaml`
+- 可視化: `src/blcs/configs/visualize.yaml`

--- a/src/plcs/README.md
+++ b/src/plcs/README.md
@@ -1,0 +1,38 @@
+# PLCS (Player Localization in Court System)
+
+PLCS は、テニスコート座標系におけるプレイヤーの位置・向き（姿勢）を、2D の姿勢観測（例: 2D pose）から推定するためのタスク実装です。
+
+## 目的 / 想定入出力
+
+- 入力: 2D pose（関節座標など）＋カメラ/コート情報
+- 出力: コート座標系でのプレイヤー位置・回転、評価指標、可視化
+
+## ディレクトリ構成（要点）
+
+- `configs/`: Hydra 設定（フレーム/シーケンス学習、生成、可視化の設定を含む）
+- `data/`: データセット I/O、シーン生成、DataModule（frame/sequence）
+- `models/`: 推定モデル（frame / sequence）
+- `training/`: LightningModule、損失、メトリクス（frame/sequence）
+- `inference/`: 推論・可視化向けの Predictor
+- `scripts/`: 実行スクリプト（Hydra 前提）
+- `utils/`: PLCS 固有ユーティリティ（共通ロジックは `src/utils` を使用）
+
+## 代表的な実行コマンド（Hydra）
+
+データ生成:
+- `uv run python -m src.plcs.scripts.generate_dataset`
+
+学習（frame / sequence）:
+- `uv run python -m src.plcs.scripts.train`
+- `uv run python -m src.plcs.scripts.train_sequence`
+- 例: `uv run python -m src.plcs.scripts.train run.gpus=0 training.max_epochs=1`
+
+可視化:
+- `uv run python -m src.plcs.scripts.visualize`
+- 例: `uv run python -m src.plcs.scripts.visualize visualization.scene_path=data/plcs/scenes/scene_000000.npz visualization.info=true`
+
+## 設定の入口
+
+- 学習（frame）: `src/plcs/configs/train.yaml`
+- 学習（sequence）: `src/plcs/configs/train_sequence.yaml`
+- 可視化: `src/plcs/configs/visualize.yaml`

--- a/src/wasb/README.md
+++ b/src/wasb/README.md
@@ -1,0 +1,41 @@
+# WASB / HRCNet（半自動アノテーション・データセット拡張）
+
+`src/wasb` は、WASB/HRCNet 系のボール検出モデル等を用いた半自動アノテーション、およびテニスデータセット拡張のための実装です。
+動画からのフレーム抽出、ボール検出、クリップ分割、ラベル出力までを一連のパイプラインとして扱います。
+
+## ディレクトリ構成（要点）
+
+- `configs/`: Hydra 設定（学習・生成・可視化などのエントリポイント YAML）
+- `data/`: データセット/動画入出力、DataModule、サンプリング等
+- `models/`: 検出・補完・セグメンテーション等のモデル実装
+- `training/`: LightningModule、学習ループ周辺
+- `inference/`: 予測器（WASB/HRCNet）、軌道補完など
+- `pipeline/`: エンドツーエンドのアノテーションパイプライン（例: `annotation_pipeline.py`）
+- `scripts/`: 実行スクリプト（Hydra 前提、学習/生成/可視化が中心）
+- `tennis_format.py`: `label.csv` 等の I/O ヘルパー（データセット形式の取り扱い）
+- `utils/`: ストリーミングローダ、動画抽出などの補助実装
+
+## 代表的な実行コマンド（Hydra）
+
+データセット生成（入口）:
+- `uv run python -m src.wasb.scripts.generate_dataset`
+
+データセット生成（各ステップ）:
+- `uv run python -m src.wasb.scripts.generate_dataset.download_videos`
+- `uv run python -m src.wasb.scripts.generate_dataset.clip_sampling`
+- `uv run python -m src.wasb.scripts.generate_dataset.batch`
+
+学習:
+- `uv run python -m src.wasb.scripts.train.ball_detection`
+- `uv run python -m src.wasb.scripts.train.trajectory`
+- `uv run python -m src.wasb.scripts.train.event_detection`
+
+可視化:
+- `uv run python -m src.wasb.scripts.visualize.trajectory`
+- `uv run python -m src.wasb.scripts.visualize.ball_video`
+- `uv run python -m src.wasb.scripts.visualize.ball_video_ensemble`
+
+## 設定の入口（例）
+
+- ボール検出学習: `src/wasb/configs/train_ball_detection.yaml`（実行時の共通ランタイムは `src/wasb/configs/run/ball_detection.yaml`）
+- スクリプトごとの `Config entry point` は、各 `src/wasb/scripts/**.py` の docstring を参照してください。


### PR DESCRIPTION
…sage examples and directory structure

Create comprehensive README.md files for three task modules: BLCS (Ball Localization in Court System) for 3D ball trajectory estimation, PLCS (Player Localization in Court System) for player pose estimation, and WASB for semi-automatic annotation and dataset expansion. Each README documents purpose, input/output, directory structure, common Hydra commands for dataset generation/training/visualization