### PR TITLE
Harden worktree helper scripts

### DIFF
--- a/worktree_remove.sh
+++ b/worktree_remove.sh
@@ -4,78 +4,140 @@ set -euo pipefail
 # worktree削除スクリプト
 # 使い方:
 #   ./worktree_remove.sh <worktree-path1> [worktree-path2] [...]
-#   ./worktree_remove.sh /root/repos/wt/wt-20231231-123456
-#   ./worktree_remove.sh /root/repos/wt/wt-20231231-123456 /root/repos/wt/feature-foo
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <worktree-path1> [worktree-path2] [...]" >&2
-  echo "Example: $0 /root/repos/wt/wt-20231231-123456" >&2
-  echo "         $0 /root/repos/wt/wt-20231231-123456 /root/repos/wt/feature-foo" >&2
+  echo "Example: $0 /home/motoki/repos/wt/feature-foo" >&2
   exit 1
 fi
 
-ORIG_REPO="/root/repos/tennis-lab"
+die() { echo "Error: $*" >&2; exit 1; }
 
-# 各ワークツリーに対して処理を実行
-for WT_DIR in "$@"; do
+# 対象 worktree が属する common .git / main worktree / admin gitdir を解決
+resolve_ctx_from_wt() {
+  local wt_dir="$1"
+  local common_git_dir main_wt admin_gitdir
+
+  common_git_dir="$(git -C "$wt_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
+    || die "Failed to resolve git-common-dir for: $wt_dir"
+
+  main_wt="$(
+    git --git-dir "$common_git_dir" worktree list --porcelain \
+      | awk '/^worktree /{print $2; exit}'
+  )"
+  [[ -n "$main_wt" ]] || die "Failed to resolve main worktree for: $wt_dir"
+
+  # worktree list --porcelain から、その worktree の admin gitdir を引く（.git/worktrees/<id>）
+  admin_gitdir="$(
+    git --git-dir "$common_git_dir" worktree list --porcelain \
+      | awk -v target="$wt_dir" '
+          $1=="worktree"{wt=$2}
+          $1=="gitdir"{gd=$2; if (wt==target){print gd; exit}}
+        '
+  )"
+
+  echo "$common_git_dir|$main_wt|$admin_gitdir"
+}
+
+remove_symlinks() {
+  local wt_dir="$1"
+  echo "==> Removing symbolic links in '$wt_dir'..."
+
+  for link in data .venv third_party outputs; do
+    local p="$wt_dir/$link"
+    if [[ -L "$p" ]]; then
+      echo "  - Removing symlink: $link"
+      rm -f "$p"
+    elif [[ -e "$p" ]]; then
+      echo "  - Warning: '$link' exists but is not a symlink (skipping)"
+    fi
+  done
+}
+
+cleanup_submodules_best_effort() {
+  local wt_dir="$1"
+
+  if [[ -f "$wt_dir/.gitmodules" ]]; then
+    echo "==> Deinitializing submodules (best-effort)..."
+    git -C "$wt_dir" submodule deinit -f --all >/dev/null 2>&1 || true
+
+    # .gitmodules に書かれたパスの作業ツリー側を消す（worktree remove が submodule で落ちる回避）
+    git -C "$wt_dir" config --file .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null \
+      | awk '{print $2}' \
+      | while read -r sm_path; do
+          [[ -z "$sm_path" ]] && continue
+          if [[ -e "$wt_dir/$sm_path" || -L "$wt_dir/$sm_path" ]]; then
+            echo "  - Removing submodule path: $sm_path"
+            rm -rf "$wt_dir/$sm_path"
+          fi
+        done || true
+  fi
+}
+
+try_git_worktree_remove() {
+  local common_git_dir="$1"
+  local main_wt="$2"
+  local wt_dir="$3"
+
+  git --git-dir "$common_git_dir" --work-tree "$main_wt" worktree remove "$wt_dir" --force
+}
+
+manual_fallback_cleanup() {
+  local common_git_dir="$1"
+  local main_wt="$2"
+  local admin_gitdir="$3"
+  local wt_dir="$4"
+
+  echo "==> Fallback: manual cleanup for '$wt_dir'..."
+  rm -rf "$wt_dir"
+
+  # admin gitdir が残っていたら消す（lock等で prune できないケースの保険）
+  if [[ -n "$admin_gitdir" && -e "$admin_gitdir" ]]; then
+    echo "  - Removing admin gitdir: $admin_gitdir"
+    rm -rf "$admin_gitdir"
+  fi
+
+  git --git-dir "$common_git_dir" --work-tree "$main_wt" worktree prune --verbose >/dev/null 2>&1 || true
+}
+
+# ---- main ------------------------------------------------------------------
+
+for WT_DIR_IN in "$@"; do
   echo ""
   echo "========================================"
-  echo "Processing: $WT_DIR"
+  echo "Processing: $WT_DIR_IN"
   echo "========================================"
-  
-  if [[ ! -d "$WT_DIR" ]]; then
-    echo "Error: Directory '$WT_DIR' does not exist (skipping)" >&2
+
+  if [[ ! -d "$WT_DIR_IN" ]]; then
+    echo "Error: Directory '$WT_DIR_IN' does not exist (skipping)" >&2
     continue
   fi
 
-  # worktree かどうか確認
-  if ! git -C "$WT_DIR" rev-parse --is-inside-work-tree &>/dev/null; then
+  # 実パス化
+  WT_DIR="$(cd "$WT_DIR_IN" && pwd -P)"
+
+  if ! git -C "$WT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "Error: '$WT_DIR' is not a valid git worktree (skipping)" >&2
     continue
   fi
 
-  echo "==> Removing symbolic links in '$WT_DIR'..."
+  remove_symlinks "$WT_DIR"
+  cleanup_submodules_best_effort "$WT_DIR"
 
-  # worktree内に移動
-  cd "$WT_DIR"
-
-  # シンボリックリンクを削除（worktree_symbolic.sh で作成されたもの）
-  for link in data .venv third_party outputs; do
-    if [[ -L "$link" ]]; then
-      echo "  - Removing symlink: $link"
-      rm -f "$link"
-    elif [[ -e "$link" ]]; then
-      echo "  - Warning: '$link' exists but is not a symlink (skipping)"
-    fi
-  done
-
-  # サブモジュール関連のクリーンアップ（念のため）
-  if [[ -f .gitmodules ]] || [[ -d .git/modules ]]; then
-    echo "==> Cleaning up submodule references..."
-    # .git/modules 内のサブモジュールディレクトリを削除
-    if [[ -d .git/modules ]]; then
-      rm -rf .git/modules
-    fi
-    # サブモジュールディレクトリ自体を削除（シンボリックの場合もあるため念のため）
-    if [[ -f .gitmodules ]]; then
-      git config --file .gitmodules --get-regexp '^submodule\..*\.path$' | \
-        awk '{print $2}' | \
-        while read -r sm_path; do
-          if [[ -e "$sm_path" ]] || [[ -L "$sm_path" ]]; then
-            echo "  - Removing submodule path: $sm_path"
-            rm -rf "$sm_path"
-          fi
-        done
-    fi
-  fi
-
-  # 元のリポジトリに戻る
-  cd "$ORIG_REPO"
+  ctx="$(resolve_ctx_from_wt "$WT_DIR")"
+  COMMON_GIT_DIR="${ctx%%|*}"
+  rest="${ctx#*|}"
+  MAIN_WT="${rest%%|*}"
+  ADMIN_GITDIR="${rest#*|}"
 
   echo "==> Removing worktree: $WT_DIR"
-  git worktree remove "$WT_DIR" --force
-
-  echo "==> Done! Worktree '$WT_DIR' removed successfully."
+  if try_git_worktree_remove "$COMMON_GIT_DIR" "$MAIN_WT" "$WT_DIR"; then
+    echo "==> Done! Worktree '$WT_DIR' removed successfully."
+  else
+    echo "Warning: 'git worktree remove' failed. Trying fallback cleanup..." >&2
+    manual_fallback_cleanup "$COMMON_GIT_DIR" "$MAIN_WT" "$ADMIN_GITDIR" "$WT_DIR"
+    echo "==> Done (fallback). Worktree '$WT_DIR' cleaned."
+  fi
 done
 
 echo ""

--- a/worktree_symbolic.sh
+++ b/worktree_symbolic.sh
@@ -1,64 +1,133 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd /root/repos/tennis-lab
-
 # 使い方:
 #   ./worktree_symbolic.sh                 # ブランチ名を自動生成
 #   ./worktree_symbolic.sh feature/foo     # ブランチ名を指定
-BRANCH="${1:-feature/wt-$(date +%Y%m%d-%H%M%S)}"
-WT_PARENT="/root/repos/wt"
-ORIG="$(pwd -P)"
-BASE_REF="main"  # 新規ブランチは必ずmainから作成
+#
+# 環境変数:
+#   WT_PARENT=/path/to/wt-parent           # worktree を作る親ディレクトリ（省略可）
+#   BASE_REF=main                          # 新規ブランチ作成の基点（省略可）
 
-# 現在のブランチがmainでない場合、mainをチェックアウト
-CURRENT_BRANCH="$(git branch --show-current)"
-if [[ "$CURRENT_BRANCH" != "main" ]]; then
-  echo "現在のブランチ ($CURRENT_BRANCH) からmainに切り替えます..."
-  git checkout main
-  git pull origin main 2>/dev/null || echo "Warning: Could not pull from origin/main"
-fi
+# ---- helpers ---------------------------------------------------------------
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+# スクリプトの場所から、その worktree が属する「共通 .git」と「main worktree」を解決する
+resolve_repo_context() {
+  local script_dir common_git_dir main_wt
+
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+  # common git dir（例: /path/to/main/.git）
+  common_git_dir="$(git -C "$script_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
+    || die "This script must be located inside a git working tree."
+
+  # main worktree は worktree list の先頭に出る（通常）
+  main_wt="$(
+    git --git-dir "$common_git_dir" worktree list --porcelain \
+      | awk '/^worktree /{print $2; exit}'
+  )"
+  [[ -n "$main_wt" && -d "$main_wt" ]] || die "Failed to resolve main worktree."
+
+  echo "$common_git_dir|$main_wt"
+}
+
+# その branch がすでにどこかの worktree に割り当てられているなら、そのパスを返す
+find_worktree_for_branch() {
+  local common_git_dir="$1"
+  local main_wt="$2"
+  local branch="$3"
+
+  git --git-dir "$common_git_dir" --work-tree "$main_wt" worktree list --porcelain \
+    | awk -v b="refs/heads/$branch" '
+        $1=="worktree"{wt=$2}
+        $1=="branch" && $2==b {print wt; exit}
+      '
+}
+
+safe_replace_with_symlink() {
+  local link_path="$1"
+  local target_path="$2"
+
+  if [[ -L "$link_path" ]]; then
+    rm -f "$link_path"
+  elif [[ -e "$link_path" ]]; then
+    # 既存がディレクトリ/ファイルの場合は削除（この挙動が嫌ならここを保守的に変更）
+    rm -rf "$link_path"
+  fi
+
+  ln -s "$target_path" "$link_path"
+}
+
+# ---- main ------------------------------------------------------------------
+
+BRANCH="${1:-feature/wt-$(date +%Y%m%d-%H%M%S)}"
+BRANCH="${BRANCH#refs/heads/}"  # 念のため
+
+# branch 名の妥当性チェック
+git check-ref-format --branch "$BRANCH" >/dev/null 2>&1 \
+  || die "Invalid branch name: $BRANCH"
+
+BASE_REF="${BASE_REF:-main}"
+
+ctx="$(resolve_repo_context)"
+COMMON_GIT_DIR="${ctx%%|*}"
+ORIG="${ctx#*|}"   # main worktree（データ共有の起点）
+
+WT_PARENT_DEFAULT="$(dirname "$ORIG")/wt"
+WT_PARENT="${WT_PARENT:-$WT_PARENT_DEFAULT}"
 
 mkdir -p "$WT_PARENT"
 
-# そのブランチが既にどこかの worktree に割り当てられているか調べる
-existing_wt="$(
-  git worktree list --porcelain \
-  | awk -v b="refs/heads/$BRANCH" '
-      $1=="worktree"{wt=$2}
-      $1=="branch" && $2==b {print wt; exit}
-    '
-)"
+# origin があれば、BASE_REF をなるべく最新化（checkout しない）
+if git --git-dir "$COMMON_GIT_DIR" --work-tree "$ORIG" remote get-url origin >/dev/null 2>&1; then
+  git --git-dir "$COMMON_GIT_DIR" --work-tree "$ORIG" fetch -q origin "$BASE_REF" || true
+fi
 
-if [[ -n "${existing_wt}" ]]; then
-  # 既にworktreeがある → そこに移動して開く
+# base ref は origin/<BASE_REF> があればそれを優先
+BASE_REF_RESOLVED="$BASE_REF"
+if git --git-dir "$COMMON_GIT_DIR" --work-tree "$ORIG" show-ref --verify --quiet "refs/remotes/origin/$BASE_REF"; then
+  BASE_REF_RESOLVED="origin/$BASE_REF"
+fi
+
+# そのブランチがすでに worktree に存在するか
+existing_wt="$(find_worktree_for_branch "$COMMON_GIT_DIR" "$ORIG" "$BRANCH" || true)"
+
+if [[ -n "$existing_wt" ]]; then
   cd "$existing_wt"
 else
-  # worktree未作成 → 作る
-  WT_DIR="$WT_PARENT/${BRANCH##*/}"
+  WT_SLUG="${BRANCH//\//-}"        # branch の / を - にして衝突しにくく
+  WT_DIR="$WT_PARENT/$WT_SLUG"
 
-  if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
-    # ブランチは存在するが worktree は無い → そのブランチをcheckoutするworktreeを作る
-    git worktree add "$WT_DIR" "$BRANCH"
+  # すでにディレクトリがある場合は「それが worktree なら開く / 違うならエラー」
+  if [[ -d "$WT_DIR" ]]; then
+    if git -C "$WT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      cd "$WT_DIR"
+    else
+      die "Directory already exists but is not a git worktree: $WT_DIR"
+    fi
   else
-    # ブランチが無い → 新規ブランチ作成 + worktree 作成
-    git worktree add -b "$BRANCH" "$WT_DIR" "$BASE_REF"
+    # ブランチが既にあるか？
+    if git --git-dir "$COMMON_GIT_DIR" --work-tree "$ORIG" show-ref --verify --quiet "refs/heads/$BRANCH"; then
+      git --git-dir "$COMMON_GIT_DIR" --work-tree "$ORIG" worktree add "$WT_DIR" "$BRANCH"
+    else
+      git --git-dir "$COMMON_GIT_DIR" --work-tree "$ORIG" worktree add -b "$BRANCH" "$WT_DIR" "$BASE_REF_RESOLVED"
+    fi
+    cd "$WT_DIR"
   fi
-
-  cd "$WT_DIR"
 fi
 
 # シンボリックリンク生成（大きいものだけ共有）
-rm -rf data .venv third_party outputs
-ln -s "$ORIG/data" data
-ln -s "$ORIG/.venv" .venv
-ln -s "$ORIG/third_party" third_party
-ln -s "$ORIG/outputs" outputs
-
-# ※ third_party を symlink にしたいなら（trackedなら差分が出ます）
-# rm -rf third_party
-# ln -s "$ORIG/third_party" third_party
+# ※ third_party が tracked/submodule の場合、差分が出たり運用ポリシーが必要です
+safe_replace_with_symlink "$PWD/data"       "$ORIG/data"
+safe_replace_with_symlink "$PWD/.venv"      "$ORIG/.venv"
+safe_replace_with_symlink "$PWD/third_party" "$ORIG/third_party"
+safe_replace_with_symlink "$PWD/outputs"    "$ORIG/outputs"
 
 # VSCodeで開く
-command -v code >/dev/null && code . || \
-echo "code コマンドが無いです（VSCodeで 'Shell Command: Install code command in PATH' を実行）"
+if command -v code >/dev/null 2>&1; then
+  code .
+else
+  echo "code コマンドが無いです（VSCodeで 'Shell Command: Install code command in PATH' を実行）" >&2
+fi


### PR DESCRIPTION
## Summary
- make worktree scripts resolve repo context dynamically
- add safer symlink handling and branch/worktree validation
- add fallback cleanup when worktree removal fails

## Testing
- not run (pre-commit skipped per request; uv cache rename error)
