### PR TITLE
Align MAE config with run schema

### DIFF
--- a/src/mae/README.md
+++ b/src/mae/README.md
@@ -84,6 +84,14 @@ training:
   learning_rate: 1.5e-4
   max_epochs: 400
   warmup_epochs: 40
+
+# Run
+run:
+  output_dir: outputs/mae
+  seed: 42
+  gpus: 1
+  fast_dev_run: false
+  dry_run: false
 ```
 
 ## Data Preparation

--- a/src/mae/configs/run/train.yaml
+++ b/src/mae/configs/run/train.yaml
@@ -1,0 +1,6 @@
+output_dir: outputs/mae
+seed: 42
+resume: null
+fast_dev_run: false
+dry_run: false
+gpus: 1

--- a/src/mae/configs/train.yaml
+++ b/src/mae/configs/train.yaml
@@ -12,10 +12,7 @@ defaults:
   - model: base
   - data: cached_batches
   - training: default
-  - optional override trainer: default
-
-# Random seed
-seed: 42
+  - run: train
 
 # Checkpoint configuration
 checkpoint:
@@ -39,15 +36,9 @@ logger:
   name: mae
   version: null
 
-# Trainer configuration
-trainer:
-  accelerator: auto
-  devices: auto
-  strategy: auto
-  precision: 16-mixed
-  gradient_clip_val: 1.0
-  accumulate_grad_batches: 1
-  log_every_n_steps: 50
-  val_check_interval: 1.0
-  enable_progress_bar: true
-  deterministic: false
+hydra:
+  run:
+    dir: ${run.output_dir}/${now:%Y-%m-%d_%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/mae/configs/training/default.yaml
+++ b/src/mae/configs/training/default.yaml
@@ -11,5 +11,15 @@ min_lr: 1.0e-6
 warmup_epochs: 40
 max_epochs: 400
 
+# Trainer settings
+precision: 16-mixed
+gradient_clip_val: 1.0
+accumulate_grad_batches: 1
+log_every_n_steps: 50
+val_check_interval: 1.0
+enable_progress_bar: true
+deterministic: false
+strategy: auto
+
 # Logging
 log_reconstruction_every_n_epochs: 10

--- a/src/mae/configs/training/fast.yaml
+++ b/src/mae/configs/training/fast.yaml
@@ -11,5 +11,15 @@ min_lr: 1.0e-6
 warmup_epochs: 10
 max_epochs: 100
 
+# Trainer settings
+precision: 16-mixed
+gradient_clip_val: 1.0
+accumulate_grad_batches: 1
+log_every_n_steps: 50
+val_check_interval: 1.0
+enable_progress_bar: true
+deterministic: false
+strategy: auto
+
 # Logging
 log_reconstruction_every_n_epochs: 5

--- a/src/mae/training/runner.py
+++ b/src/mae/training/runner.py
@@ -22,21 +22,13 @@ from src.mae.training.epoch_cache_callback import (
 class MAETrainingRunner(BaseTrainingRunner):
     """Training runner for MAE pre-training task.
 
-    MAE config uses top-level keys (seed, trainer, training) instead of
-    nested config.run structure. This runner overrides base methods to
-    adapt to MAE's config layout.
+    MAE config follows the shared `config.run.*` schema for runtime settings.
     """
 
     # ---- config access helpers ----
     def _get_seed(self, config: Any) -> int | None:
-        return config.get("seed", 42)
-
-    def _get_gpus(self, config: Any) -> int:
-        trainer_cfg = config.get("trainer", {})
-        devices = trainer_cfg.get("devices", "auto")
-        if devices == "auto" or devices is None:
-            return 1
-        return int(devices) if isinstance(devices, (int, str)) and str(devices).isdigit() else 1
+        run_cfg = config.get("run", {})
+        return run_cfg.get("seed", 42)
 
     def build_datamodule(self, config: Any) -> pl.LightningDataModule:
         return MAEDataModule.from_config(config)
@@ -90,6 +82,7 @@ class MAETrainingRunner(BaseTrainingRunner):
         )
         pp_cfg = PreprocessConfig(**(preprocess_dict or {}))
 
+        run_cfg = config.get("run", {})
         producer_cfg = CacheProducerConfig(
             cache_root=str(data_cfg.get("cache_root", "data/mae/cache")),
             video_dir=str(data_cfg.get("video_dir", "data/tennis/raw/videos")),
@@ -107,7 +100,7 @@ class MAETrainingRunner(BaseTrainingRunner):
             min_batch_size=int(data_cfg.get("min_batch_size", 1)),
             upsample_limit=float(data_cfg.get("upsample_limit", 1.0)),
             frame_sample_ratio=float(data_cfg.get("frame_sample_ratio", 1.0)),
-            seed=int(config.get("seed", 42)),
+            seed=int(run_cfg.get("seed", 42)),
             val_split=float(data_cfg.get("val_split", 0.1)),
             static_val=True,
             preprocess=pp_cfg,
@@ -117,19 +110,19 @@ class MAETrainingRunner(BaseTrainingRunner):
     def trainer_kwargs(
         self, config: Any, accelerator: str, devices: int
     ) -> dict[str, Any]:
-        trainer_cfg = config.get("trainer", {})
+        training_cfg = config.get("training", {})
         kwargs: dict[str, Any] = {
-            "precision": trainer_cfg.get(
+            "precision": training_cfg.get(
                 "precision", "16-mixed" if accelerator == "gpu" else 32
             ),
-            "accumulate_grad_batches": trainer_cfg.get("accumulate_grad_batches", 1),
-            "log_every_n_steps": trainer_cfg.get("log_every_n_steps", 50),
-            "val_check_interval": trainer_cfg.get("val_check_interval", 1.0),
-            "enable_progress_bar": trainer_cfg.get("enable_progress_bar", True),
-            "strategy": trainer_cfg.get("strategy", "auto"),
+            "accumulate_grad_batches": training_cfg.get("accumulate_grad_batches", 1),
+            "log_every_n_steps": training_cfg.get("log_every_n_steps", 50),
+            "val_check_interval": training_cfg.get("val_check_interval", 1.0),
+            "enable_progress_bar": training_cfg.get("enable_progress_bar", True),
+            "strategy": training_cfg.get("strategy", "auto"),
         }
         # MAE uses non-deterministic by default for performance
-        if not trainer_cfg.get("deterministic", False):
+        if not training_cfg.get("deterministic", False):
             kwargs["deterministic"] = False
         return kwargs
 
@@ -137,44 +130,22 @@ class MAETrainingRunner(BaseTrainingRunner):
         # MAE pre-training doesn't have a test phase
         return True
 
-    def prepare_output_dir(self, config: Any) -> Path:
-        # MAE uses Hydra-managed output directory (cwd)
-        return Path.cwd()
-
     def is_dry_run(self, config: Any) -> bool:
-        # MAE uses trainer.fast_dev_run for dry run behavior
-        trainer_cfg = config.get("trainer", {})
-        return bool(trainer_cfg.get("fast_dev_run", False))
+        # MAE uses run.fast_dev_run for dry run behavior
+        run_cfg = config.get("run", {})
+        return bool(run_cfg.get("fast_dev_run", False))
 
     def seed_everything(self, config: Any) -> None:
         seed = self._get_seed(config)
         if seed is not None:
             pl.seed_everything(int(seed), workers=True)
 
-    def select_devices(self, config: Any) -> tuple[str, int]:
-        trainer_cfg = config.get("trainer", {})
-        accelerator = str(trainer_cfg.get("accelerator", "auto"))
-        devices = trainer_cfg.get("devices", "auto")
-
-        if accelerator == "auto":
-            import torch
-            accelerator = "gpu" if torch.cuda.is_available() else "cpu"
-
-        if devices == "auto" or devices is None:
-            devices = 1
-        elif isinstance(devices, str) and devices.isdigit():
-            devices = int(devices)
-        elif not isinstance(devices, int):
-            devices = 1
-
-        return accelerator, devices
-
     def build_trainer(
         self, config: Any, callbacks: list[Any], logger: TensorBoardLogger
     ) -> pl.Trainer:
         """Build trainer with MAE-specific configuration."""
         accelerator, devices = self.select_devices(config)
-        trainer_cfg = config.get("trainer", {})
+        run_cfg = config.get("run", {})
         training_cfg = config.get("training", {})
 
         base_kwargs: dict[str, Any] = {
@@ -183,8 +154,8 @@ class MAETrainingRunner(BaseTrainingRunner):
             "devices": devices,
             "callbacks": callbacks,
             "logger": logger,
-            "gradient_clip_val": trainer_cfg.get("gradient_clip_val", 1.0),
-            "fast_dev_run": bool(trainer_cfg.get("fast_dev_run", False)),
+            "gradient_clip_val": training_cfg.get("gradient_clip_val", 1.0),
+            "fast_dev_run": bool(run_cfg.get("fast_dev_run", False)),
         }
 
         extra_kwargs = self.trainer_kwargs(config, accelerator, devices)


### PR DESCRIPTION
## Summary
- move MAE runtime settings to config.run.* and align runner access
- add run/train config and move trainer options into training presets
- update MAE README config example

## Testing
- python - <<"PY" ... hydra compose ... (manual config verification)

Closes #183