### PR TITLE
feat: worktree_symbolic.shを常にmainブランチから作成するように修正

### DIFF
--- a/worktree_symbolic.sh
+++ b/worktree_symbolic.sh
@@ -9,7 +9,15 @@ cd /root/repos/tennis-lab
 BRANCH="${1:-feature/wt-$(date +%Y%m%d-%H%M%S)}"
 WT_PARENT="/root/repos/wt"
 ORIG="$(pwd -P)"
-BASE_REF="HEAD"  # 新規ブランチ作成時の起点（必要なら main などに変更）
+BASE_REF="main"  # 新規ブランチは必ずmainから作成
+
+# 現在のブランチがmainでない場合、mainをチェックアウト
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "現在のブランチ ($CURRENT_BRANCH) からmainに切り替えます..."
+  git checkout main
+  git pull origin main 2>/dev/null || echo "Warning: Could not pull from origin/main"
+fi
 
 mkdir -p "$WT_PARENT"
 


### PR DESCRIPTION
## 概要
worktree_symbolic.shを実行する際、常にmainブランチから新しいブランチを作成するように修正しました。

## 変更内容
- `BASE_REF`を`'main'`に変更（常にmainブランチから新規ブランチを作成）
- スクリプト実行時に現在のブランチがmainでない場合、自動的にmainに切り替える
- `origin/main`から最新の変更を取得（可能な場合）
- どのブランチから実行しても一貫した動作を保証

## 動作
従来は現在のブランチから新しいブランチが作成されていましたが、この変更により常にmainブランチから作成されるようになります。

## テスト
- pre-commit: ✅ 通過