### PR TITLE
Add temporal peak consistency loss with velocity/acceleration regular…

### DIFF
--- a/src/wasb/configs/loss/ball_detection.yaml
+++ b/src/wasb/configs/loss/ball_detection.yaml
@@ -1,4 +1,10 @@
 # Ball detection loss configuration (WASB heatmap losses).
 bce_weight: 1.0
 mse_weight: 0.0
-
+temporal_weight: 0.1
+temporal:
+  order: 2
+  robust: true
+  prob_mode: sigmoid_norm
+  beta: 25.0
+  detach_conf: true

--- a/src/wasb/configs/training/ball_detection.yaml
+++ b/src/wasb/configs/training/ball_detection.yaml
@@ -7,6 +7,13 @@ warmup_steps: 1000
 min_lr: 1e-6
 bce_weight: 1.0
 mse_weight: 0.0
+temporal_weight: 0.1
+temporal:
+  order: 2
+  robust: true
+  prob_mode: sigmoid_norm
+  beta: 25.0
+  detach_conf: true
 precision: "bf16-mixed"
 input_key: frames
 use_metrics: true

--- a/src/wasb/training/ball_detection/lightning_module.py
+++ b/src/wasb/training/ball_detection/lightning_module.py
@@ -12,7 +12,11 @@ from torch.optim import AdamW
 from torch.optim.lr_scheduler import LambdaLR
 
 from src.wasb.models import build_model
-from src.wasb.training.ball_detection.loss import LossWeights, WASBLoss
+from src.wasb.training.ball_detection.loss import (
+    LossWeights,
+    TemporalPeakLossConfig,
+    WASBLoss,
+)
 from src.wasb.training.ball_detection.metrics import WASBMetrics
 
 if TYPE_CHECKING:
@@ -59,11 +63,19 @@ class WASBLightningModule(pl.LightningModule):
         loss_cfg = self.config.get("loss", {})
         bce_weight = loss_cfg.get("bce_weight", train_cfg.get("bce_weight", 1.0))
         mse_weight = loss_cfg.get("mse_weight", train_cfg.get("mse_weight", 1.0))
+        temporal_weight = loss_cfg.get("temporal_weight", train_cfg.get("temporal_weight", 0.0))
+        temporal_cfg_raw = loss_cfg.get("temporal", train_cfg.get("temporal", {}))
         loss_weights = LossWeights(
             bce=bce_weight,
             mse=mse_weight,
+            temporal=temporal_weight,
         )
-        self.loss_fn = WASBLoss(weights=loss_weights)
+        temporal_cfg = (
+            TemporalPeakLossConfig(**temporal_cfg_raw)
+            if isinstance(temporal_cfg_raw, dict) and temporal_cfg_raw
+            else TemporalPeakLossConfig()
+        )
+        self.loss_fn = WASBLoss(weights=loss_weights, temporal_cfg=temporal_cfg)
 
         self.use_metrics = bool(train_cfg.get("use_metrics", True))
         if self.use_metrics:

--- a/src/wasb/training/ball_detection/loss.py
+++ b/src/wasb/training/ball_detection/loss.py
@@ -1,4 +1,14 @@
-"""Loss functions for WASB ball detection training."""
+"""Loss functions for WASB ball detection training.
+
+Adds an optional temporal-consistency loss that encourages the predicted heatmap
+peak to move smoothly over time (velocity or acceleration regularization) using
+a differentiable soft-argmax style coordinate extraction.
+
+Notes:
+- `pred_heatmaps` are treated as logits for BCEWithLogits (as in your original code).
+- The temporal loss converts logits -> probability map internally.
+- If a loss weight is 0.0, that loss is NOT computed (skipped).
+"""
 
 from __future__ import annotations
 
@@ -10,22 +20,52 @@ import torch.nn.functional as F
 from torch import Tensor
 
 
-@dataclass
+@dataclass(frozen=True)
 class LossWeights:
-    """Weights for WASB losses."""
+    """Weights for WASB losses.
+
+    If a weight is 0.0, the corresponding loss is skipped entirely.
+    """
 
     bce: float = 1.0
     mse: float = 1.0
+    temporal: float = 0.0
+
+
+@dataclass(frozen=True)
+class TemporalPeakLossConfig:
+    """Configuration for temporal peak consistency loss.
+
+    Attributes:
+        order: 1 => velocity smoothness, 2 => acceleration smoothness (recommended).
+        robust: If True, use SmoothL1 (Huber) for stability against outliers.
+        prob_mode:
+            - "sigmoid_norm": sigmoid(logits) then normalize spatially to sum to 1.
+              Works well with BCE-with-logits training.
+            - "spatial_softmax": softmax(beta * logits) across H*W.
+        beta: Temperature scale for "spatial_softmax" (ignored for "sigmoid_norm").
+        detach_conf: If True, prevents the model from "cheating" by lowering confidence
+                     to reduce the temporal penalty.
+    """
+
+    order: int = 2
+    robust: bool = True
+    prob_mode: str = "sigmoid_norm"
+    beta: float = 25.0
+    detach_conf: bool = True
+
 
 class WASBLoss(nn.Module):
-    """Composite heatmap loss for WASB tennis models."""
+    """Composite heatmap loss for WASB tennis models (BCE + MSE + optional temporal)."""
 
     def __init__(
         self,
         weights: LossWeights | None = None,
+        temporal_cfg: TemporalPeakLossConfig | None = None,
     ) -> None:
         super().__init__()
         self.weights = weights or LossWeights()
+        self.temporal_cfg = temporal_cfg or TemporalPeakLossConfig()
 
     def forward(
         self,
@@ -33,28 +73,49 @@ class WASBLoss(nn.Module):
         target_heatmaps: Tensor,
         visibility: Tensor | None = None,
     ) -> dict[str, Tensor]:
-        """Compute heatmap BCE with optional frame masking.
+        """Compute losses with optional frame masking.
 
         Args:
-            pred_heatmaps: Predicted heatmaps (B, T, H, W).
-            target_heatmaps: Target heatmaps (B, T, H, W).
+            pred_heatmaps: Predicted heatmaps (logits) of shape (B, T, H, W).
+            target_heatmaps: Target heatmaps of shape (B, T, H, W).
             visibility: Optional visibility mask (B, T) where >0 is valid.
 
         Returns:
             Dict with individual losses and total.
         """
-        bce_loss = heatmap_bce(pred_heatmaps, target_heatmaps, visibility)
-        mse_loss = heatmap_mse(pred_heatmaps, target_heatmaps, visibility)
+        zero = pred_heatmaps.new_zeros(())  # scalar 0 on the right device/dtype
+        total = zero
 
-        total = (
-            self.weights.bce * bce_loss
-            + self.weights.mse * mse_loss
-        )
+        # BCE
+        if self.weights.bce != 0.0:
+            bce_loss = heatmap_bce(pred_heatmaps, target_heatmaps, visibility)
+            total = total + (self.weights.bce * bce_loss)
+        else:
+            bce_loss = zero  # skipped
+
+        # MSE
+        if self.weights.mse != 0.0:
+            mse_loss = heatmap_mse(pred_heatmaps, target_heatmaps, visibility)
+            total = total + (self.weights.mse * mse_loss)
+        else:
+            mse_loss = zero  # skipped
+
+        # Temporal consistency (peak smoothness)
+        if self.weights.temporal != 0.0:
+            temporal_loss = peak_temporal_consistency_loss(
+                pred_logits=pred_heatmaps,
+                visibility=visibility,
+                cfg=self.temporal_cfg,
+            )
+            total = total + (self.weights.temporal * temporal_loss)
+        else:
+            temporal_loss = zero  # skipped
 
         return {
             "total": total,
             "bce": bce_loss,
             "mse": mse_loss,
+            "temporal": temporal_loss,
         }
 
 
@@ -65,7 +126,7 @@ def heatmap_bce(
     eps: float = 1e-8,
     logit_clip: float | None = 20.0,
 ) -> Tensor:
-    """Frame-wise BCE between predicted and target heatmaps."""
+    """Frame-wise BCE between predicted and target heatmaps (logits vs targets)."""
     logits = pred_heatmaps
     if logit_clip is not None and logit_clip > 0:
         # Prevent extreme logits that can cause saturated gradients/unstable stats.
@@ -100,3 +161,104 @@ def heatmap_mse(
     masked = loss * vis_mask
     denom = vis_mask.sum() * pred_heatmaps.shape[-2] * pred_heatmaps.shape[-1]
     return masked.sum() / (denom + eps)
+
+
+def peak_temporal_consistency_loss(
+    pred_logits: Tensor,  # (B, T, H, W) logits
+    visibility: Tensor | None,
+    cfg: TemporalPeakLossConfig,
+    eps: float = 1e-8,
+) -> Tensor:
+    """Temporal smoothness loss on the predicted heatmap peak coordinates.
+
+    - Extracts (x_t, y_t) via a differentiable soft-argmax.
+    - Penalizes either velocity (order=1) or acceleration (order=2).
+
+    Returns:
+        Scalar tensor loss.
+    """
+    B, T, H, W = pred_logits.shape
+    if cfg.order == 2 and T < 3:
+        return pred_logits.new_zeros(())
+    if cfg.order == 1 and T < 2:
+        return pred_logits.new_zeros(())
+
+    coords, conf = _heatmap_to_coords(
+        pred_logits=pred_logits,
+        prob_mode=cfg.prob_mode,
+        beta=cfg.beta,
+        eps=eps,
+    )  # coords: (B,T,2), conf: (B,T)
+
+    if cfg.order == 1:
+        # d_t = p_{t+1} - p_t
+        d = coords[:, 1:] - coords[:, :-1]  # (B, T-1, 2)
+        w = conf[:, 1:] * conf[:, :-1]      # (B, T-1)
+        if visibility is not None:
+            v = (visibility > 0).to(dtype=coords.dtype, device=coords.device)
+            w = w * (v[:, 1:] * v[:, :-1])
+
+    elif cfg.order == 2:
+        # d_t = p_{t+1} - 2*p_t + p_{t-1}  (discrete acceleration)
+        d = coords[:, 2:] - 2.0 * coords[:, 1:-1] + coords[:, :-2]  # (B, T-2, 2)
+        w = conf[:, 2:] * conf[:, 1:-1] * conf[:, :-2]              # (B, T-2)
+        if visibility is not None:
+            v = (visibility > 0).to(dtype=coords.dtype, device=coords.device)
+            w = w * (v[:, 2:] * v[:, 1:-1] * v[:, :-2])
+    else:
+        raise ValueError(f"Unsupported cfg.order={cfg.order} (expected 1 or 2).")
+
+    if cfg.detach_conf:
+        w = w.detach()
+
+    if cfg.robust:
+        per = F.smooth_l1_loss(d, torch.zeros_like(d), reduction="none").sum(dim=-1)  # (B, *,)
+    else:
+        per = (d * d).sum(dim=-1)  # (B, *,)
+
+    num = (per * w).sum()
+    den = w.sum().clamp_min(eps)
+
+    # If everything is masked, return 0 (avoid noisy NaNs).
+    if torch.isfinite(den).item() and den.item() <= eps:
+        return pred_logits.new_zeros(())
+
+    return num / den
+
+
+def _heatmap_to_coords(
+    pred_logits: Tensor,  # (B,T,H,W)
+    prob_mode: str,
+    beta: float,
+    eps: float,
+) -> tuple[Tensor, Tensor]:
+    """Convert heatmap logits to expected peak coordinates (soft-argmax).
+
+    Returns:
+        coords: (B, T, 2) where last dim is (x, y) in pixel coordinates.
+        conf:   (B, T) confidence proxy (max probability mass).
+    """
+    B, T, H, W = pred_logits.shape
+    dtype = pred_logits.dtype
+    device = pred_logits.device
+
+    x_grid = torch.arange(W, device=device, dtype=dtype)
+    y_grid = torch.arange(H, device=device, dtype=dtype)
+    yy, xx = torch.meshgrid(y_grid, x_grid, indexing="ij")  # (H,W)
+
+    flat = pred_logits.view(B * T, H * W)
+
+    if prob_mode == "spatial_softmax":
+        p = F.softmax(flat * beta, dim=-1).view(B * T, H, W)
+    elif prob_mode == "sigmoid_norm":
+        p = torch.sigmoid(flat).view(B * T, H, W)
+        p = p / (p.sum(dim=(1, 2), keepdim=True) + eps)
+    else:
+        raise ValueError(f"Unknown prob_mode={prob_mode!r} (expected 'sigmoid_norm' or 'spatial_softmax').")
+
+    conf = p.amax(dim=(1, 2)).view(B, T)
+
+    x = (p * xx).sum(dim=(1, 2))
+    y = (p * yy).sum(dim=(1, 2))
+    coords = torch.stack([x, y], dim=-1).view(B, T, 2)
+    return coords, conf


### PR DESCRIPTION
…ization for smooth ball trajectory prediction

Add temporal_weight parameter and temporal config section to ball_detection loss and training configs with order=2 (acceleration), robust=true (SmoothL1), sigmoid_norm prob_mode, beta=25.0, and detach_conf=true. Update WASBLoss to accept TemporalPeakLossConfig and compute temporal loss when weight > 0. Implement peak_temporal_consistency_loss() that extracts differentiable soft-argmax peak