### PR TITLE
fix(training): align lightning log dirs

### DIFF
--- a/src/evnet_detection/scripts/train_3d.py
+++ b/src/evnet_detection/scripts/train_3d.py
@@ -22,6 +22,7 @@ import pytorch_lightning as pl
 import torch
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
+from pytorch_lightning.loggers import TensorBoardLogger
 
 from src.evnet_detection.data.datamodule import EventDetectionDataModule
 from src.evnet_detection.training.lightning_module import EventDetectionLightningModule
@@ -85,11 +86,13 @@ def run_training(cfg: DictConfig) -> None:
         return
 
     accelerator, devices = _select_devices(int(cfg.run.gpus))
+    tb_logger = TensorBoardLogger(save_dir=output_dir, name="logs")
     trainer = pl.Trainer(
         max_epochs=int(cfg.training.max_epochs),
         accelerator=accelerator,
         devices=devices,
         gradient_clip_val=float(cfg.training.gradient_clip_val),
+        logger=tb_logger,
         precision="16-mixed" if accelerator == "gpu" else 32,
         log_every_n_steps=50,
         deterministic=True,
@@ -104,4 +107,3 @@ def main(cfg: DictConfig) -> None:  # pragma: no cover - CLI entry point
 
 if __name__ == "__main__":
     main()
-

--- a/src/evnet_detection/scripts/train_uv.py
+++ b/src/evnet_detection/scripts/train_uv.py
@@ -22,6 +22,7 @@ import pytorch_lightning as pl
 import torch
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
+from pytorch_lightning.loggers import TensorBoardLogger
 
 from src.evnet_detection.data.datamodule import EventDetectionDataModule
 from src.evnet_detection.training.lightning_module import EventDetectionLightningModule
@@ -85,11 +86,13 @@ def run_training(cfg: DictConfig) -> None:
         return
 
     accelerator, devices = _select_devices(int(cfg.run.gpus))
+    tb_logger = TensorBoardLogger(save_dir=output_dir, name="logs")
     trainer = pl.Trainer(
         max_epochs=int(cfg.training.max_epochs),
         accelerator=accelerator,
         devices=devices,
         gradient_clip_val=float(cfg.training.gradient_clip_val),
+        logger=tb_logger,
         precision="16-mixed" if accelerator == "gpu" else 32,
         log_every_n_steps=50,
         deterministic=True,
@@ -104,4 +107,3 @@ def main(cfg: DictConfig) -> None:  # pragma: no cover - CLI entry point
 
 if __name__ == "__main__":
     main()
-

--- a/src/trajectory_completion/scripts/train.py
+++ b/src/trajectory_completion/scripts/train.py
@@ -19,6 +19,7 @@ import pytorch_lightning as pl
 import torch
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
+from pytorch_lightning.loggers import TensorBoardLogger
 
 from src.trajectory_completion.data.datamodule import TrajectoryCompletionDataModule
 from src.trajectory_completion.training.lightning_module import (
@@ -85,13 +86,14 @@ def run_training(cfg: DictConfig) -> None:
 
     train_cfg = cfg.get("training", {}) or {}
     accelerator, devices = _select_devices(int(cfg.run.gpus))
+    tb_logger = TensorBoardLogger(save_dir=output_dir, name="logs")
 
     trainer = pl.Trainer(
         max_epochs=int(train_cfg.get("max_epochs", 50)),
         accelerator=accelerator,
         devices=devices,
         gradient_clip_val=float(train_cfg.get("gradient_clip_val", 1.0)),
-        logger=False,
+        logger=tb_logger,
         enable_checkpointing=False,
         enable_progress_bar=True,
         fast_dev_run=bool(cfg.run.fast_dev_run),
@@ -111,4 +113,3 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover
 
 if __name__ == "__main__":
     raise SystemExit(main())
-


### PR DESCRIPTION
### Motivation
- Ensure training scripts for event detection and trajectory completion write Lightning logs into the configured `run.output_dir` (matching the BLCS script behavior) so logs and checkpoints are colocated.

### Description
- Added `from pytorch_lightning.loggers import TensorBoardLogger` and instantiate `tb_logger = TensorBoardLogger(save_dir=output_dir, name="logs")` in `src/evnet_detection/scripts/train_uv.py` and `src/evnet_detection/scripts/train_3d.py`.
- Added the same `TensorBoardLogger` instantiation and passed `logger=tb_logger` to `pl.Trainer` in `src/trajectory_completion/scripts/train.py`.
- Kept dry-run behavior unchanged (dry runs still disable external logging via `logger=False`).

### Testing
- No automated tests or CI were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f474eaf9083298ce5dc15c4372005)