### PR TITLE
feat: Docker Compose環境を追加（tennis-lab / GVHMR分離）

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,77 @@
+# =============================================================================
+# tennis-lab Docker Compose 設定
+# - tennis-lab: メインプロジェクト (src/) の実行環境
+# - gvhmr: third_party/GVHMR の実行環境
+# =============================================================================
+version: "3.8"
+
+services:
+  # ---------------------------------------------------------------------------
+  # tennis-lab: メインプロジェクト用コンテナ
+  # ---------------------------------------------------------------------------
+  tennis-lab:
+    build:
+      context: ..
+      dockerfile: docker/tennis-lab/Dockerfile
+    image: tennis-lab:latest
+    container_name: tennis-lab
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
+    volumes:
+      # ソースコードのマウント（開発時）
+      - ..:/workspace
+      # データディレクトリ
+      - ../data:/workspace/data
+      # 出力ディレクトリ
+      - ../outputs:/workspace/outputs
+    working_dir: /workspace
+    stdin_open: true
+    tty: true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+  # ---------------------------------------------------------------------------
+  # gvhmr: GVHMR 用コンテナ
+  # ---------------------------------------------------------------------------
+  gvhmr:
+    build:
+      context: ..
+      dockerfile: docker/gvhmr/Dockerfile
+    image: gvhmr:latest
+    container_name: gvhmr
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
+    volumes:
+      # GVHMR ソースコードのマウント（開発時）
+      - ../third_party/GVHMR:/workspace/third_party/GVHMR
+      # 入出力ディレクトリ
+      - ../third_party/GVHMR/inputs:/workspace/third_party/GVHMR/inputs
+      - ../third_party/GVHMR/outputs:/workspace/third_party/GVHMR/outputs
+      # 共有データディレクトリ（tennis-labと共有）
+      - ../data:/workspace/data
+    working_dir: /workspace/third_party/GVHMR
+    stdin_open: true
+    tty: true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+# =============================================================================
+# ネットワーク設定
+# =============================================================================
+networks:
+  default:
+    name: tennis-lab-network

--- a/docker/gvhmr/Dockerfile
+++ b/docker/gvhmr/Dockerfile
@@ -1,0 +1,100 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# GVHMR: third_party/GVHMR 用 Docker イメージ
+# Python 3.10 + CUDA 12.1 + PyTorch 2.3 + pytorch3d
+# =============================================================================
+FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
+
+# -----------------------------------------------------------------------------
+# 環境変数設定
+# -----------------------------------------------------------------------------
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Asia/Tokyo
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV UV_SYSTEM_PYTHON=1
+ENV UV_LINK_MODE=copy
+
+# pytorch3d ビルド用
+ENV FORCE_CUDA=1
+ENV TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0"
+
+# -----------------------------------------------------------------------------
+# システムパッケージのインストール
+# -----------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    wget \
+    build-essential \
+    cmake \
+    ninja-build \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender-dev \
+    ffmpeg \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    libboost-all-dev \
+    libeigen3-dev \
+    libflann-dev \
+    libfreeimage-dev \
+    libmetis-dev \
+    libgoogle-glog-dev \
+    libgflags-dev \
+    libsqlite3-dev \
+    libglew-dev \
+    qtbase5-dev \
+    libqt5opengl5-dev \
+    libcgal-dev \
+    libceres-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# -----------------------------------------------------------------------------
+# Python 3.10 のインストール
+# -----------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+    python3.10 \
+    python3.10-dev \
+    python3.10-venv \
+    python3-pip \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# -----------------------------------------------------------------------------
+# uv のインストール
+# -----------------------------------------------------------------------------
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# -----------------------------------------------------------------------------
+# ワークディレクトリ設定
+# -----------------------------------------------------------------------------
+WORKDIR /workspace/third_party/GVHMR
+
+# -----------------------------------------------------------------------------
+# 依存関係のインストール
+# requirements.txt を使用してインストール
+# -----------------------------------------------------------------------------
+COPY third_party/GVHMR/requirements.txt ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install -r requirements.txt
+
+# -----------------------------------------------------------------------------
+# GVHMR ソースコードのコピーとインストール
+# -----------------------------------------------------------------------------
+COPY third_party/GVHMR/ ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install -e .
+
+# -----------------------------------------------------------------------------
+# デフォルトコマンド
+# -----------------------------------------------------------------------------
+CMD ["bash"]

--- a/docker/tennis-lab/Dockerfile
+++ b/docker/tennis-lab/Dockerfile
@@ -1,0 +1,78 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# tennis-lab: メインプロジェクト (src/) 用 Docker イメージ
+# Python 3.11 + CUDA 12.4 + PyTorch環境
+# =============================================================================
+FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
+
+# -----------------------------------------------------------------------------
+# 環境変数設定
+# -----------------------------------------------------------------------------
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Asia/Tokyo
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV UV_SYSTEM_PYTHON=1
+ENV UV_LINK_MODE=copy
+
+# -----------------------------------------------------------------------------
+# システムパッケージのインストール
+# -----------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    wget \
+    build-essential \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender-dev \
+    ffmpeg \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# -----------------------------------------------------------------------------
+# Python 3.11 のインストール
+# -----------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+    python3.11 \
+    python3.11-dev \
+    python3.11-venv \
+    python3-pip \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# -----------------------------------------------------------------------------
+# uv のインストール
+# -----------------------------------------------------------------------------
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# -----------------------------------------------------------------------------
+# ワークディレクトリ設定
+# -----------------------------------------------------------------------------
+WORKDIR /workspace
+
+# -----------------------------------------------------------------------------
+# 依存関係のインストール（キャッシュ活用のためpyproject.tomlを先にコピー）
+# -----------------------------------------------------------------------------
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+# -----------------------------------------------------------------------------
+# ソースコードのコピー
+# -----------------------------------------------------------------------------
+COPY . .
+
+# -----------------------------------------------------------------------------
+# デフォルトコマンド
+# -----------------------------------------------------------------------------
+CMD ["bash"]

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -1,0 +1,159 @@
+# Docker 環境
+
+このディレクトリには tennis-lab プロジェクトの Docker 環境設定が含まれています。
+
+## 概要
+
+tennis-lab は以下の2つの独立した実行環境で構成されています：
+
+| サービス | 説明 | Python | CUDA |
+|----------|------|--------|------|
+| `tennis-lab` | メインプロジェクト (`src/`) | 3.11 | 12.4 |
+| `gvhmr` | GVHMR (`third_party/GVHMR/`) | 3.10 | 12.1 |
+
+## 前提条件
+
+- Docker Engine 20.10+
+- Docker Compose v2.0+
+- NVIDIA Container Toolkit
+- NVIDIA GPU (CUDA 対応)
+
+### NVIDIA Container Toolkit のインストール
+
+```bash
+# Ubuntu/Debian
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
+curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update
+sudo apt-get install -y nvidia-container-toolkit
+sudo systemctl restart docker
+```
+
+## クイックスタート
+
+### 1. イメージのビルド
+
+```bash
+cd docker
+docker compose build
+```
+
+### 2. コンテナの起動
+
+```bash
+# 両方のコンテナを起動
+docker compose up -d
+
+# tennis-lab のみ起動
+docker compose up -d tennis-lab
+
+# gvhmr のみ起動
+docker compose up -d gvhmr
+```
+
+### 3. コンテナへのアクセス
+
+```bash
+# tennis-lab コンテナに入る
+docker compose exec tennis-lab bash
+
+# gvhmr コンテナに入る
+docker compose exec gvhmr bash
+```
+
+### 4. コンテナの停止
+
+```bash
+docker compose down
+```
+
+## 使用例
+
+### tennis-lab での学習実行
+
+```bash
+# コンテナ内で
+docker compose exec tennis-lab bash
+
+# 学習スクリプトの実行
+uv run python -m src.wasb.scripts.train.ball_detection
+```
+
+### GVHMR での推論実行
+
+```bash
+# コンテナ内で
+docker compose exec gvhmr bash
+
+# デモの実行
+bash run_demo.sh
+```
+
+## ディレクトリ構成
+
+```
+docker/
+├── docker-compose.yml    # Docker Compose 設定ファイル
+├── tennis-lab/
+│   └── Dockerfile        # tennis-lab 用 Dockerfile
+└── gvhmr/
+    └── Dockerfile        # GVHMR 用 Dockerfile
+```
+
+## ボリュームマウント
+
+### tennis-lab
+
+| ホスト | コンテナ | 説明 |
+|--------|----------|------|
+| プロジェクトルート | `/workspace` | ソースコード |
+| `data/` | `/workspace/data` | データセット |
+| `outputs/` | `/workspace/outputs` | 出力ファイル |
+
+### gvhmr
+
+| ホスト | コンテナ | 説明 |
+|--------|----------|------|
+| `third_party/GVHMR/` | `/workspace/third_party/GVHMR` | GVHMR ソースコード |
+| `third_party/GVHMR/inputs/` | `/workspace/third_party/GVHMR/inputs` | 入力ファイル |
+| `third_party/GVHMR/outputs/` | `/workspace/third_party/GVHMR/outputs` | 出力ファイル |
+| `data/` | `/workspace/data` | 共有データセット |
+
+## GPU 設定
+
+デフォルトでは全ての GPU が使用可能です。特定の GPU のみを使用する場合：
+
+```bash
+# 特定の GPU のみ使用
+NVIDIA_VISIBLE_DEVICES=0 docker compose up -d tennis-lab
+
+# 複数の GPU を指定
+NVIDIA_VISIBLE_DEVICES=0,1 docker compose up -d tennis-lab
+```
+
+## トラブルシューティング
+
+### GPU が認識されない
+
+```bash
+# NVIDIA Container Toolkit の確認
+nvidia-smi
+docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi
+```
+
+### ビルドエラー
+
+```bash
+# キャッシュを無効にしてビルド
+docker compose build --no-cache
+```
+
+### 権限エラー
+
+ホストとコンテナ間でファイルの権限問題が発生する場合：
+
+```bash
+# ホストのUID/GIDでコンテナを実行
+docker compose run --user $(id -u):$(id -g) tennis-lab bash
+```


### PR DESCRIPTION
## 概要

Docker Compose を使用して、tennis-lab と GVHMR の実行環境を分離しました。

## 変更内容

### 追加ファイル
- `docker/tennis-lab/Dockerfile`: メインプロジェクト用 (Python 3.11 + CUDA 12.4)
- `docker/gvhmr/Dockerfile`: GVHMR用 (Python 3.10 + CUDA 12.1 + pytorch3d)
- `docker/docker-compose.yml`: 両サービスの設定
- `docs/docker/README.md`: 使用方法のドキュメント

## 構成

| サービス | Python | CUDA | 用途 |
|----------|--------|------|------|
| tennis-lab | 3.11 | 12.4 | `src/` メインプロジェクト |
| gvhmr | 3.10 | 12.1 | `third_party/GVHMR/` |

## 使用方法

```bash
cd docker
docker compose build
docker compose up -d
docker compose exec tennis-lab bash
```

詳細は `docs/docker/README.md` を参照してください。