### PR TITLE
feat(wasb): add ball position masking augmentation for occlusion simulation

### DIFF
--- a/src/wasb/configs/data/ball_detection.yaml
+++ b/src/wasb/configs/data/ball_detection.yaml
@@ -34,6 +34,13 @@ augment:
     scale: [0.02, 0.05]
     ratio: [0.3, 3.3]
     value: 0
+  # Ball position masking for occlusion simulation.
+  # Masks the heatmap of selected frames so the model must predict
+  # the ball location from temporal context.
+  ball_masking:
+    enabled: false
+    prob: 0.3
+    max_masked_ratio: 0.5
 
 # Sampling strategy (curriculum).
 # - Warmup: standard shuffle sampling (as before).

--- a/src/wasb/data/ball_detection_dataset.py
+++ b/src/wasb/data/ball_detection_dataset.py
@@ -136,6 +136,19 @@ def build_sequence_index(
     return samples
 
 
+@dataclass(frozen=True)
+class BallMaskingConfig:
+    """Configuration for ball position masking augmentation.
+
+    This simulates occlusion by zeroing out heatmaps for some frames,
+    forcing the model to predict ball positions from temporal context.
+    """
+
+    enabled: bool = False
+    prob: float = 0.3
+    max_masked_ratio: float = 0.5
+
+
 class BallDetectionSequenceDataset(Dataset):
     """Sliding-window dataset for WASB ball detection training."""
 
@@ -153,6 +166,7 @@ class BallDetectionSequenceDataset(Dataset):
         resize_hw: tuple[int, int] | None = None,
         heatmap_hw: tuple[int, int] | None = None,
         heatmap_sigma: float | None = None,
+        ball_masking: BallMaskingConfig | None = None,
     ) -> None:
         """Initialize the dataset.
 
@@ -167,6 +181,7 @@ class BallDetectionSequenceDataset(Dataset):
             csv_filename: Annotation file name inside each clip directory.
             transform: Optional transform applied to each PIL image.
             resize_hw: Optional ``(height, width)`` resize before ``ToTensor``.
+            ball_masking: Configuration for ball position masking augmentation.
         """
         if frames_out > frames_in:
             raise ValueError("frames_out cannot exceed frames_in")
@@ -180,6 +195,7 @@ class BallDetectionSequenceDataset(Dataset):
         self.resize_hw = resize_hw
         self.heatmap_hw = tuple(heatmap_hw) if heatmap_hw is not None else None
         self.heatmap_sigma = heatmap_sigma
+        self.ball_masking = ball_masking or BallMaskingConfig()
 
         self.transform = transform or self._default_transform(resize_hw)
         self.samples = build_sequence_index(
@@ -237,7 +253,9 @@ class BallDetectionSequenceDataset(Dataset):
         else:
             final_w, final_h = first_w, first_h
 
-        targets_norm = targets_px / torch.tensor([final_w, final_h], dtype=torch.float32)
+        targets_norm = targets_px / torch.tensor(
+            [final_w, final_h], dtype=torch.float32
+        )
         visibility = torch.tensor(
             [t.visibility for t in sample.targets], dtype=torch.int64
         )
@@ -246,6 +264,9 @@ class BallDetectionSequenceDataset(Dataset):
         target_heatmaps = self._build_heatmaps(
             targets_norm, visibility, heatmap_hw, sigma=self.heatmap_sigma
         )
+
+        # Apply ball position masking for occlusion simulation.
+        masked_indices = self._apply_ball_masking(target_heatmaps)
 
         return {
             "frames": frames_tensor,
@@ -257,7 +278,47 @@ class BallDetectionSequenceDataset(Dataset):
             "match": sample.match,
             "clip": sample.clip,
             "frame_paths": [str(p) for p in sample.frame_paths],
+            "masked_indices": masked_indices,
         }
+
+    def _apply_ball_masking(self, target_heatmaps: torch.Tensor) -> torch.Tensor:
+        """Apply ball position masking to simulate occlusion.
+
+        Randomly masks (zeros out) heatmaps for some frames, simulating
+        scenarios where the ball is occluded. The model must learn to
+        predict ball positions from temporal context (preceding/following frames).
+
+        Args:
+            target_heatmaps: Heatmaps of shape (frames_out, H, W).
+
+        Returns:
+            Boolean tensor of shape (frames_out,) indicating which frames
+            were masked (True = masked).
+        """
+        num_frames = target_heatmaps.shape[0]
+        masked_indices = torch.zeros(num_frames, dtype=torch.bool)
+
+        if not self.ball_masking.enabled:
+            return masked_indices
+
+        # Determine if we apply masking this sample (based on prob).
+        if torch.rand(1).item() > self.ball_masking.prob:
+            return masked_indices
+
+        # Decide how many frames to mask (at least 1, up to max_masked_ratio).
+        max_masked = max(1, int(num_frames * self.ball_masking.max_masked_ratio))
+        num_to_mask = torch.randint(1, max_masked + 1, (1,)).item()
+        num_to_mask = int(num_to_mask)
+
+        # Randomly select frame indices to mask.
+        mask_indices = torch.randperm(num_frames)[:num_to_mask]
+
+        # Zero out the heatmaps for masked frames.
+        for idx in mask_indices:
+            target_heatmaps[idx] = 0.0
+            masked_indices[idx] = True
+
+        return masked_indices
 
     def _get_heatmap_hw(self, final_h: int, final_w: int) -> tuple[int, int]:
         """Resolve heatmap height/width, defaulting to half-resolution."""

--- a/src/wasb/data/types.py
+++ b/src/wasb/data/types.py
@@ -27,6 +27,7 @@ class BallDetectionSample(TypedDict):
     match: str  # match/game directory name
     clip: str  # clip directory name
     frame_paths: list[str]  # paths to frame images
+    masked_indices: torch.Tensor  # (T,) boolean mask; True for masked frames
 
 
 class TrajectoryWindowSample(TypedDict):

--- a/tests/e2e/wasb/test_data_validation.py
+++ b/tests/e2e/wasb/test_data_validation.py
@@ -45,7 +45,9 @@ class TestWASBDatasetValidation:
                 assert label_file.exists(), f"Missing Label.csv in {clip_dir}"
 
                 # Should have image files
-                image_files = list(clip_dir.glob("*.jpg")) + list(clip_dir.glob("*.png"))
+                image_files = list(clip_dir.glob("*.jpg")) + list(
+                    clip_dir.glob("*.png")
+                )
                 assert len(image_files) > 0, f"No image files in {clip_dir}"
 
     def test_label_csv_format(self, wasb_dataset_dir: Path) -> None:
@@ -64,7 +66,9 @@ class TestWASBDatasetValidation:
                 assert "file name" in header or "filename" in header, (
                     f"Missing 'file name' in header: {header}"
                 )
-                assert "visibility" in header, f"Missing 'visibility' in header: {header}"
+                assert "visibility" in header, (
+                    f"Missing 'visibility' in header: {header}"
+                )
                 assert "x-coordinate" in header or "x" in header, (
                     f"Missing x coordinate in header: {header}"
                 )
@@ -122,6 +126,7 @@ class TestWASBBallDetectionSampleValidation:
             "scores",
             "match",
             "clip",
+            "masked_indices",
         ]
 
         missing = [k for k in required_keys if k not in sample]
@@ -152,7 +157,18 @@ class TestWASBBallDetectionSampleValidation:
 
         # visibility: (frames_out,)
         visibility = sample["visibility"]
-        assert len(visibility.shape) == 1, f"visibility should be 1D, got {visibility.shape}"
+        assert len(visibility.shape) == 1, (
+            f"visibility should be 1D, got {visibility.shape}"
+        )
+
+        # masked_indices: (frames_out,) boolean tensor
+        masked_indices = sample["masked_indices"]
+        assert len(masked_indices.shape) == 1, (
+            f"masked_indices should be 1D, got {masked_indices.shape}"
+        )
+        assert masked_indices.dtype == torch.bool, (
+            f"masked_indices should be bool, got {masked_indices.dtype}"
+        )
 
     def test_sample_normalized_targets_in_range(self, ball_detection_dataset) -> None:
         """Test that normalized targets are in [0, 1] range."""
@@ -287,7 +303,79 @@ class TestWASBDataLoaderBatchValidation:
 
         # frames: (B, T, C, H, W)
         frames = batch["frames"]
-        assert len(frames.shape) == 5, f"Batched frames should be 5D, got {frames.shape}"
+        assert len(frames.shape) == 5, (
+            f"Batched frames should be 5D, got {frames.shape}"
+        )
 
         B, T, C, H, W = frames.shape
         assert C == 3, f"Expected 3 channels, got {C}"
+
+
+@pytest.mark.e2e
+class TestBallMaskingAugmentation:
+    """Tests for ball position masking augmentation."""
+
+    @pytest.fixture
+    def dataset_with_masking(self, tmp_path: Path):
+        """Create a dataset with ball masking enabled."""
+        from src.wasb.data.ball_detection_dataset import (
+            BallDetectionSequenceDataset,
+            BallMaskingConfig,
+        )
+
+        dataset_dir = create_minimal_wasb_dataset(tmp_path / "wasb_data")
+
+        try:
+            ball_masking = BallMaskingConfig(
+                enabled=True,
+                prob=1.0,  # Always apply masking for testing
+                max_masked_ratio=0.5,
+            )
+            dataset = BallDetectionSequenceDataset(
+                root_dir=dataset_dir,
+                matches=["game1"],
+                frames_in=3,
+                frames_out=1,
+                step=1,
+                visibility_mode="none",
+                heatmap_sigma=5.0,
+                ball_masking=ball_masking,
+            )
+            return dataset
+        except Exception as e:
+            pytest.skip(f"Could not create dataset: {e}")
+
+    def test_masking_applies_when_enabled(self, dataset_with_masking) -> None:
+        """Test that masking is applied when enabled."""
+        if len(dataset_with_masking) == 0:
+            pytest.skip("Dataset is empty")
+
+        # Sample multiple times and check that some frames are masked
+        masked_count = 0
+        for i in range(min(10, len(dataset_with_masking))):
+            sample = dataset_with_masking[i]
+            if sample["masked_indices"].any():
+                masked_count += 1
+
+        # With prob=1.0, most samples should have masking
+        assert masked_count > 0, "No frames were masked with prob=1.0"
+
+    def test_masked_heatmaps_are_zero(self, dataset_with_masking) -> None:
+        """Test that masked frames have zero heatmaps."""
+        if len(dataset_with_masking) == 0:
+            pytest.skip("Dataset is empty")
+
+        # Find a sample with masking
+        for i in range(min(10, len(dataset_with_masking))):
+            sample = dataset_with_masking[i]
+            masked_indices = sample["masked_indices"]
+            if masked_indices.any():
+                heatmaps = sample["target_heatmaps"]
+                for idx in range(len(masked_indices)):
+                    if masked_indices[idx]:
+                        assert heatmaps[idx].sum() == 0.0, (
+                            f"Masked frame {idx} should have zero heatmap"
+                        )
+                return
+
+        pytest.skip("Could not find sample with masking applied")


### PR DESCRIPTION
## Summary
This PR adds a new data augmentation feature that simulates ball occlusion by masking heatmaps of selected frames. The model must predict ball positions from temporal context (preceding/following frames), which mimics real tennis match scenarios where the ball is frequently occluded.

## Changes
- Add `BallMaskingConfig` dataclass to configure masking behavior:
  - `enabled`: Whether masking is active
  - `prob`: Probability of applying masking to a sample
  - `max_masked_ratio`: Maximum fraction of frames to mask
- Add `ball_masking` parameter to `BallDetectionSequenceDataset`
- Add `masked_indices` field to `BallDetectionSample` TypedDict (outputs which frames were masked)
- Add `ball_masking` config section to `ball_detection.yaml`
- Add `TestBallMaskingAugmentation` test class

## Design Rationale
The `masked_indices` output tensor allows downstream code to apply different learning rates or loss weights to masked frames if needed. This is useful for curriculum learning or emphasizing learning from masked frames.

## Example Configuration
```yaml
augment:
  ball_masking:
    enabled: true
    prob: 0.3
    max_masked_ratio: 0.5
```

## Tests
- All existing tests pass
- Added new tests for ball masking functionality