### PR TITLE
fix(blcs): Remove deprecated GenerationMode from generate_dataset script

### DIFF
--- a/src/blcs/scripts/generate_dataset.py
+++ b/src/blcs/scripts/generate_dataset.py
@@ -1,12 +1,9 @@
 """Generate a BLCS dataset with Hydra-managed configuration.
 
 Example commands:
-    # Shot mode (default):
     `uv run python -m src.blcs.scripts.generate_dataset`
-    `uv run python -m src.blcs.scripts.generate_dataset run.output_dir=data/blcs sampling.per_from_cell_samples=10`
-
-    # Rally mode:
-    `uv run python -m src.blcs.scripts.generate_dataset generator.mode=rally generator.num_rally_scenes=100`
+    `uv run python -m src.blcs.scripts.generate_dataset generator.num_rally_scenes=100`
+    `uv run python -m src.blcs.scripts.generate_dataset run.output_dir=data/blcs generator.num_rally_scenes=500`
 
 Config entry point: `src/blcs/configs/generate_dataset.yaml`
 """
@@ -31,7 +28,6 @@ from src.blcs.generate_dataset.io.dataset_io import BLCSDatasetWriter
 from src.blcs.generate_dataset.sampling.distribution_sampler import SamplingConfig
 from src.blcs.generate_dataset.scene_generator import (
     BLCSSceneGenerator,
-    GenerationMode,
     GeneratorConfig,
 )
 from src.blcs.simulation.ball_physics import PhysicsConfig
@@ -109,17 +105,12 @@ def _build_generator_config(cfg: DictConfig) -> GeneratorConfig:
         per_from_cell_samples=int(cfg.sampling.per_from_cell_samples),
     )
 
-    # Parse generation mode
-    mode_str = str(cfg.generator.mode).lower()
-    mode = GenerationMode.RALLY if mode_str == "rally" else GenerationMode.SHOT
-
     return GeneratorConfig(
         physics=physics_config,
         shot=shot_config,
         rally=rally_config,
         camera=camera_config,
         sampling=sampling_config,
-        mode=mode,
         num_cameras_sampled=int(cfg.generator.num_cameras_sampled),
         ball_visibility_threshold=float(cfg.generator.ball_visibility_threshold),
         max_attempts_per_cell=int(cfg.generator.max_attempts_per_cell),
@@ -159,15 +150,10 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
         )
 
     generator_config = _build_generator_config(cfg)
-    mode = generator_config.mode
 
     logger.info("Output directory: %s", output_dir)
-    logger.info("Generation mode: %s", mode.value)
-    if mode == GenerationMode.SHOT:
-        logger.info("Samples per from-cell: %s", cfg.sampling.per_from_cell_samples)
-    else:
-        logger.info("Number of rally scenes: %s", cfg.generator.num_rally_scenes)
-        logger.info("Max rallies per scene: %s", cfg.rally.max_rallies)
+    logger.info("Number of rally scenes: %s", cfg.generator.num_rally_scenes)
+    logger.info("Max rallies per scene: %s", cfg.rally.max_rallies)
     logger.info("Cameras sampled per scene: %s", generator_config.num_cameras_sampled)
     logger.info("Ball visibility threshold: %s", generator_config.ball_visibility_threshold)
     logger.info("Device: %s", cfg.run.device)
@@ -175,45 +161,28 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
     generator = BLCSSceneGenerator(config=generator_config, device=str(cfg.run.device))
     writer = BLCSDatasetWriter(output_dir)
 
-    logger.info("Starting scene generation...")
+    logger.info("Starting rally scene generation...")
     total_scenes = 0
     total_cameras = 0
 
-    if mode == GenerationMode.SHOT:
-        # Shot mode: use distribution-controlled generation
-        for scene_data in tqdm(generator.generate_all_scenes(), desc="Generating shots"):
-            writer.save_scene(scene_data)
-            total_scenes += 1
-            total_cameras += len(scene_data.cameras)
+    num_rally_scenes = int(cfg.generator.num_rally_scenes)
+    for scene_data in tqdm(
+        generator.generate_rally_scenes(num_rally_scenes),
+        desc="Generating rallies",
+        total=num_rally_scenes,
+    ):
+        writer.save_rally_scene(scene_data)
+        total_scenes += 1
+        total_cameras += len(scene_data.cameras)
 
-            if total_scenes % 100 == 0:
-                avg_cams = total_cameras / total_scenes
-                logger.info(
-                    "Progress: %s scenes, %s cameras (avg %.1f/scene)",
-                    total_scenes,
-                    total_cameras,
-                    avg_cams,
-                )
-    else:
-        # Rally mode: generate fixed number of rally scenes
-        num_rally_scenes = int(cfg.generator.num_rally_scenes)
-        for scene_data in tqdm(
-            generator.generate_rally_scenes(num_rally_scenes),
-            desc="Generating rallies",
-            total=num_rally_scenes,
-        ):
-            writer.save_rally_scene(scene_data)
-            total_scenes += 1
-            total_cameras += len(scene_data.cameras)
-
-            if total_scenes % 100 == 0:
-                avg_cams = total_cameras / total_scenes
-                logger.info(
-                    "Progress: %s rally scenes, %s cameras (avg %.1f/scene)",
-                    total_scenes,
-                    total_cameras,
-                    avg_cams,
-                )
+        if total_scenes % 100 == 0:
+            avg_cams = total_cameras / total_scenes
+            logger.info(
+                "Progress: %s rally scenes, %s cameras (avg %.1f/scene)",
+                total_scenes,
+                total_cameras,
+                avg_cams,
+            )
 
     logger.info("Generation complete: %s scenes, %s cameras", total_scenes, total_cameras)
 
@@ -232,8 +201,7 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
     logger.info("=" * 60)
     logger.info("Dataset generation complete!")
     logger.info("Output: %s", output_dir)
-    logger.info("Mode: %s", mode.value)
-    logger.info("Total scenes: %s", total_scenes)
+    logger.info("Total rally scenes: %s", total_scenes)
     logger.info("Total cameras: %s", total_cameras)
     if total_scenes > 0:
         logger.info("Avg cameras/scene: %.2f", total_cameras / total_scenes)


### PR DESCRIPTION
## Summary

Complete integration of RALLY mode changes from PR #99 into scripts and visualization:
- Removes deprecated `GenerationMode` from `generate_dataset.py`
- Adds rally scene support to visualization renderers with backward compatibility
- Updates config files to use rally scene paths

## Background

PR #99 unified SHOT mode into RALLY mode, changing the metadata structure:
- OLD: `category`, `to_cell`, `t_net`, etc. at scene level
- NEW: These fields moved to per-shot in `shots[]` array

This broke:
1. `generate_dataset.py` - ImportError on `GenerationMode`
2. Visualization renderers - KeyError on `meta['category']`

## Changes

### Part 1: Fix generate_dataset.py
- Remove `GenerationMode` import and mode-related logic
- Simplify to rally-only generation
- Update docstring examples

### Part 2: Rally visualization support
- **Auto-detection**: Detect scene type via `'shots'` key (rally) vs `'category'` (legacy)
- **Title rendering**: Show rally info (length, end reason) for rally scenes
- **Event extraction**: Extract events from all shots with shot indices (S1 Bounce 1, S2 Net hit, etc.)
- **Shot boundaries**: New `SHOT_BOUNDARY` event type with cyan diamond markers
- **Scene info**: Enhanced printer with per-shot breakdown for rallies
- **Config update**: Default visualization uses `rally_000000.npz`

### Backward Compatibility
- Legacy SHOT scene files still work (auto-detected)
- No changes to dataset loading (training/inference unaffected)
- All existing functionality preserved

## Files Modified

1. `src/blcs/scripts/generate_dataset.py` - Rally-only generation
2. `src/utils/rendering/blcs_scene_renderer.py` - Rally scene support
3. `src/utils/rendering/ball_renderer.py` - SHOT_BOUNDARY event type
4. `src/blcs/configs/visualization/default.yaml` - Rally scene path

## Test plan

- [x] Script imports successfully without errors
- [x] Code changes complete with backward compatibility
- [ ] Generate rally scene dataset to test visualization
- [ ] Verify rally scene rendering shows correct titles and events
- [ ] Verify legacy shot scenes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)