### PR TITLE
feat(blcs): Add cell-to-cell distribution control for rally 2nd+ shots

### DIFF
--- a/src/blcs/configs/generate_dataset.yaml
+++ b/src/blcs/configs/generate_dataset.yaml
@@ -4,6 +4,7 @@ defaults:
   - rally: default
   - camera: default
   - sampling: default
+  - targeted_velocity: default
   - generator: default
   - run: generate_dataset
   - _self_

--- a/src/blcs/configs/generator/default.yaml
+++ b/src/blcs/configs/generator/default.yaml
@@ -1,7 +1,4 @@
-# Generation mode: "shot" for single shots, "rally" for multi-shot rallies
-mode: shot
-
-# Number of scenes for rally mode (ignored in shot mode)
+# Number of rally scenes to generate
 num_rally_scenes: 1000
 
 num_cameras_sampled: 8

--- a/src/blcs/configs/sampling/default.yaml
+++ b/src/blcs/configs/sampling/default.yaml
@@ -1,8 +1,11 @@
+# Category ratios for shot distribution
+# Each shot (1st, 2nd, ...) uses these ratios
+# Higher in_court ratio = more shots continue the rally
 category_ratios:
   direct_net: 0.05
   direct_fence: 0.05
-  in_court: 0.60
-  out_court: 0.30
+  in_court: 0.80
+  out_court: 0.10
 
 in_court_cell_weights: uniform
 out_court_cell_weights: uniform

--- a/src/blcs/configs/targeted_velocity/default.yaml
+++ b/src/blcs/configs/targeted_velocity/default.yaml
@@ -1,0 +1,22 @@
+# Targeted velocity sampler configuration
+# Used for computing velocity to aim at specific target cells
+
+# Azimuth noise (degrees, added to computed azimuth)
+azimuth_noise_deg: 5.0
+
+# Elevation noise (degrees, added to computed elevation)
+elevation_noise_deg: 3.0
+
+# Speed variation factor (multiplier range: 1 +/- speed_variation)
+speed_variation: 0.15
+
+# Minimum/maximum elevation constraints (degrees)
+min_elevation_deg: 3.0
+max_elevation_deg: 35.0
+
+# Minimum/maximum speed constraints (m/s)
+min_speed: 12.0
+max_speed: 40.0
+
+# Gravity for projectile calculation (m/s^2)
+gravity: 9.81

--- a/src/blcs/generate_dataset/scene_generator.py
+++ b/src/blcs/generate_dataset/scene_generator.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -31,6 +30,7 @@ from src.blcs.simulation.rally_simulator import (
     RallySimulator,
 )
 from src.blcs.simulation.shot_simulator import ShotConfig, ShotSimulator
+from src.blcs.simulation.targeted_velocity_sampler import TargetedVelocityConfig
 from src.utils.projection.camera_projector import (
     CameraConfig,
     CameraProjector,
@@ -43,11 +43,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class GenerationMode(Enum):
-    """Generation mode for scene generator."""
-
-    SHOT = "shot"  # Single shot per scene (original behavior)
-    RALLY = "rally"  # Multi-shot rally per scene
 
 
 @dataclass
@@ -149,9 +144,9 @@ class GeneratorConfig:
     rally: RallyConfig = field(default_factory=RallyConfig)
     camera: CameraConfig = field(default_factory=CameraConfig)
     sampling: SamplingConfig = field(default_factory=SamplingConfig)
-
-    # Generation mode
-    mode: GenerationMode = GenerationMode.SHOT
+    targeted_velocity: TargetedVelocityConfig = field(
+        default_factory=TargetedVelocityConfig
+    )
 
     # Camera sampling parameters
     num_cameras_sampled: int = 15  # Number of cameras to try per scene
@@ -163,12 +158,12 @@ class GeneratorConfig:
 class BLCSSceneGenerator:
     """Generates BLCS training scenes with controlled distribution.
 
-    Supports two modes:
-    - SHOT: Single shot per scene (original behavior)
-    - RALLY: Multi-shot rally per scene
+    Generates rally scenes with distribution-controlled shot sampling.
+    Each shot in a rally (including 2nd+ shots) uses the DistributionSampler
+    to control (from_cell, side, category, to_cell) distribution.
 
-    Workflow (PLCS-aligned):
-    1. Generate shot/rally via physics simulation
+    Workflow:
+    1. Generate rally via physics simulation with distribution control
     2. Sample multiple candidate cameras (num_cameras_sampled)
     3. Filter by ball visibility threshold
     4. If any valid cameras, yield scene with all valid cameras
@@ -183,21 +178,26 @@ class BLCSSceneGenerator:
         self.device = torch.device(device)
 
         self.cell_manager = CellManager()
+        self.distribution_sampler = DistributionSampler(self.config.sampling)
+
         self.shot_simulator = ShotSimulator(
             physics_config=self.config.physics,
             shot_config=self.config.shot,
             cell_manager=self.cell_manager,
             device=device,
         )
+
+        # Rally simulator with distribution sampler for 2nd+ shot control
         self.rally_simulator = RallySimulator(
             physics_config=self.config.physics,
             shot_config=self.config.shot,
             rally_config=self.config.rally,
             cell_manager=self.cell_manager,
+            targeted_velocity_config=self.config.targeted_velocity,
+            distribution_sampler=self.distribution_sampler,
             device=device,
         )
         self.camera_projector = CameraProjector(self.config.camera)
-        self.distribution_sampler = DistributionSampler(self.config.sampling)
         self.physics = BallPhysics(self.config.physics)
 
         # Track statistics
@@ -447,7 +447,7 @@ class BLCSSceneGenerator:
             attempts += 1
 
             # Random starting position
-            from_cell = torch.randint(0, 20, (1,)).item()
+            from_cell = int(torch.randint(0, 20, (1,)).item())
             side = "near" if torch.rand(1).item() < 0.5 else "far"
 
             scene_id = f"rally_{scene_counter:06d}"
@@ -474,23 +474,18 @@ class BLCSSceneGenerator:
 
     def generate(
         self,
-        num_scenes: int | None = None,
-    ) -> Iterator[BLCSSceneData | RallySceneData]:
-        """Generate scenes based on configured mode.
+        num_scenes: int,
+    ) -> Iterator[RallySceneData]:
+        """Generate rally scenes with distribution-controlled sampling.
 
         Args:
-            num_scenes: Number of scenes for rally mode (ignored in shot mode).
+            num_scenes: Number of rally scenes to generate.
 
         Yields:
-            Scene data (BLCSSceneData or RallySceneData depending on mode).
+            RallySceneData for each generated rally scene.
 
         """
-        if self.config.mode == GenerationMode.SHOT:
-            yield from self.generate_all_scenes()
-        else:
-            if num_scenes is None:
-                raise ValueError("num_scenes is required for rally mode")
-            yield from self.generate_rally_scenes(num_scenes)
+        yield from self.generate_rally_scenes(num_scenes)
 
     def get_statistics(self) -> dict:
         """Get current generation statistics.

--- a/src/blcs/simulation/cell_manager.py
+++ b/src/blcs/simulation/cell_manager.py
@@ -340,3 +340,54 @@ class CellManager:
 
         """
         return list(range(9, 20))
+
+    def get_cell_center(
+        self,
+        cell_id: int,
+        side: str,
+        device: str | torch.device = "cpu",
+    ) -> Tensor:
+        """Get the center position of a cell.
+
+        Args:
+            cell_id: Cell ID (0-19).
+            side: "near" or "far".
+            device: Torch device.
+
+        Returns:
+            Tensor: Center position [3] (x, y, z=0).
+
+        """
+        bounds = self.cell_id_to_bounds(cell_id, side)
+
+        x = (bounds.x_min + bounds.x_max) / 2
+        y = (bounds.y_min + bounds.y_max) / 2
+
+        return torch.tensor([x, y, 0.0], device=device)
+
+    def sample_bounce_position_in_cell(
+        self,
+        cell_id: int,
+        side: str,
+        device: str | torch.device = "cpu",
+    ) -> Tensor:
+        """Sample a random ground-level position within a cell for targeting.
+
+        Unlike sample_position_in_cell which includes height, this returns z=0
+        for use as a bounce target position.
+
+        Args:
+            cell_id: Cell ID (0-19).
+            side: "near" or "far".
+            device: Torch device.
+
+        Returns:
+            Tensor: Position [3] (x, y, z=0).
+
+        """
+        bounds = self.cell_id_to_bounds(cell_id, side)
+
+        x = bounds.x_min + torch.rand(1).item() * (bounds.x_max - bounds.x_min)
+        y = bounds.y_min + torch.rand(1).item() * (bounds.y_max - bounds.y_min)
+
+        return torch.tensor([x, y, 0.0], device=device)

--- a/src/blcs/simulation/rally_simulator.py
+++ b/src/blcs/simulation/rally_simulator.py
@@ -29,10 +29,16 @@ from src.blcs.simulation.ball_physics import (
 )
 from src.blcs.simulation.cell_manager import CellManager, ShotCategory
 from src.blcs.simulation.shot_simulator import ShotConfig, ShotSimulator
+from src.blcs.simulation.targeted_velocity_sampler import (
+    TargetedVelocityConfig,
+    TargetedVelocitySampler,
+)
 from src.utils.geometry import HALF_DOUBLES_WIDTH, HALF_LENGTH
 
 if TYPE_CHECKING:
-    pass
+    from src.blcs.generate_dataset.sampling.distribution_sampler import (
+        DistributionSampler,
+    )
 
 
 class RallyEndReason(Enum):
@@ -156,6 +162,8 @@ class RallySimulator:
         shot_config: ShotConfig | None = None,
         rally_config: RallyConfig | None = None,
         cell_manager: CellManager | None = None,
+        targeted_velocity_config: TargetedVelocityConfig | None = None,
+        distribution_sampler: DistributionSampler | None = None,
         device: str | torch.device = "cpu",
     ) -> None:
         """Initialize rally simulator.
@@ -165,6 +173,9 @@ class RallySimulator:
             shot_config: Shot generation parameters.
             rally_config: Rally-specific parameters.
             cell_manager: Cell manager for position sampling.
+            targeted_velocity_config: Configuration for targeted velocity sampling.
+            distribution_sampler: Distribution sampler for controlled shot distribution.
+                When provided, 2nd+ shots will use distribution-controlled sampling.
             device: Torch device.
 
         """
@@ -182,6 +193,16 @@ class RallySimulator:
             cell_manager=cell_manager,
             device=device,
         )
+
+        # Create targeted velocity sampler for cell-to-cell shots
+        self.targeted_velocity_sampler = TargetedVelocitySampler(
+            cell_manager=self.cell_manager,
+            config=targeted_velocity_config,
+            device=device,
+        )
+
+        # Distribution sampler for controlled shot distribution
+        self.distribution_sampler = distribution_sampler
 
     def check_rally_end(
         self,
@@ -253,6 +274,7 @@ class RallySimulator:
         self,
         ball_pos_at_return: Tensor,
         from_side: str,
+        target_cell: int | None = None,
     ) -> BallState:
         """Sample initial state for return shot.
 
@@ -262,12 +284,15 @@ class RallySimulator:
         Args:
             ball_pos_at_return: Ball position at return timing.
             from_side: Side of the court making the return ("near" or "far").
+            target_cell: Optional target cell ID to aim for. If provided,
+                uses TargetedVelocitySampler for velocity calculation.
 
         Returns:
             BallState for the return shot.
 
         """
         cfg = self.rally_config
+        target_side = "far" if from_side == "near" else "near"
 
         # Adjust position to return height
         z_min, z_max = cfg.return_z_range
@@ -276,8 +301,16 @@ class RallySimulator:
         position = ball_pos_at_return.clone()
         position[2] = return_height
 
-        # Sample velocity using shot simulator's method
-        velocity = self.shot_simulator._sample_velocity(from_side)
+        # Sample velocity - targeted if target_cell specified, random otherwise
+        if target_cell is not None:
+            velocity = self.targeted_velocity_sampler.sample_velocity_for_target_cell(
+                start_pos=position,
+                target_cell=target_cell,
+                target_side=target_side,
+                from_side=from_side,
+            )
+        else:
+            velocity = self.shot_simulator._sample_velocity(from_side)
 
         # Sample spin
         spin = self.shot_simulator._sample_spin()
@@ -292,31 +325,10 @@ class RallySimulator:
             side: "near" or "far".
 
         Returns:
-            Cell ID (0-19), or 0 if position is outside all cells.
+            Cell ID (0-19).
 
         """
-        # Use cell manager to find closest cell
-        # For now, use a simple approximation
-        x, y, _ = position.tolist()
-
-        # Determine cell based on x position (simplified)
-        # Cells are arranged in a grid on each side
-        if side == "near":
-            # Near side: y < 0
-            base_cell = 0 if y > -self.COURT_Y_LIMIT / 2 else 6  # Service box/baseline
-        else:
-            # Far side: y > 0
-            base_cell = 10 if y < self.COURT_Y_LIMIT / 2 else 16  # Service box/baseline
-
-        # Adjust for x position (left/center/right)
-        if x < -self.COURT_X_LIMIT / 3:
-            cell_offset = 0
-        elif x > self.COURT_X_LIMIT / 3:
-            cell_offset = 2
-        else:
-            cell_offset = 1
-
-        return min(base_cell + cell_offset, 19)
+        return self.cell_manager.position_to_cell_id(position, side)
 
     def _sample_valid_first_shot(
         self,
@@ -369,6 +381,67 @@ class RallySimulator:
         # Failed to find valid first shot after max retries
         return None
 
+    def _get_needed_target_cells(
+        self,
+        from_cell: int,
+        from_side: str,
+    ) -> list[int]:
+        """Get target cells that need more samples based on distribution.
+
+        If distribution_sampler is not set, returns all in-court cells.
+
+        Args:
+            from_cell: Origin cell ID.
+            from_side: Side making the shot.
+
+        Returns:
+            List of target cell IDs that need more samples.
+
+        """
+        if self.distribution_sampler is None:
+            # No distribution control - return all in-court cells
+            return list(range(9))
+
+        # Get cells that still need samples
+        needed: list[tuple[int, int]] = []  # (cell_id, deficit)
+
+        # Check IN_COURT cells (0-8) - prioritize these
+        for to_cell in range(9):
+            if self.distribution_sampler.should_accept(
+                from_cell, from_side, ShotCategory.IN_COURT, to_cell
+            ):
+                current = self.distribution_sampler.get_current_count(
+                    from_cell, from_side, ShotCategory.IN_COURT, to_cell
+                )
+                target = self.distribution_sampler.get_target_count(
+                    from_cell, from_side, ShotCategory.IN_COURT, to_cell
+                )
+                deficit = target - current
+                needed.append((to_cell, deficit))
+
+        # Check OUT_COURT cells (9-19) with lower priority
+        for to_cell in range(9, 20):
+            if self.distribution_sampler.should_accept(
+                from_cell, from_side, ShotCategory.OUT_COURT, to_cell
+            ):
+                current = self.distribution_sampler.get_current_count(
+                    from_cell, from_side, ShotCategory.OUT_COURT, to_cell
+                )
+                target = self.distribution_sampler.get_target_count(
+                    from_cell, from_side, ShotCategory.OUT_COURT, to_cell
+                )
+                deficit = target - current
+                # Lower priority for out-court
+                needed.append((to_cell, deficit // 2))
+
+        if not needed:
+            # All targets met - return random in-court cells
+            return list(range(9))
+
+        # Sort by deficit (highest first) and return cell IDs
+        needed.sort(key=lambda x: -x[1])
+        return [cell_id for cell_id, _ in needed]
+
     def _sample_valid_return_shot(
         self,
         ball_pos_at_return: Tensor,
@@ -376,11 +449,10 @@ class RallySimulator:
         from_cell: int,
         max_frames: int,
     ) -> tuple[dict, BallState] | None:
-        """Sample a return shot that continues the rally (doesn't end immediately).
+        """Sample a return shot with distribution control.
 
-        For 2nd shot onwards, we retry sampling until we find a shot that:
-        - Doesn't hit the net before first bounce
-        - Bounces within court + margin
+        For 2nd shot onwards, uses TargetedVelocitySampler to aim at specific
+        cells and DistributionSampler to control the distribution of shots.
 
         Args:
             ball_pos_at_return: Ball position at return timing.
@@ -394,11 +466,18 @@ class RallySimulator:
         """
         cfg = self.rally_config
 
-        for _ in range(cfg.max_return_retries):
-            # Sample initial state for return
+        # Get target cells that need more samples
+        needed_targets = self._get_needed_target_cells(from_cell, from_side)
+
+        for attempt in range(cfg.max_return_retries):
+            # Cycle through needed targets
+            target_cell = needed_targets[attempt % len(needed_targets)]
+
+            # Sample initial state with targeted velocity
             initial_state = self._sample_return_initial_state(
                 ball_pos_at_return=ball_pos_at_return,
                 from_side=from_side,
+                target_cell=target_cell,
             )
 
             # Simulate the shot
@@ -415,13 +494,35 @@ class RallySimulator:
                 hit_net_before_bounce=shot_result["hit_net_before_bounce"],
             )
 
-            # Accept shots that don't end the rally immediately
-            # (or end with double bounce, which is a valid rally continuation)
-            if not should_end:
+            # Get actual category and to_cell
+            category = shot_result["category"]
+            to_cell = shot_result["to_cell"]
+
+            # Check distribution acceptance
+            should_accept_distribution = True
+            if self.distribution_sampler is not None:
+                should_accept_distribution = self.distribution_sampler.should_accept(
+                    from_cell, from_side, category, to_cell
+                )
+
+            # Accept shots that:
+            # 1. Don't end the rally immediately AND meet distribution requirements
+            # 2. Or have double bounce (valid rally end)
+            if not should_end and should_accept_distribution:
+                # Record sample if distribution sampler is set
+                if self.distribution_sampler is not None:
+                    self.distribution_sampler.record_sample(
+                        from_cell, from_side, category, to_cell
+                    )
                 return shot_result, initial_state
 
             # Also accept if double bounce occurred (opponent didn't return)
+            # These are valid rally endings regardless of distribution
             if shot_result["t_bounce2_sim"] >= 0:
+                if self.distribution_sampler is not None:
+                    self.distribution_sampler.record_sample(
+                        from_cell, from_side, category, to_cell
+                    )
                 return shot_result, initial_state
 
         # Failed to find valid return shot after max retries

--- a/src/blcs/simulation/targeted_velocity_sampler.py
+++ b/src/blcs/simulation/targeted_velocity_sampler.py
@@ -1,0 +1,223 @@
+"""Targeted velocity sampler for cell-to-cell shots.
+
+Computes initial velocity to aim at specific target cells while
+adding realistic variation. Uses simplified projectile motion
+(gravity only) for speed, with drag/magnus effects adding natural noise.
+
+The calculation is approximate because:
+1. We use gravity-only projectile equations for speed estimation
+2. The actual simulation includes drag and magnus forces
+3. This discrepancy creates natural variation in landing positions
+
+Additional noise parameters are applied to azimuth, elevation, and speed
+to further increase variation.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+from torch import Tensor
+
+if TYPE_CHECKING:
+    from src.blcs.simulation.cell_manager import CellManager
+
+
+@dataclass
+class TargetedVelocityConfig:
+    """Configuration for targeted velocity sampling."""
+
+    # Azimuth noise (degrees, added to computed azimuth)
+    azimuth_noise_deg: float = 5.0
+
+    # Elevation noise (degrees, added to computed elevation)
+    elevation_noise_deg: float = 3.0
+
+    # Speed variation factor (multiplier range: 1 ± speed_variation)
+    speed_variation: float = 0.15
+
+    # Minimum/maximum elevation constraints (degrees)
+    min_elevation_deg: float = 3.0
+    max_elevation_deg: float = 35.0
+
+    # Minimum/maximum speed constraints (m/s)
+    min_speed: float = 12.0
+    max_speed: float = 40.0
+
+    # Gravity for projectile calculation (m/s²)
+    gravity: float = 9.81
+
+
+class TargetedVelocitySampler:
+    """Samples velocity to aim at specific target cells.
+
+    Uses projectile motion approximation (ignoring drag/magnus) to
+    compute initial velocity that lands ball near target, then adds
+    realistic variation.
+
+    The drag and magnus forces in the actual physics simulation will
+    cause the ball to deviate from the idealized trajectory, creating
+    natural variation in landing positions.
+    """
+
+    def __init__(
+        self,
+        cell_manager: CellManager | None = None,
+        config: TargetedVelocityConfig | None = None,
+        device: str | torch.device = "cpu",
+    ) -> None:
+        """Initialize targeted velocity sampler.
+
+        Args:
+            cell_manager: Cell manager for court grid operations.
+            config: Configuration parameters.
+            device: Torch device.
+
+        """
+        # Import here to avoid circular dependency
+        from src.blcs.simulation.cell_manager import CellManager
+
+        self.cell_manager = cell_manager or CellManager()
+        self.config = config or TargetedVelocityConfig()
+        self.device = torch.device(device)
+
+    def compute_velocity_to_target(
+        self,
+        start_pos: Tensor,
+        target_pos: Tensor,
+        from_side: str,
+    ) -> Tensor:
+        """Compute velocity to reach target using projectile approximation.
+
+        Uses simplified projectile motion (gravity only) to estimate
+        the required initial velocity. The actual simulation with
+        drag/magnus will cause deviation from this ideal trajectory.
+
+        Args:
+            start_pos: Starting position [3] (x, y, z).
+            target_pos: Target position [3] (typically z=0 for bounce).
+            from_side: "near" or "far" - determines base direction.
+
+        Returns:
+            Tensor: Velocity [3] in m/s.
+
+        """
+        cfg = self.config
+
+        # Horizontal displacement
+        dx = (target_pos[0] - start_pos[0]).item()
+        dy = (target_pos[1] - start_pos[1]).item()
+        horizontal_dist = math.sqrt(dx**2 + dy**2)
+
+        # Vertical displacement (start height to ground)
+        z0 = start_pos[2].item()
+
+        # Base direction (determines sign of vy)
+        base_dir = 1.0 if from_side == "near" else -1.0
+
+        # Compute azimuth (angle in x-y plane from y-axis)
+        # atan2(dx, dy * base_dir) gives angle from base direction
+        azimuth_rad = math.atan2(dx, abs(dy))
+
+        # Add noise to azimuth
+        azimuth_noise = (
+            (torch.rand(1).item() - 0.5) * 2 * math.radians(cfg.azimuth_noise_deg)
+        )
+        azimuth_rad += azimuth_noise
+
+        # Find elevation and speed using projectile equation
+        # For a ball starting at height z0, landing at z=0:
+        # Using range equation: R = v² * sin(2θ) / g for flat ground
+        # Modified for height difference:
+        # t = (v*sin(θ) + sqrt((v*sin(θ))² + 2*g*z0)) / g
+        # R = v*cos(θ) * t
+
+        # Try different elevations and find one that works
+        best_elevation = math.radians(15.0)  # default
+        best_speed = 25.0  # default
+
+        for elev_deg in [8, 12, 15, 18, 22, 26, 30]:
+            elev_rad = math.radians(elev_deg)
+
+            # Simplified estimation using range equation with height adjustment
+            # R = v² * sin(2θ) / g is for flat ground
+            # We adjust for starting height z0
+
+            sin_2elev = math.sin(2 * elev_rad)
+            if sin_2elev < 0.1:
+                continue
+
+            # Base speed from range equation
+            speed_base = math.sqrt(horizontal_dist * cfg.gravity / sin_2elev)
+
+            # Adjust for starting height (ball starts higher, can go further)
+            # Approximate correction factor
+            height_factor = 1.0 - 0.1 * z0 / max(horizontal_dist, 1.0)
+            speed = speed_base * max(0.8, height_factor)
+
+            if cfg.min_speed <= speed <= cfg.max_speed:
+                best_elevation = elev_rad
+                best_speed = speed
+                break
+
+        # Add noise to elevation
+        elevation_noise = (
+            (torch.rand(1).item() - 0.5) * 2 * math.radians(cfg.elevation_noise_deg)
+        )
+        best_elevation = max(
+            math.radians(cfg.min_elevation_deg),
+            min(math.radians(cfg.max_elevation_deg), best_elevation + elevation_noise),
+        )
+
+        # Add noise to speed
+        speed_factor = 1.0 + (torch.rand(1).item() - 0.5) * 2 * cfg.speed_variation
+        best_speed = max(
+            cfg.min_speed, min(cfg.max_speed, best_speed * speed_factor)
+        )
+
+        # Convert to velocity components
+        # vx: horizontal component in x direction
+        # vy: horizontal component in y direction (toward opponent)
+        # vz: vertical component (upward)
+        cos_elev = math.cos(best_elevation)
+        sin_elev = math.sin(best_elevation)
+
+        vx = best_speed * cos_elev * math.sin(azimuth_rad)
+        vy = best_speed * cos_elev * math.cos(azimuth_rad) * base_dir
+        vz = best_speed * sin_elev
+
+        return torch.tensor([vx, vy, vz], device=self.device, dtype=torch.float32)
+
+    def sample_velocity_for_target_cell(
+        self,
+        start_pos: Tensor,
+        target_cell: int,
+        target_side: str,
+        from_side: str,
+    ) -> Tensor:
+        """Sample velocity aimed at a specific target cell.
+
+        Samples a random position within the target cell and computes
+        velocity to reach that position.
+
+        Args:
+            start_pos: Starting position [3].
+            target_cell: Target cell ID (0-19).
+            target_side: Side of target cell ("near" or "far").
+            from_side: Side the shot is coming from.
+
+        Returns:
+            Tensor: Velocity [3] in m/s.
+
+        """
+        # Sample target position within cell (ground level)
+        target_pos = self.cell_manager.sample_bounce_position_in_cell(
+            cell_id=target_cell,
+            side=target_side,
+            device=self.device,
+        )
+
+        return self.compute_velocity_to_target(start_pos, target_pos, from_side)

--- a/tests/unit/blcs/test_rally_simulator.py
+++ b/tests/unit/blcs/test_rally_simulator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from src.blcs.simulation.ball_physics import PhysicsConfig
 from src.blcs.simulation.rally_simulator import (
     RallyConfig,
     RallyEndReason,

--- a/tests/unit/blcs/test_targeted_velocity_sampler.py
+++ b/tests/unit/blcs/test_targeted_velocity_sampler.py
@@ -1,0 +1,177 @@
+"""Unit tests for TargetedVelocitySampler."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.blcs.simulation.cell_manager import CellManager
+from src.blcs.simulation.targeted_velocity_sampler import (
+    TargetedVelocityConfig,
+    TargetedVelocitySampler,
+)
+
+
+class TestTargetedVelocityConfig:
+    """Tests for TargetedVelocityConfig dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test default configuration values."""
+        config = TargetedVelocityConfig()
+        assert config.azimuth_noise_deg == 5.0
+        assert config.elevation_noise_deg == 3.0
+        assert config.speed_variation == 0.15
+        assert config.min_elevation_deg == 3.0
+        assert config.max_elevation_deg == 35.0
+        assert config.min_speed == 12.0
+        assert config.max_speed == 40.0
+        assert config.gravity == 9.81
+
+    def test_custom_values(self) -> None:
+        """Test custom configuration values."""
+        config = TargetedVelocityConfig(
+            azimuth_noise_deg=10.0,
+            elevation_noise_deg=5.0,
+            speed_variation=0.2,
+        )
+        assert config.azimuth_noise_deg == 10.0
+        assert config.elevation_noise_deg == 5.0
+        assert config.speed_variation == 0.2
+
+
+class TestTargetedVelocitySampler:
+    """Tests for TargetedVelocitySampler class."""
+
+    @pytest.fixture
+    def sampler(self) -> TargetedVelocitySampler:
+        """Create a targeted velocity sampler with default config."""
+        return TargetedVelocitySampler(device="cpu")
+
+    @pytest.fixture
+    def cell_manager(self) -> CellManager:
+        """Create a cell manager."""
+        return CellManager()
+
+    def test_initialization(self, sampler: TargetedVelocitySampler) -> None:
+        """Test sampler initialization."""
+        assert sampler.cell_manager is not None
+        assert sampler.config is not None
+
+    def test_velocity_direction_near_to_far(
+        self, sampler: TargetedVelocitySampler
+    ) -> None:
+        """Test velocity points toward far side when from_side='near'."""
+        start_pos = torch.tensor([0.0, -5.0, 1.0])
+        target_pos = torch.tensor([0.0, 5.0, 0.0])
+
+        vel = sampler.compute_velocity_to_target(start_pos, target_pos, "near")
+
+        assert vel.shape == (3,)
+        # Y component should be positive (toward far side)
+        assert vel[1] > 0
+
+    def test_velocity_direction_far_to_near(
+        self, sampler: TargetedVelocitySampler
+    ) -> None:
+        """Test velocity points toward near side when from_side='far'."""
+        start_pos = torch.tensor([0.0, 5.0, 1.0])
+        target_pos = torch.tensor([0.0, -5.0, 0.0])
+
+        vel = sampler.compute_velocity_to_target(start_pos, target_pos, "far")
+
+        assert vel.shape == (3,)
+        # Y component should be negative (toward near side)
+        assert vel[1] < 0
+
+    def test_velocity_z_component_positive(
+        self, sampler: TargetedVelocitySampler
+    ) -> None:
+        """Test velocity z component is positive (upward arc)."""
+        start_pos = torch.tensor([0.0, -5.0, 1.0])
+        target_pos = torch.tensor([0.0, 5.0, 0.0])
+
+        vel = sampler.compute_velocity_to_target(start_pos, target_pos, "near")
+
+        # Z component should be positive (ball goes up initially)
+        assert vel[2] > 0
+
+    def test_velocity_magnitude_within_bounds(
+        self, sampler: TargetedVelocitySampler
+    ) -> None:
+        """Test velocity magnitude is within configured bounds."""
+        start_pos = torch.tensor([0.0, -5.0, 1.0])
+        target_pos = torch.tensor([0.0, 5.0, 0.0])
+
+        for _ in range(10):  # Multiple samples due to randomness
+            vel = sampler.compute_velocity_to_target(start_pos, target_pos, "near")
+            speed = torch.norm(vel).item()
+
+            cfg = sampler.config
+            # Allow some tolerance for edge cases
+            assert speed >= cfg.min_speed * 0.8, f"Speed {speed} below min"
+            assert speed <= cfg.max_speed * 1.2, f"Speed {speed} above max"
+
+    def test_sample_velocity_for_target_cell(
+        self, sampler: TargetedVelocitySampler
+    ) -> None:
+        """Test sampling velocity for a specific target cell."""
+        start_pos = torch.tensor([0.0, -5.0, 1.0])
+
+        vel = sampler.sample_velocity_for_target_cell(
+            start_pos=start_pos,
+            target_cell=4,  # Center cell
+            target_side="far",
+            from_side="near",
+        )
+
+        assert vel.shape == (3,)
+        # Should aim toward far side
+        assert vel[1] > 0
+
+    def test_sample_velocity_for_different_cells(
+        self, sampler: TargetedVelocitySampler
+    ) -> None:
+        """Test that different target cells produce different velocities."""
+        start_pos = torch.tensor([0.0, -5.0, 1.0])
+
+        # Sample for left cell
+        vel_left = sampler.sample_velocity_for_target_cell(
+            start_pos=start_pos,
+            target_cell=0,  # Left cell
+            target_side="far",
+            from_side="near",
+        )
+
+        # Sample for right cell
+        vel_right = sampler.sample_velocity_for_target_cell(
+            start_pos=start_pos,
+            target_cell=2,  # Right cell
+            target_side="far",
+            from_side="near",
+        )
+
+        # X components should have different signs on average
+        # (left cell -> negative x, right cell -> positive x)
+        # Note: Due to noise, individual samples may not follow this
+        # but the general trend should be there
+        assert vel_left.shape == vel_right.shape == (3,)
+
+    def test_velocity_variation_with_noise(
+        self, sampler: TargetedVelocitySampler
+    ) -> None:
+        """Test that noise causes variation in velocity."""
+        start_pos = torch.tensor([0.0, -5.0, 1.0])
+        target_pos = torch.tensor([0.0, 5.0, 0.0])
+
+        velocities = []
+        for _ in range(5):
+            vel = sampler.compute_velocity_to_target(start_pos, target_pos, "near")
+            velocities.append(vel.clone())
+
+        # Check that not all velocities are identical
+        # (due to noise, they should vary)
+        velocities_stacked = torch.stack(velocities)
+        std = velocities_stacked.std(dim=0)
+
+        # At least one component should have non-zero std
+        assert std.sum() > 0, "Velocities should vary due to noise"


### PR DESCRIPTION
## Summary

- ラリーシミュレーションの2打目以降にも1打目と同じcell-to-cell分布制御を適用
- これにより、全ショットで(from_cell, side, category, to_cell)の組み合わせが均一に分布
- SHOTモードを廃止し、RALLYモードに統合

## Changes

### 新規追加
- `TargetedVelocitySampler`: 物理ベースの速度計算（弾道力学 + ノイズ）
- `targeted_velocity/default.yaml`: 速度計算の設定ファイル

### 改修
- `RallySimulator`: DistributionSamplerを統合、正確なセル判定を使用
- `CellManager`: `get_cell_center()`, `sample_bounce_position_in_cell()`追加
- `SceneGenerator`: SHOTモード削除、RALLYモードのみに
- `sampling/default.yaml`: in_court=0.80に調整（約20%が各打ちで脱落）

### アーキテクチャ
```
1打目 → DistributionSampler判定 → 2打目 → DistributionSampler判定 → 3打目 → ...
         ↓                           ↓                            ↓
    IN_COURT(80%)              IN_COURT(80%)                 IN_COURT(80%)
    OUT_COURT(10%)             OUT_COURT(10%)                OUT_COURT(10%)
    NET(5%)                    NET(5%) → 終了                NET(5%) → 終了
```

## Test plan
- [x] TargetedVelocitySamplerのユニットテスト追加・通過
- [x] RallySimulatorの既存テスト通過
- [x] ruffチェック通過
- [ ] 実際のデータセット生成で分布を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)