### PR TITLE
Add skills for agent sub-tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,92 +37,12 @@ Config entry point: `src/plcs/configs/generate_dataset.yaml`
 
 ## 3. 使用可能なツール
 
-### `src.agents.scripts.consult`（推奨：開発前のアプローチ相談）
-複数のLLMプロバイダーに同時に相談し、タスクへのアプローチを提案させます。開発前に使用することで、より良い実装方針を得られます。
+Sub-agent ツールの詳細な使い方はスキル化済みのドキュメントを参照してください。
 
-**実行例**
-```bash
-# 基本的な相談
-uv run python -m src.agents.scripts.consult 'task.prompt=BLCSのgenerate_datasetの改善案を提案してください'
-
-# アプローチ相談用のシステムプロンプトを使用
-uv run python -m src.agents.scripts.consult system_prompt=approach 'task.prompt=...'
-
-# 特定のプロバイダーを無効化
-uv run python -m src.agents.scripts.consult claude.enable=false 'task.prompt=...'
-```
-
-**想定出力（例）**
-```
-============================================================
-Sub-agent Consultation Results
-============================================================
-
-[CLAUDE] ✓
-----------------------------------------
-（提案内容）
-
-[CODEX] ✓
-----------------------------------------
-（提案内容）
-
-============================================================
-```
-
-### `src.agents.scripts.review`（推奨：開発後のレビュー）
-複数のLLMプロバイダーにコード変更をレビューさせ、問題点や改善点、新しいタスクを発見します。
-
-**実行例**
-```bash
-# 全ての変更をレビュー
-uv run python -m src.agents.scripts.review
-
-# ステージされた変更のみをレビュー
-uv run python -m src.agents.scripts.review review.scope=staged
-
-# 最後のコミットをレビュー
-uv run python -m src.agents.scripts.review review.scope=head
-
-# 特定の観点でレビュー
-uv run python -m src.agents.scripts.review 'review.focus=security'
-```
-
-### `src.agents.scripts.pre_commit`
-変更ファイル（`git diff --name-only HEAD`）に対して `pre-commit` を実行し、失敗した場合は Codex Sub-agent に修正を委譲します。ログは `agents_workspace/sub_agents/logs/` に保存され、標準出力には 1 行の JSON を返します。
-
-**実行例**
-```bash
-uv run python -m src.agents.scripts.pre_commit
-```
-（ヘルプ：`uv run python -m src.agents.scripts.pre_commit --help`）
-
-**想定出力（例）**
-```json
-{"status":"pass","fixed":false,"files_touched":[],"remaining_errors":[],"summary":"pre-commit passed","needs_main":false,"message_for_main":""}
-```
-
-
-### `src.agents.scripts.test`（推奨：テスト用）
-指定したテストコマンド（デフォルトは `uv run --no-sync pytest -q -n auto`）を実行し、失敗した場合はログから対象ファイルを抽出して Codex Sub-agent に修正を委譲します。ログは `agents_workspace/sub_agents/logs/pytest_*.log` に保存され、標準出力には 1 行の JSON を返します。
-
-**基本（デフォルトの pytest）**
-```bash
-uv run python -m src.agents.scripts.test
-```
-（ヘルプ：`uv run python -m src.agents.scripts.test --help`）
-
-**テスト対象を絞る（例：単体テスト/ケース指定）**
-```bash
-uv run python -m src.agents.scripts.test 'task.test_cmd=uv run --no-sync pytest -q tests/test_example.py::test_case'
-```
-
-**想定出力（例）**
-```json
-{"status":"pass","fixed":false,"files_touched":[],"remaining_failures":[],"summary":"tests passed","needs_main":false,"message_for_main":""}
-```
-```json
-{"status":"fail","fixed":false,"files_touched":[],"remaining_failures":["..."],"summary":"...","needs_main":false,"message_for_main":""}
-```
+- `skills/agents-consult/SKILL.md`
+- `skills/agents-review/SKILL.md`
+- `skills/agents-pre-commit/SKILL.md`
+- `skills/agents-test/SKILL.md`
 
 ## 4. 推奨ワークフロー（ブランチ作成→相談→作業→レビュー→検査→テスト）
 
@@ -135,18 +55,18 @@ uv run python -m src.agents.scripts.test 'task.test_cmd=uv run --no-sync pytest 
 
 2) **開発前の相談（推奨）**
 - 複雑なタスクの場合は、`src.agents.scripts.consult` を使用して複数のLLMにアプローチを提案させる
-- 例: `uv run python -m src.agents.scripts.consult system_prompt=approach 'task.prompt=...'`
+- 実行例は `skills/agents-consult/SKILL.md` を参照
 - 複数の視点からのフィードバックを得ることで、より良い実装方針を決定できる
 
 3) **検査とテスト（必須）**
 - 変更後は必ず `src.agents.scripts.pre_commit` → `src.agents.scripts.test` の順で実行する（ユーザーが「実行しないで」と言った場合を除く）
 - **テストは全て実行するのではなく、変更に影響するテストのみを `task.test_cmd` で指定して実行する**
-  - 例: `uv run python -m src.agents.scripts.test 'task.test_cmd=uv run --no-sync pytest -q -n auto tests/unit/test_affected.py'`
+  - 実行例は `skills/agents-test/SKILL.md` を参照
   - 変更したモジュールに対応するテストファイルを特定し、必要最小限のテストを実行する
 
 4) **開発後のレビュー（推奨）**
 - 変更完了後、`src.agents.scripts.review` を使用してコード変更をレビューさせる
-- 例: `uv run python -m src.agents.scripts.review review.scope=staged`
+- 実行例は `skills/agents-review/SKILL.md` を参照
 - 問題点の発見、改善提案、新しいタスクの特定に役立つ
 
 5) **ドキュメントの整合性確認（必須）**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,6 @@ uv run pytest tests/unit/test_example.py::test_case
 
 # Run with coverage
 uv run pytest --cov=src --cov-report=html --cov-report=term-missing
-
-# Using the test subagent (recommended)
-uv run python -m src.agents.scripts.test
-uv run python -m src.agents.scripts.test 'task.test_cmd=uv run pytest tests/...'
 ```
 
 ### Linting and Type Checking
@@ -57,9 +53,6 @@ uv run ruff check --fix src tests
 
 # Run mypy
 uv run mypy src tests
-
-# Using pre-commit subagent (recommended, runs both)
-uv run python -m src.agents.scripts.pre_commit
 ```
 
 ### Training
@@ -189,16 +182,10 @@ def predict(self, *args, **kwargs) -> dict[str, Any]:
 
 ### Multi-LLM Consultation Tools
 
-This project provides tools for consulting multiple LLM providers:
-
-```bash
-# Before development: Get approach suggestions from multiple LLMs
-uv run python -m src.agents.scripts.consult system_prompt=approach 'task.prompt=...'
-
-# After development: Review changes with multiple LLMs
-uv run python -m src.agents.scripts.review
-uv run python -m src.agents.scripts.review review.scope=staged
-```
+This project provides sub-agent tools for consultation and review.
+Usage examples are documented in:
+- `skills/agents-consult/SKILL.md`
+- `skills/agents-review/SKILL.md`
 
 ### Mandatory Workflow (AI Agents MUST follow)
 
@@ -208,25 +195,15 @@ uv run python -m src.agents.scripts.review review.scope=staged
    ```
 
 2. **Before complex tasks** (recommended):
-   ```bash
-   # Consult multiple LLMs for approach suggestions
-   uv run python -m src.agents.scripts.consult system_prompt=approach 'task.prompt=...'
-   ```
+   - See `skills/agents-consult/SKILL.md` for commands.
 
 3. **After ANY code changes**:
-   ```bash
-   # Run linting/type checking
-   uv run python -m src.agents.scripts.pre_commit
-
-   # Run ONLY affected tests (do NOT run all tests)
-   uv run python -m src.agents.scripts.test 'task.test_cmd=uv run --no-sync pytest -q -n auto tests/unit/test_affected.py'
-   ```
+   - Run lint/type checks via `src.agents.scripts.pre_commit`.
+   - Run ONLY affected tests via `src.agents.scripts.test`.
+   - See `skills/agents-pre-commit/SKILL.md` and `skills/agents-test/SKILL.md` for commands.
 
 4. **Before commit** (recommended):
-   ```bash
-   # Review changes with multiple LLMs
-   uv run python -m src.agents.scripts.review review.scope=staged
-   ```
+   - See `skills/agents-review/SKILL.md` for commands.
 
 5. **Check documentation consistency**:
    - Update `src/{task}/README.md` if your changes affect the documented behavior

--- a/skills/agents-consult/SKILL.md
+++ b/skills/agents-consult/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: agents-consult
+description: Consult multiple LLM providers via src.agents.scripts.consult to get approach suggestions before implementing changes. Use when you need design options, risk checks, or alternative solutions for a task in this repo, especially before complex work.
+---
+
+# Agents Consult
+
+## Overview
+
+Use this skill to ask multiple LLM providers for implementation approaches before you start coding.
+
+## Quick start
+
+Run the consult script with a clear prompt.
+
+```bash
+uv run python -m src.agents.scripts.consult 'task.prompt=Propose improvements for BLCS generate_dataset.'
+```
+
+## Common options
+
+Use the approach-oriented system prompt when you want structured design guidance.
+
+```bash
+uv run python -m src.agents.scripts.consult system_prompt=approach 'task.prompt=...'
+```
+
+Disable a provider to avoid specific models.
+
+```bash
+uv run python -m src.agents.scripts.consult claude.enable=false 'task.prompt=...'
+```
+
+## Output
+
+Expect a multi-provider summary with sections like:
+
+```
+Sub-agent Consultation Results
+[CLAUDE] ...
+[CODEX] ...
+```

--- a/skills/agents-pre-commit/SKILL.md
+++ b/skills/agents-pre-commit/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: agents-pre-commit
+description: Run pre-commit checks using src.agents.scripts.pre_commit after editing code. Use when you need automated lint/format hooks on changed files or before running tests and review.
+---
+
+# Agents Pre Commit
+
+## Overview
+
+Use this skill to run the repo's pre-commit hooks on files changed since HEAD.
+
+## Quick start
+
+```bash
+uv run python -m src.agents.scripts.pre_commit
+```
+
+## Notes
+
+The script runs pre-commit on `git diff --name-only HEAD` and may delegate fixes to sub-agents.
+Logs are saved under `agents_workspace/sub_agents/logs/`.
+
+If `uv` cache permissions fail, use a workspace cache:
+
+```bash
+uv --cache-dir agents_workspace/tmp_cache/uv_cache run python -m src.agents.scripts.pre_commit
+```

--- a/skills/agents-review/SKILL.md
+++ b/skills/agents-review/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: agents-review
+description: Review code changes using src.agents.scripts.review after edits. Use when you need multi-provider feedback on diffs, staged changes, or the last commit, or when focusing on a review theme like security.
+---
+
+# Agents Review
+
+## Overview
+
+Use this skill to run multi-provider review after changes, especially before finalizing or committing.
+
+## Quick start
+
+Review all changes in the working tree.
+
+```bash
+uv run python -m src.agents.scripts.review
+```
+
+## Common scopes
+
+Review only staged changes.
+
+```bash
+uv run python -m src.agents.scripts.review review.scope=staged
+```
+
+Review the last commit.
+
+```bash
+uv run python -m src.agents.scripts.review review.scope=head
+```
+
+Focus the review on a theme like security.
+
+```bash
+uv run python -m src.agents.scripts.review 'review.focus=security'
+```

--- a/skills/agents-test/SKILL.md
+++ b/skills/agents-test/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: agents-test
+description: Run targeted tests using src.agents.scripts.test after code changes. Use when you need to execute only affected tests, pass a custom pytest command, or collect JSON test summaries with sub-agent fixes.
+---
+
+# Agents Test
+
+## Overview
+
+Use this skill to run only the affected tests and capture a JSON summary.
+
+## Quick start
+
+Run the default test command (pytest with `-q -n auto`) through the sub-agent.
+
+```bash
+uv run python -m src.agents.scripts.test
+```
+
+## Targeted tests (required by repo policy)
+
+Always pass a narrowed `task.test_cmd` for affected files.
+
+```bash
+uv run python -m src.agents.scripts.test \
+  'task.test_cmd=uv run --no-sync pytest -q -n auto tests/unit/test_affected.py'
+```
+
+Use a specific test case when needed.
+
+```bash
+uv run python -m src.agents.scripts.test \
+  'task.test_cmd=uv run --no-sync pytest -q tests/test_example.py::test_case'
+```
+
+## Output and logs
+
+The script prints a single-line JSON summary and stores logs under
+`agents_workspace/sub_agents/logs/pytest_*.log`.
+
+## Cache workaround
+
+If `uv` cache permissions fail, use a workspace cache:
+
+```bash
+uv run python -m src.agents.scripts.test \
+  'task.test_cmd=uv --cache-dir agents_workspace/tmp_cache/uv_cache run --no-sync pytest -q tests/...'
+```


### PR DESCRIPTION
## Summary\n- add skill docs for consult/review/pre_commit/test sub-agents\n- trim AGENTS.md and CLAUDE.md to reference the new skills\n\n## Testing\n- uv run python -m src.agents.scripts.pre_commit\n- uv run python -m src.agents.scripts.test 'task.test_cmd=uv run --no-sync pytest -q -n auto tests/unit/wasb/test_heatmap_smoothing.py'