### PR TITLE
feat(models): make MoE, YaRN and MLP settings configurable for event & completion models

### DIFF
--- a/src/evnet_detection/configs/model/traj3d_transformer.yaml
+++ b/src/evnet_detection/configs/model/traj3d_transformer.yaml
@@ -3,7 +3,21 @@ hidden_dim: 256
 num_layers: 6
 num_heads: 8
 dropout: 0.1
+mlp_inter_dim: null
+use_moe: false
+
+moe:
+  moe_inter_dim: 256
+  n_routed_experts: 64
+  n_shared_experts: 0
+  n_activated_experts: 6
+  n_expert_groups: 1
+  n_limited_groups: 1
+  score_func: softmax
+  route_scale: 1.0
+
+rope_theta: 10000.0
+yarn: null
 causal: false
 max_seq_len: 256
 num_events: 2  # [shot, bounce]
-

--- a/src/evnet_detection/configs/model/uv_transformer.yaml
+++ b/src/evnet_detection/configs/model/uv_transformer.yaml
@@ -3,7 +3,21 @@ hidden_dim: 256
 num_layers: 6
 num_heads: 8
 dropout: 0.1
+mlp_inter_dim: null
+use_moe: false
+
+moe:
+  moe_inter_dim: 256
+  n_routed_experts: 64
+  n_shared_experts: 0
+  n_activated_experts: 6
+  n_expert_groups: 1
+  n_limited_groups: 1
+  score_func: softmax
+  route_scale: 1.0
+
+rope_theta: 10000.0
+yarn: null
 causal: false
 max_seq_len: 256
 num_events: 2  # [shot, bounce]
-

--- a/src/evnet_detection/models/traj3d_event_model.py
+++ b/src/evnet_detection/models/traj3d_event_model.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 from torch import Tensor
 
 from src.common.models import (
+    MoEConfig,
     RMSNorm,
     TransformerBlock,
     TransformerBlockConfig,
@@ -36,6 +37,9 @@ class Traj3DEventModel(nn.Module):
         causal: bool = False,
         max_seq_len: int = 256,
         num_events: int = 2,
+        mlp_inter_dim: int | None = None,
+        use_moe: bool = False,
+        moe_config: MoEConfig | None = None,
     ) -> None:
         super().__init__()
         self.hidden_dim = int(hidden_dim)
@@ -47,6 +51,12 @@ class Traj3DEventModel(nn.Module):
             raise ValueError("hidden_dim must be divisible by num_heads.")
         head_dim = self.hidden_dim // int(num_heads)
         rope_dim = head_dim
+        mlp_inter_dim_value = (
+            int(mlp_inter_dim) if mlp_inter_dim is not None else int((8 * self.hidden_dim) / 3)
+        )
+
+        if use_moe and moe_config is None:
+            raise ValueError("use_moe=True requires moe_config.")
 
         self.embed = Ball3DTokenEmbedding(dim=self.hidden_dim, dropout=dropout)
         self.blocks = nn.ModuleList(
@@ -55,14 +65,14 @@ class Traj3DEventModel(nn.Module):
                     TransformerBlockConfig(
                         dim=self.hidden_dim,
                         n_heads=int(num_heads),
-                        mlp_inter_dim=int((8 * self.hidden_dim) / 3),
+                        mlp_inter_dim=mlp_inter_dim_value,
                         head_dim=head_dim,
                         rope_dim=rope_dim,
                         attn_dropout=dropout,
                         rope_base=float(rope_theta),
                         yarn=yarn,
-                        use_moe=False,
-                        moe_config=None,
+                        use_moe=bool(use_moe),
+                        moe_config=moe_config,
                     )
                 )
                 for _ in range(int(num_layers))
@@ -80,17 +90,62 @@ class Traj3DEventModel(nn.Module):
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
+    @staticmethod
+    def _parse_yarn_config(model_cfg: DictConfig) -> YaRNConfig | None:
+        yarn_cfg = model_cfg.get("yarn")
+        if yarn_cfg is None:
+            return None
+        return YaRNConfig(
+            original_seq_len=int(yarn_cfg.get("original_seq_len")),
+            rope_factor=float(yarn_cfg.get("rope_factor")),
+            beta_fast=int(yarn_cfg.get("beta_fast", 32)),
+            beta_slow=int(yarn_cfg.get("beta_slow", 1)),
+        )
+
+    @staticmethod
+    def _build_moe_config(model_cfg: DictConfig, *, dim: int, mlp_inter_dim: int) -> MoEConfig:
+        moe_cfg = model_cfg.get("moe") or model_cfg.get("moe_config")
+        if moe_cfg is None:
+            return MoEConfig(dim=dim, moe_inter_dim=mlp_inter_dim)
+        return MoEConfig(
+            dim=int(moe_cfg.get("dim", dim)),
+            moe_inter_dim=int(moe_cfg.get("moe_inter_dim", mlp_inter_dim)),
+            n_routed_experts=int(moe_cfg.get("n_routed_experts", 64)),
+            n_shared_experts=int(moe_cfg.get("n_shared_experts", 0)),
+            n_activated_experts=int(moe_cfg.get("n_activated_experts", 6)),
+            n_expert_groups=int(moe_cfg.get("n_expert_groups", 1)),
+            n_limited_groups=int(moe_cfg.get("n_limited_groups", 1)),
+            score_func=moe_cfg.get("score_func", "softmax"),
+            route_scale=float(moe_cfg.get("route_scale", 1.0)),
+        )
+
     @classmethod
     def from_config(cls, config: DictConfig) -> Traj3DEventModel:
         model_cfg = config.get("model", {}) or {}
+        hidden_dim = int(model_cfg.get("hidden_dim", 256))
+        mlp_inter_dim = model_cfg.get("mlp_inter_dim")
+        mlp_inter_dim_value = int(mlp_inter_dim) if mlp_inter_dim is not None else None
+        use_moe = bool(model_cfg.get("use_moe", False))
+        moe_config = None
+        if use_moe:
+            moe_config = cls._build_moe_config(
+                model_cfg,
+                dim=hidden_dim,
+                mlp_inter_dim=int(mlp_inter_dim_value or (8 * hidden_dim / 3)),
+            )
         return cls(
-            hidden_dim=int(model_cfg.get("hidden_dim", 256)),
+            hidden_dim=hidden_dim,
             num_layers=int(model_cfg.get("num_layers", 6)),
             num_heads=int(model_cfg.get("num_heads", 8)),
             dropout=float(model_cfg.get("dropout", 0.1)),
+            rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            yarn=cls._parse_yarn_config(model_cfg),
             causal=bool(model_cfg.get("causal", False)),
             max_seq_len=int(model_cfg.get("max_seq_len", 256)),
             num_events=int(model_cfg.get("num_events", 2)),
+            mlp_inter_dim=mlp_inter_dim_value,
+            use_moe=use_moe,
+            moe_config=moe_config,
         )
 
     def forward(self, ball_pos_world: Tensor, seq_len: Tensor | None = None) -> Tensor:

--- a/src/evnet_detection/models/uv_event_model.py
+++ b/src/evnet_detection/models/uv_event_model.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 from torch import Tensor
 
 from src.common.models import (
+    MoEConfig,
     RMSNorm,
     TransformerBlock,
     TransformerBlockConfig,
@@ -43,6 +44,9 @@ class UVEventModel(nn.Module):
         causal: bool = False,
         max_seq_len: int = 256,
         num_events: int = 2,
+        mlp_inter_dim: int | None = None,
+        use_moe: bool = False,
+        moe_config: MoEConfig | None = None,
     ) -> None:
         super().__init__()
         self.hidden_dim = int(hidden_dim)
@@ -55,6 +59,12 @@ class UVEventModel(nn.Module):
         head_dim = self.hidden_dim // int(num_heads)
         rope_dim = head_dim
         max_tokens = int(NUM_COURT_KP + self.max_seq_len)
+        mlp_inter_dim_value = (
+            int(mlp_inter_dim) if mlp_inter_dim is not None else int((8 * self.hidden_dim) / 3)
+        )
+
+        if use_moe and moe_config is None:
+            raise ValueError("use_moe=True requires moe_config.")
 
         self.court_embed = CourtTokenEmbedding(dim=self.hidden_dim, dropout=dropout)
         self.ball_embed = BallUVTokenEmbedding(dim=self.hidden_dim, dropout=dropout)
@@ -66,14 +76,14 @@ class UVEventModel(nn.Module):
                     TransformerBlockConfig(
                         dim=self.hidden_dim,
                         n_heads=int(num_heads),
-                        mlp_inter_dim=int((8 * self.hidden_dim) / 3),
+                        mlp_inter_dim=mlp_inter_dim_value,
                         head_dim=head_dim,
                         rope_dim=rope_dim,
                         attn_dropout=dropout,
                         rope_base=float(rope_theta),
                         yarn=yarn,
-                        use_moe=False,
-                        moe_config=None,
+                        use_moe=bool(use_moe),
+                        moe_config=moe_config,
                     )
                 )
                 for _ in range(int(num_layers))
@@ -91,17 +101,62 @@ class UVEventModel(nn.Module):
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
+    @staticmethod
+    def _parse_yarn_config(model_cfg: DictConfig) -> YaRNConfig | None:
+        yarn_cfg = model_cfg.get("yarn")
+        if yarn_cfg is None:
+            return None
+        return YaRNConfig(
+            original_seq_len=int(yarn_cfg.get("original_seq_len")),
+            rope_factor=float(yarn_cfg.get("rope_factor")),
+            beta_fast=int(yarn_cfg.get("beta_fast", 32)),
+            beta_slow=int(yarn_cfg.get("beta_slow", 1)),
+        )
+
+    @staticmethod
+    def _build_moe_config(model_cfg: DictConfig, *, dim: int, mlp_inter_dim: int) -> MoEConfig:
+        moe_cfg = model_cfg.get("moe") or model_cfg.get("moe_config")
+        if moe_cfg is None:
+            return MoEConfig(dim=dim, moe_inter_dim=mlp_inter_dim)
+        return MoEConfig(
+            dim=int(moe_cfg.get("dim", dim)),
+            moe_inter_dim=int(moe_cfg.get("moe_inter_dim", mlp_inter_dim)),
+            n_routed_experts=int(moe_cfg.get("n_routed_experts", 64)),
+            n_shared_experts=int(moe_cfg.get("n_shared_experts", 0)),
+            n_activated_experts=int(moe_cfg.get("n_activated_experts", 6)),
+            n_expert_groups=int(moe_cfg.get("n_expert_groups", 1)),
+            n_limited_groups=int(moe_cfg.get("n_limited_groups", 1)),
+            score_func=moe_cfg.get("score_func", "softmax"),
+            route_scale=float(moe_cfg.get("route_scale", 1.0)),
+        )
+
     @classmethod
     def from_config(cls, config: DictConfig) -> UVEventModel:
         model_cfg = config.get("model", {}) or {}
+        hidden_dim = int(model_cfg.get("hidden_dim", 256))
+        mlp_inter_dim = model_cfg.get("mlp_inter_dim")
+        mlp_inter_dim_value = int(mlp_inter_dim) if mlp_inter_dim is not None else None
+        use_moe = bool(model_cfg.get("use_moe", False))
+        moe_config = None
+        if use_moe:
+            moe_config = cls._build_moe_config(
+                model_cfg,
+                dim=hidden_dim,
+                mlp_inter_dim=int(mlp_inter_dim_value or (8 * hidden_dim / 3)),
+            )
         return cls(
-            hidden_dim=int(model_cfg.get("hidden_dim", 256)),
+            hidden_dim=hidden_dim,
             num_layers=int(model_cfg.get("num_layers", 6)),
             num_heads=int(model_cfg.get("num_heads", 8)),
             dropout=float(model_cfg.get("dropout", 0.1)),
+            rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            yarn=cls._parse_yarn_config(model_cfg),
             causal=bool(model_cfg.get("causal", False)),
             max_seq_len=int(model_cfg.get("max_seq_len", 256)),
             num_events=int(model_cfg.get("num_events", 2)),
+            mlp_inter_dim=mlp_inter_dim_value,
+            use_moe=use_moe,
+            moe_config=moe_config,
         )
 
     def forward(

--- a/src/trajectory_completion/configs/model/uv_transformer.yaml
+++ b/src/trajectory_completion/configs/model/uv_transformer.yaml
@@ -4,10 +4,21 @@ hidden_dim: 256
 num_layers: 6
 num_heads: 8
 dropout: 0.1
+mlp_inter_dim: null
+use_moe: false
+
+moe:
+  moe_inter_dim: 256
+  n_routed_experts: 64
+  n_shared_experts: 0
+  n_activated_experts: 6
+  n_expert_groups: 1
+  n_limited_groups: 1
+  score_func: softmax
+  route_scale: 1.0
 
 rope_theta: 10000.0
 yarn: null
 
 causal: false
 max_seq_len: ${data.max_seq_len}
-

--- a/src/trajectory_completion/models/uv_completion_model.py
+++ b/src/trajectory_completion/models/uv_completion_model.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 from torch import Tensor
 
 from src.common.models import (
+    MoEConfig,
     RMSNorm,
     TransformerBlock,
     TransformerBlockConfig,
@@ -42,6 +43,9 @@ class UVTrajectoryCompletionModel(nn.Module):
         yarn: YaRNConfig | None = None,
         causal: bool = False,
         max_seq_len: int = 256,
+        mlp_inter_dim: int | None = None,
+        use_moe: bool = False,
+        moe_config: MoEConfig | None = None,
     ) -> None:
         super().__init__()
         self.hidden_dim = int(hidden_dim)
@@ -53,26 +57,31 @@ class UVTrajectoryCompletionModel(nn.Module):
         head_dim = self.hidden_dim // int(num_heads)
         rope_dim = head_dim
         max_tokens = int(NUM_COURT_KP + self.max_seq_len)
+        mlp_inter_dim_value = (
+            int(mlp_inter_dim) if mlp_inter_dim is not None else int((8 * self.hidden_dim) / 3)
+        )
+
+        if use_moe and moe_config is None:
+            raise ValueError("use_moe=True requires moe_config.")
 
         self.court_embed = CourtKPUVTokenEmbedding(dim=self.hidden_dim, dropout=float(dropout))
         self.ball_embed = UVObsTokenEmbedding(dim=self.hidden_dim, dropout=float(dropout))
         self.type_embed = nn.Embedding(2, self.hidden_dim)
 
-        mlp_inter_dim = int((8 * self.hidden_dim) / 3)
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(
                     TransformerBlockConfig(
                         dim=self.hidden_dim,
                         n_heads=int(num_heads),
-                        mlp_inter_dim=mlp_inter_dim,
+                        mlp_inter_dim=mlp_inter_dim_value,
                         head_dim=head_dim,
                         rope_dim=rope_dim,
                         attn_dropout=float(dropout),
                         rope_base=float(rope_theta),
                         yarn=yarn,
-                        use_moe=False,
-                        moe_config=None,
+                        use_moe=bool(use_moe),
+                        moe_config=moe_config,
                     )
                 )
                 for _ in range(int(num_layers))
@@ -95,19 +104,62 @@ class UVTrajectoryCompletionModel(nn.Module):
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
+    @staticmethod
+    def _parse_yarn_config(model_cfg: DictConfig) -> YaRNConfig | None:
+        yarn_cfg = model_cfg.get("yarn")
+        if yarn_cfg is None:
+            return None
+        return YaRNConfig(
+            original_seq_len=int(yarn_cfg.get("original_seq_len")),
+            rope_factor=float(yarn_cfg.get("rope_factor")),
+            beta_fast=int(yarn_cfg.get("beta_fast", 32)),
+            beta_slow=int(yarn_cfg.get("beta_slow", 1)),
+        )
+
+    @staticmethod
+    def _build_moe_config(model_cfg: DictConfig, *, dim: int, mlp_inter_dim: int) -> MoEConfig:
+        moe_cfg = model_cfg.get("moe") or model_cfg.get("moe_config")
+        if moe_cfg is None:
+            return MoEConfig(dim=dim, moe_inter_dim=mlp_inter_dim)
+        return MoEConfig(
+            dim=int(moe_cfg.get("dim", dim)),
+            moe_inter_dim=int(moe_cfg.get("moe_inter_dim", mlp_inter_dim)),
+            n_routed_experts=int(moe_cfg.get("n_routed_experts", 64)),
+            n_shared_experts=int(moe_cfg.get("n_shared_experts", 0)),
+            n_activated_experts=int(moe_cfg.get("n_activated_experts", 6)),
+            n_expert_groups=int(moe_cfg.get("n_expert_groups", 1)),
+            n_limited_groups=int(moe_cfg.get("n_limited_groups", 1)),
+            score_func=moe_cfg.get("score_func", "softmax"),
+            route_scale=float(moe_cfg.get("route_scale", 1.0)),
+        )
+
     @classmethod
     def from_config(cls, config: DictConfig) -> UVTrajectoryCompletionModel:
         model_cfg = config.get("model", {}) or {}
         data_cfg = config.get("data", {}) or {}
+        hidden_dim = int(model_cfg.get("hidden_dim", 256))
+        mlp_inter_dim = model_cfg.get("mlp_inter_dim")
+        mlp_inter_dim_value = int(mlp_inter_dim) if mlp_inter_dim is not None else None
+        use_moe = bool(model_cfg.get("use_moe", False))
+        moe_config = None
+        if use_moe:
+            moe_config = cls._build_moe_config(
+                model_cfg,
+                dim=hidden_dim,
+                mlp_inter_dim=int(mlp_inter_dim_value or (8 * hidden_dim / 3)),
+            )
         return cls(
-            hidden_dim=int(model_cfg.get("hidden_dim", 256)),
+            hidden_dim=hidden_dim,
             num_layers=int(model_cfg.get("num_layers", 6)),
             num_heads=int(model_cfg.get("num_heads", 8)),
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
-            yarn=None,
+            yarn=cls._parse_yarn_config(model_cfg),
             causal=bool(model_cfg.get("causal", False)),
             max_seq_len=int(model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 256))),
+            mlp_inter_dim=mlp_inter_dim_value,
+            use_moe=use_moe,
+            moe_config=moe_config,
         )
 
     def forward(
@@ -205,4 +257,3 @@ if __name__ == "__main__":
     )
     assert out.shape == (2, 32, 2)
     print("trajectory_completion.model smoke ok")
-


### PR DESCRIPTION
### Motivation
- The Transformer blocks had `use_moe`/MoE hardcoded and several MLP/RoPE/YaRN parameters were not configurable, limiting experiments and tuning from configs.
- Allowing full configuration makes it possible to enable/parameterize MoE and YaRN and to control MLP sizes via YAML without code changes.

### Description
- Added `mlp_inter_dim`, `use_moe`, and `moe_config`/`MoEConfig` plumbing to `Traj3DEventModel`, `UVEventModel`, and `UVTrajectoryCompletionModel` constructors and `from_config` methods so these options can be driven by config files.
- Implemented `_parse_yarn_config` and `_build_moe_config` helpers to construct `YaRNConfig` and `MoEConfig` from Hydra/OMEGACONF-style dicts and validated `use_moe` requires a `moe_config`.
- Updated TransformerBlock instantiation to use the configurable `mlp_inter_dim` and `use_moe`/`moe_config` values instead of hardcoded values.
- Extended model YAMLs (`src/evnet_detection/configs/model/traj3d_transformer.yaml`, `src/evnet_detection/configs/model/uv_transformer.yaml`, `src/trajectory_completion/configs/model/uv_transformer.yaml`) to expose `mlp_inter_dim`, `use_moe`, `moe` subfields, and `rope_theta`/`yarn` entries for easy tuning.

### Testing
- Ran smoke tests for the modified modules with `python -m src.evnet_detection.models.traj3d_event_model` and it printed success (`3d model smoke ok`).
- Ran `python -m src.evnet_detection.models.uv_event_model` and it printed success (`uv model smoke ok`).
- Ran `python -m src.trajectory_completion.models.uv_completion_model` and it printed success (`trajectory_completion.model smoke ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f47da4c0c8329be49143e9ff22a6d)