### PR TITLE
feat(plcs): add mixed scene batch sampler with configurable scenes pe…

### DIFF
--- a/src/plcs/configs/data/frame.yaml
+++ b/src/plcs/configs/data/frame.yaml
@@ -1,10 +1,11 @@
 scene_dir: data/plcs
-batch_size: 64
+batch_size: 256
 num_workers: 4
 val_split: 0.1
 test_split: 0.1
 camera_mode: random
-scene_batch_sampler: false
+scene_batch_sampler: true
+scenes_per_batch: 16
 
 mode: frame
 

--- a/src/plcs/data/__init__.py
+++ b/src/plcs/data/__init__.py
@@ -2,7 +2,10 @@
 
 from src.plcs.data.datamodule import PLCSDataModule, PLCSSequenceDataModule
 from src.plcs.data.dataset import SceneDataset
-from src.plcs.data.scene_batch_sampler import SceneBatchSampler
+from src.plcs.data.scene_batch_sampler import (
+    MixedSceneBatchSampler,
+    SceneBatchSampler,
+)
 from src.plcs.data.sequence_dataset import SceneSequenceDataset
 from src.plcs.generate_dataset.sampling.motion_sampler import (
     MotionSampler,
@@ -20,6 +23,7 @@ __all__ = [
     "MotionSequence",
     "PLCSDataModule",
     "PLCSSequenceDataModule",
+    "MixedSceneBatchSampler",
     "SceneBatchSampler",
     "SceneData",
     "SceneDataset",

--- a/src/plcs/data/datamodule.py
+++ b/src/plcs/data/datamodule.py
@@ -9,7 +9,10 @@ import pytorch_lightning as pl
 from torch.utils.data import DataLoader, random_split
 
 from src.plcs.data.dataset import SceneDataset
-from src.plcs.data.scene_batch_sampler import SceneBatchSampler
+from src.plcs.data.scene_batch_sampler import (
+    MixedSceneBatchSampler,
+    SceneBatchSampler,
+)
 from src.plcs.data.multiview_dataset import (
     MultiViewSceneDataset,
     MultiViewSequenceDataset,
@@ -47,6 +50,7 @@ class PLCSDataModule(pl.LightningDataModule):
         self.test_split = data_cfg.get("test_split", 0.1)
         self.camera_mode = data_cfg.get("camera_mode", "random")
         self.scene_batch_sampler = bool(data_cfg.get("scene_batch_sampler", False))
+        self.scenes_per_batch = data_cfg.get("scenes_per_batch", 1)
 
         self.train_dataset: SceneDataset | None = None
         self.val_dataset: SceneDataset | None = None
@@ -95,12 +99,21 @@ class PLCSDataModule(pl.LightningDataModule):
             raise RuntimeError("Call setup('fit') before train_dataloader()")
 
         if self.scene_batch_sampler:
-            batch_sampler = SceneBatchSampler(
-                self.train_dataset,
-                batch_size=self.batch_size,
-                drop_last=True,
-                shuffle=True,
-            )
+            if self.scenes_per_batch > 1:
+                batch_sampler = MixedSceneBatchSampler(
+                    self.train_dataset,
+                    batch_size=self.batch_size,
+                    scenes_per_batch=self.scenes_per_batch,
+                    drop_last=True,
+                    shuffle=True,
+                )
+            else:
+                batch_sampler = SceneBatchSampler(
+                    self.train_dataset,
+                    batch_size=self.batch_size,
+                    drop_last=True,
+                    shuffle=True,
+                )
             return DataLoader(
                 self.train_dataset,
                 batch_sampler=batch_sampler,
@@ -128,12 +141,21 @@ class PLCSDataModule(pl.LightningDataModule):
             raise RuntimeError("Call setup('fit') before val_dataloader()")
 
         if self.scene_batch_sampler:
-            batch_sampler = SceneBatchSampler(
-                self.val_dataset,
-                batch_size=self.batch_size,
-                drop_last=False,
-                shuffle=False,
-            )
+            if self.scenes_per_batch > 1:
+                batch_sampler = MixedSceneBatchSampler(
+                    self.val_dataset,
+                    batch_size=self.batch_size,
+                    scenes_per_batch=self.scenes_per_batch,
+                    drop_last=False,
+                    shuffle=False,
+                )
+            else:
+                batch_sampler = SceneBatchSampler(
+                    self.val_dataset,
+                    batch_size=self.batch_size,
+                    drop_last=False,
+                    shuffle=False,
+                )
             return DataLoader(
                 self.val_dataset,
                 batch_sampler=batch_sampler,
@@ -160,12 +182,21 @@ class PLCSDataModule(pl.LightningDataModule):
             raise RuntimeError("Call setup('test') before test_dataloader()")
 
         if self.scene_batch_sampler:
-            batch_sampler = SceneBatchSampler(
-                self.test_dataset,
-                batch_size=self.batch_size,
-                drop_last=False,
-                shuffle=False,
-            )
+            if self.scenes_per_batch > 1:
+                batch_sampler = MixedSceneBatchSampler(
+                    self.test_dataset,
+                    batch_size=self.batch_size,
+                    scenes_per_batch=self.scenes_per_batch,
+                    drop_last=False,
+                    shuffle=False,
+                )
+            else:
+                batch_sampler = SceneBatchSampler(
+                    self.test_dataset,
+                    batch_size=self.batch_size,
+                    drop_last=False,
+                    shuffle=False,
+                )
             return DataLoader(
                 self.test_dataset,
                 batch_sampler=batch_sampler,

--- a/src/plcs/data/scene_batch_sampler.py
+++ b/src/plcs/data/scene_batch_sampler.py
@@ -104,6 +104,125 @@ class SceneBatchSampler(BatchSampler):
         return [values[i] for i in perm]
 
 
+class MixedSceneBatchSampler(BatchSampler):
+    """Batch sampler that mixes multiple scenes in each batch.
+
+    Args:
+        dataset: Dataset or Subset with an "index" attribute whose first
+            element is scene_idx.
+        batch_size: Number of samples per batch.
+        scenes_per_batch: Number of distinct scenes to include in a batch.
+        drop_last: Whether to drop incomplete batches.
+        shuffle: Whether to shuffle scenes and samples within each scene.
+        generator: Optional torch Generator for deterministic shuffling.
+    """
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        batch_size: int,
+        scenes_per_batch: int,
+        drop_last: bool = True,
+        shuffle: bool = True,
+        generator: torch.Generator | None = None,
+    ) -> None:
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        if scenes_per_batch <= 0:
+            raise ValueError("scenes_per_batch must be positive")
+        if batch_size % scenes_per_batch != 0:
+            raise ValueError("batch_size must be divisible by scenes_per_batch")
+
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.scenes_per_batch = scenes_per_batch
+        self.drop_last = drop_last
+        self.shuffle = shuffle
+        self.generator = generator
+        self.chunk_size = batch_size // scenes_per_batch
+
+        self._scene_to_indices = self._build_scene_index_map(dataset)
+
+    def __iter__(self) -> Iterable[list[int]]:
+        scene_ids = list(self._scene_to_indices.keys())
+        if self.shuffle:
+            scene_ids = self._shuffle_list(scene_ids)
+
+        scene_to_chunks: dict[int, list[list[int]]] = {}
+        for scene_id in scene_ids:
+            indices = list(self._scene_to_indices[scene_id])
+            if self.shuffle:
+                indices = self._shuffle_list(indices)
+
+            chunks = [
+                indices[start : start + self.chunk_size]
+                for start in range(0, len(indices), self.chunk_size)
+            ]
+            if self.drop_last:
+                chunks = [chunk for chunk in chunks if len(chunk) == self.chunk_size]
+            scene_to_chunks[scene_id] = chunks
+
+        available = [scene_id for scene_id, chunks in scene_to_chunks.items() if chunks]
+        while len(available) >= self.scenes_per_batch:
+            if self.shuffle:
+                selected = self._shuffle_list(available)[: self.scenes_per_batch]
+            else:
+                selected = available[: self.scenes_per_batch]
+
+            batch: list[int] = []
+            for scene_id in selected:
+                batch.extend(scene_to_chunks[scene_id].pop(0))
+                if not scene_to_chunks[scene_id]:
+                    available.remove(scene_id)
+
+            if len(batch) == self.batch_size:
+                yield batch
+            elif not self.drop_last:
+                continue
+
+    def __len__(self) -> int:
+        total_chunks = 0
+        for indices in self._scene_to_indices.values():
+            num = len(indices)
+            if self.drop_last:
+                total_chunks += num // self.chunk_size
+            else:
+                total_chunks += (num + self.chunk_size - 1) // self.chunk_size
+        return total_chunks // self.scenes_per_batch
+
+    def _build_scene_index_map(self, dataset: Dataset) -> dict[int, list[int]]:
+        scene_to_indices: dict[int, list[int]] = defaultdict(list)
+
+        if isinstance(dataset, Subset):
+            base_dataset = dataset.dataset
+            subset_indices = list(dataset.indices)
+            for subset_pos, base_idx in enumerate(subset_indices):
+                scene_idx = self._extract_scene_idx(base_dataset, base_idx)
+                scene_to_indices[scene_idx].append(subset_pos)
+        else:
+            for idx in range(len(dataset)):
+                scene_idx = self._extract_scene_idx(dataset, idx)
+                scene_to_indices[scene_idx].append(idx)
+
+        return scene_to_indices
+
+    @staticmethod
+    def _extract_scene_idx(dataset: Dataset, idx: int) -> int:
+        if hasattr(dataset, "index"):
+            scene_idx = dataset.index[idx][0]
+            return int(scene_idx)
+        raise AttributeError("Dataset must expose an 'index' attribute")
+
+    def _shuffle_list(self, values: list[int]) -> list[int]:
+        if self.generator is None:
+            values = list(values)
+            random.shuffle(values)
+            return values
+
+        perm = torch.randperm(len(values), generator=self.generator).tolist()
+        return [values[i] for i in perm]
+
+
 if __name__ == "__main__":
     class _DummyDataset(Dataset[torch.Tensor]):
         def __init__(self) -> None:
@@ -128,3 +247,16 @@ if __name__ == "__main__":
         scene_ids = {dummy.index[i][0] for i in batch}
         assert len(scene_ids) == 1
     print("SceneBatchSampler smoke test passed.")
+
+    mixed_sampler = MixedSceneBatchSampler(
+        dummy,
+        batch_size=4,
+        scenes_per_batch=2,
+        drop_last=False,
+        shuffle=False,
+    )
+    mixed_batches = list(mixed_sampler)
+    for batch in mixed_batches:
+        scene_ids = {dummy.index[i][0] for i in batch}
+        assert len(scene_ids) == 2
+    print("MixedSceneBatchSampler smoke test passed.")


### PR DESCRIPTION
…r batch

Add MixedSceneBatchSampler to mix multiple scenes in each batch. Update datamodule to use mixed sampler when scenes_per_batch > 1.

- Add MixedSceneBatchSampler class with scenes_per_batch parameter
- Update PLCSDataModule to support scenes_per_batch config
- Use MixedSceneBatchSampler when scenes_per_batch > 1, else SceneBatchSampler
- Update frame.yaml config: batch_size 64→256, scene_batch_sampler true, scenes_per_batch 16