### PR TITLE
feat(plcs): add scene-level batch sampler

### DIFF
--- a/src/plcs/README.md
+++ b/src/plcs/README.md
@@ -236,6 +236,9 @@ uv run python -m src.plcs.scripts.visualize_multiview \
 | 単一カメラ可視化 | `visualize.yaml` | `visualization/default.yaml` |
 | マルチビュー可視化 | `visualize_multiview.yaml` | `visualization/multiview.yaml` |
 
+`data/frame.yaml` には `scene_batch_sampler` オプションがあり、`true` にすると
+バッチを同一シーンで構成してシーンキャッシュのヒット率を高めます。
+
 ### ロス設定ファイル
 
 ロス関数のウェイトは `configs/loss/` ディレクトリで管理されています：

--- a/src/plcs/configs/data/frame.yaml
+++ b/src/plcs/configs/data/frame.yaml
@@ -4,6 +4,7 @@ num_workers: 4
 val_split: 0.1
 test_split: 0.1
 camera_mode: random
+scene_batch_sampler: false
 
 mode: frame
 

--- a/src/plcs/data/__init__.py
+++ b/src/plcs/data/__init__.py
@@ -2,6 +2,7 @@
 
 from src.plcs.data.datamodule import PLCSDataModule, PLCSSequenceDataModule
 from src.plcs.data.dataset import SceneDataset
+from src.plcs.data.scene_batch_sampler import SceneBatchSampler
 from src.plcs.data.sequence_dataset import SceneSequenceDataset
 from src.plcs.generate_dataset.sampling.motion_sampler import (
     MotionSampler,
@@ -19,6 +20,7 @@ __all__ = [
     "MotionSequence",
     "PLCSDataModule",
     "PLCSSequenceDataModule",
+    "SceneBatchSampler",
     "SceneData",
     "SceneDataset",
     "SceneSequenceDataset",

--- a/src/plcs/data/datamodule.py
+++ b/src/plcs/data/datamodule.py
@@ -9,6 +9,7 @@ import pytorch_lightning as pl
 from torch.utils.data import DataLoader, random_split
 
 from src.plcs.data.dataset import SceneDataset
+from src.plcs.data.scene_batch_sampler import SceneBatchSampler
 from src.plcs.data.multiview_dataset import (
     MultiViewSceneDataset,
     MultiViewSequenceDataset,
@@ -45,6 +46,7 @@ class PLCSDataModule(pl.LightningDataModule):
         self.val_split = data_cfg.get("val_split", 0.1)
         self.test_split = data_cfg.get("test_split", 0.1)
         self.camera_mode = data_cfg.get("camera_mode", "random")
+        self.scene_batch_sampler = bool(data_cfg.get("scene_batch_sampler", False))
 
         self.train_dataset: SceneDataset | None = None
         self.val_dataset: SceneDataset | None = None
@@ -91,6 +93,20 @@ class PLCSDataModule(pl.LightningDataModule):
         """
         if self.train_dataset is None:
             raise RuntimeError("Call setup('fit') before train_dataloader()")
+
+        if self.scene_batch_sampler:
+            batch_sampler = SceneBatchSampler(
+                self.train_dataset,
+                batch_size=self.batch_size,
+                drop_last=True,
+                shuffle=True,
+            )
+            return DataLoader(
+                self.train_dataset,
+                batch_sampler=batch_sampler,
+                num_workers=self.num_workers,
+                pin_memory=True,
+            )
 
         return DataLoader(
             self.train_dataset,

--- a/src/plcs/data/scene_batch_sampler.py
+++ b/src/plcs/data/scene_batch_sampler.py
@@ -1,0 +1,130 @@
+"""Scene-aware batch sampler for PLCS datasets.
+
+This sampler ensures that each batch contains samples from a single scene,
+which improves cache locality when loading scene files.
+"""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from typing import Iterable
+
+import torch
+from torch.utils.data import BatchSampler, Dataset, Subset
+
+
+class SceneBatchSampler(BatchSampler):
+    """Batch sampler that groups samples by scene index.
+
+    Args:
+        dataset: Dataset or Subset with an "index" attribute whose first
+            element is scene_idx.
+        batch_size: Number of samples per batch.
+        drop_last: Whether to drop the last incomplete batch per scene.
+        shuffle: Whether to shuffle scenes and samples within each scene.
+        generator: Optional torch Generator for deterministic shuffling.
+    """
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        batch_size: int,
+        drop_last: bool = True,
+        shuffle: bool = True,
+        generator: torch.Generator | None = None,
+    ) -> None:
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.drop_last = drop_last
+        self.shuffle = shuffle
+        self.generator = generator
+
+        self._scene_to_indices = self._build_scene_index_map(dataset)
+
+    def __iter__(self) -> Iterable[list[int]]:
+        scene_ids = list(self._scene_to_indices.keys())
+        if self.shuffle:
+            scene_ids = self._shuffle_list(scene_ids)
+
+        for scene_id in scene_ids:
+            indices = list(self._scene_to_indices[scene_id])
+            if self.shuffle:
+                indices = self._shuffle_list(indices)
+
+            for start in range(0, len(indices), self.batch_size):
+                batch = indices[start : start + self.batch_size]
+                if len(batch) < self.batch_size and self.drop_last:
+                    continue
+                yield batch
+
+    def __len__(self) -> int:
+        total = 0
+        for indices in self._scene_to_indices.values():
+            num = len(indices)
+            if self.drop_last:
+                total += num // self.batch_size
+            else:
+                total += (num + self.batch_size - 1) // self.batch_size
+        return total
+
+    def _build_scene_index_map(self, dataset: Dataset) -> dict[int, list[int]]:
+        scene_to_indices: dict[int, list[int]] = defaultdict(list)
+
+        if isinstance(dataset, Subset):
+            base_dataset = dataset.dataset
+            subset_indices = list(dataset.indices)
+            for subset_pos, base_idx in enumerate(subset_indices):
+                scene_idx = self._extract_scene_idx(base_dataset, base_idx)
+                scene_to_indices[scene_idx].append(subset_pos)
+        else:
+            for idx in range(len(dataset)):
+                scene_idx = self._extract_scene_idx(dataset, idx)
+                scene_to_indices[scene_idx].append(idx)
+
+        return scene_to_indices
+
+    @staticmethod
+    def _extract_scene_idx(dataset: Dataset, idx: int) -> int:
+        if hasattr(dataset, "index"):
+            scene_idx = dataset.index[idx][0]
+            return int(scene_idx)
+        raise AttributeError("Dataset must expose an 'index' attribute")
+
+    def _shuffle_list(self, values: list[int]) -> list[int]:
+        if self.generator is None:
+            values = list(values)
+            random.shuffle(values)
+            return values
+
+        perm = torch.randperm(len(values), generator=self.generator).tolist()
+        return [values[i] for i in perm]
+
+
+if __name__ == "__main__":
+    class _DummyDataset(Dataset[torch.Tensor]):
+        def __init__(self) -> None:
+            self.index = [
+                (0, 0, 0),
+                (0, 1, 0),
+                (1, 0, 0),
+                (1, 1, 0),
+                (1, 2, 0),
+            ]
+
+        def __len__(self) -> int:
+            return len(self.index)
+
+        def __getitem__(self, idx: int) -> torch.Tensor:
+            return torch.tensor(self.index[idx], dtype=torch.int64)
+
+    dummy = _DummyDataset()
+    sampler = SceneBatchSampler(dummy, batch_size=2, drop_last=False, shuffle=False)
+    batches = list(sampler)
+    for batch in batches:
+        scene_ids = {dummy.index[i][0] for i in batch}
+        assert len(scene_ids) == 1
+    print("SceneBatchSampler smoke test passed.")


### PR DESCRIPTION
## Summary
- add SceneBatchSampler to keep batches within a single scene for PLCS frame data
- wire sampler into PLCSDataModule via data.scene_batch_sampler
- document new config toggle in frame data config and README

## Testing
- python3 src/plcs/data/scene_batch_sampler.py (failed: torch missing)