### PR TITLE
Add two-step WASB annotation examples

### DIFF
--- a/src/tools/configs/annotate_wasb_clips.yaml
+++ b/src/tools/configs/annotate_wasb_clips.yaml
@@ -1,0 +1,19 @@
+# WASB clip annotation configuration
+# Usage: uv run python -m src.tools.annotate_wasb_clips ...
+
+# Base options
+sampling:
+  method: auto  # How to sample clips (auto/manual)
+  export_frames: true  # Export frames for annotation
+
+annotate:
+  clip_indices: null  # Null = annotate all clips from clip_manifest.json
+
+# Example: manual select only (lightweight selection)
+# sampling:
+#   method: manual
+#   export_frames: false
+#
+# Example: limited annotation
+# annotate:
+#   clip_indices: [1, 3]

--- a/src/wasb/README.md
+++ b/src/wasb/README.md
@@ -216,6 +216,18 @@ logit ヒートマップを TTA で生成し、逆変換で同一の `output_hea
 温度校正 → TTA 平均 → PoE 融合 → forward-backward 平滑化を行います。最終的な座標は
 平滑化後の分布から期待値/MAP/2次またはガウスフィットで復元します。
 
+## アノテーションの2ステップ運用例
+
+`clip_manifest.json` を基点に、手動選別 → 必要分だけアノテーションする流れの例です。
+
+**Step1: manual select only**
+- `sampling.method=manual` でプレビュークリップを人手で選別。
+- `sampling.export_frames=false` にして軽量に選別だけ行い、`clip_manifest.json` へ選別結果を記録。
+
+**Step2: annotate (auto-extract if needed)**
+- `annotate.clip_indices=[1,3]` などで対象クリップのみアノテーション。
+- `clip_manifest.json` を参照し、未抽出のフレームがあればこのステップで自動抽出（既存なら再利用）。
+
 ## 実行コマンド
 
 詳細は [docs/scripts/wasb/](../../../docs/scripts/wasb/) を参照。


### PR DESCRIPTION
### Motivation
- Provide a clear, lightweight two-step workflow for WASB annotation covering manual clip selection and targeted annotation. 
- Make it explicit when frames are extracted vs. reused based on `clip_manifest.json` to avoid redundant work. 
- Supply a simple, documented config template to make the two-step flow easy to run and customize.

### Description
- Updated `src/wasb/README.md` to add an "アノテーションの2ステップ運用例" section that documents: Step1 (manual select only) using `sampling.method=manual` and `sampling.export_frames=false`, and Step2 (annotate) using `annotate.clip_indices` with `clip_manifest.json` behavior described. 
- Added a new config template `src/tools/configs/annotate_wasb_clips.yaml` with default options and commented examples for `sampling.method: manual`, `sampling.export_frames: false`, and `annotate.clip_indices: [1, 3]`. 
- Kept examples lightweight and focused on clarifying when frames are auto-extracted versus reused from `clip_manifest.json`.

### Testing
- Ran `src.agents.scripts.pre_commit` via `uv --cache-dir agents_workspace/tmp_cache/uv_cache run --no-sync python -m src.agents.scripts.pre_commit`, which failed due to network errors when installing dependencies. 
- Ran a lightweight test invocation via `uv --cache-dir agents_workspace/tmp_cache/uv_cache run --no-sync python -m src.agents.scripts.test 'task.test_cmd=echo "No tests (docs-only)"'`, which also failed due to network dependency resolution errors. 
- No unit or integration tests were changed; this PR is documentation/config-only and committed after verifying file contents locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69689d347010832981889bec4cb8012b)