### PR TITLE
feat: annotation assist, homography fix, reset buttons

### DIFF
--- a/src/tools/annotation/README.md
+++ b/src/tools/annotation/README.md
@@ -9,8 +9,16 @@ Local end-to-end workflow for creating annotations from a single video under `da
 The repo already defines an optional dependency group `webui` (FastAPI + Uvicorn).
 
 ```bash
-uv run --group webui -m src.tools.annotation.backend.app --reload --port 8000
+uv run --group webui -m src.tools.annotation.backend.app --port 8000 \
+  --assist-checkpoint third_party/WASB-SBDT/pretrained/wasb_tennis_best.pth.tar \
+  --assist-device cpu
 ```
+
+Optional assist flags:
+- `--assist-model` (`wasb` / `hrcnet`)
+- `--assist-batch-size`
+- `--assist-score-threshold`
+- `--assist-max-disp`
 
 ## 3) Run frontend (Next.js)
 ```bash
@@ -28,6 +36,8 @@ NEXT_PUBLIC_ANNOTATION_BACKEND=http://127.0.0.1:8000 npm run dev
 ### Mode: `ball` (sequential clip)
 - Use `[` to mark clip start and `]` to mark clip end on the current frame, then press `Enter` to apply.
 - Click to place the ball point, drag to move, and release to auto-save.
+- Use **Run assist** to precompute WASB predictions. Assist points render in a different color and can be applied per-frame.
+- **Reset** clears the current frame annotation (falls back to assist if available).
 - Keys:
   - `←/→` (or `Shift+←/→`): prev/next frame (10 frames with Shift)
   - `S`: save current frame annotation
@@ -36,6 +46,8 @@ NEXT_PUBLIC_ANNOTATION_BACKEND=http://127.0.0.1:8000 npm run dev
 ### Mode: `court` (sparse frames)
 - Set `frame idx` to the frame you want to annotate. Only frames you save are exported.
 - Select a keypoint, click to place it. After placing, the UI auto-advances to the next unset keypoint.
+- Use **Homography fill** (>=4 manual ground points) to auto-place missing keypoints.
+- **Reset** clears the current frame annotation.
 - Keys:
   - `Tab` / `Shift+Tab`: next/prev keypoint
   - `N`: jump to next unset keypoint

--- a/src/tools/annotation/backend/app.py
+++ b/src/tools/annotation/backend/app.py
@@ -12,13 +12,26 @@ from pathlib import Path
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 
+from src.tools.annotation.backend.ball_assist import (
+    BallAssistConfig,
+    build_assist_meta,
+    run_ball_assist_for_clip,
+)
 from src.tools.annotation.backend.exporters import (
     CourtExportConfig,
     WasbExportConfig,
     export_court_keypoints,
     export_wasb_clip,
 )
+from src.tools.annotation.backend.homography import (
+    fill_court_keypoints_from_homography,
+)
 from src.tools.annotation.backend.models import (
+    BallAssistAll,
+    BallAssistRunRequest,
+    BallAssistRunResult,
+    BallAssistState,
+    BallAssistSummary,
     BallClipConfig,
     BallFrameAnnotation,
     CourtFrameAnnotation,
@@ -30,10 +43,23 @@ from src.tools.annotation.backend.video import VideoFrameProvider
 from src.utils.geometry.constants import COURT_KP_NAMES, NUM_COURT_KP
 
 
-def create_app(video_path: str | Path, output_root: str | Path) -> FastAPI:
+def create_app(
+    video_path: str | Path,
+    output_root: str | Path,
+    assist_cfg: BallAssistConfig | None = None,
+) -> FastAPI:
     """Create a FastAPI app instance."""
     provider = VideoFrameProvider(video_path)
     state = AnnotationState(StatePaths(Path(output_root)))
+    if assist_cfg is None:
+        assist_cfg = BallAssistConfig(
+            checkpoint_path=None,
+            model_type="wasb",
+            device="cpu",
+            batch_size=64,
+            score_threshold=0.5,
+            max_disp=300,
+        )
 
     app = FastAPI(title="tennis-lab annotation backend", version="0.1.0")
     app.add_middleware(
@@ -93,6 +119,120 @@ def create_app(video_path: str | Path, output_root: str | Path) -> FastAPI:
         state.save_ball_annotation(local_idx, ann)
         return ann
 
+    @app.delete("/api/ball/annotations/{local_idx}")
+    def delete_ball_annotation(local_idx: int) -> dict[str, bool]:
+        cfg = state.load_ball_clip_config()
+        if local_idx < 0 or local_idx >= cfg.clip_length:
+            raise HTTPException(status_code=400, detail="local_idx out of clip range")
+        state.delete_ball_annotation(local_idx)
+        return {"ok": True}
+
+    @app.get("/api/ball/annotated_frames")
+    def list_ball_frames() -> list[int]:
+        return state.list_ball_annotated_frames()
+
+    @app.get("/api/ball/assist/summary", response_model=BallAssistSummary)
+    def get_ball_assist_summary() -> BallAssistSummary:
+        assist_state = state.load_ball_assist_state()
+        if assist_state is None:
+            return BallAssistSummary(
+                available=False,
+                clip_matches_current=False,
+                clip=None,
+                meta=None,
+                count=0,
+            )
+        clip_cfg = state.load_ball_clip_config()
+        matches = (
+            assist_state.clip.start_frame == clip_cfg.start_frame
+            and assist_state.clip.clip_length == clip_cfg.clip_length
+        )
+        return BallAssistSummary(
+            available=True,
+            clip_matches_current=matches,
+            clip=assist_state.clip,
+            meta=assist_state.meta,
+            count=len(assist_state.annotations),
+        )
+
+    @app.get("/api/ball/assist/all", response_model=BallAssistAll)
+    def get_ball_assist_all() -> BallAssistAll:
+        assist_state = state.load_ball_assist_state()
+        if assist_state is None:
+            raise HTTPException(status_code=404, detail="assist not available")
+        clip_cfg = state.load_ball_clip_config()
+        if (
+            assist_state.clip.start_frame != clip_cfg.start_frame
+            or assist_state.clip.clip_length != clip_cfg.clip_length
+        ):
+            raise HTTPException(status_code=409, detail="assist clip mismatch")
+        return BallAssistAll(annotations=assist_state.annotations)
+
+    @app.get("/api/ball/assist/{local_idx}", response_model=BallFrameAnnotation)
+    def get_ball_assist_frame(local_idx: int) -> BallFrameAnnotation:
+        assist_state = state.load_ball_assist_state()
+        if assist_state is None:
+            raise HTTPException(status_code=404, detail="assist not available")
+        clip_cfg = state.load_ball_clip_config()
+        if (
+            assist_state.clip.start_frame != clip_cfg.start_frame
+            or assist_state.clip.clip_length != clip_cfg.clip_length
+        ):
+            raise HTTPException(status_code=409, detail="assist clip mismatch")
+        ann = assist_state.annotations.get(local_idx)
+        if ann is None:
+            raise HTTPException(status_code=404, detail="assist frame not found")
+        return ann
+
+    @app.post("/api/ball/assist/run", response_model=BallAssistRunResult)
+    def run_ball_assist(req: BallAssistRunRequest | None = None) -> BallAssistRunResult:
+        cfg = assist_cfg
+        if req is None:
+            req = BallAssistRunRequest()
+
+        merged = BallAssistConfig(
+            checkpoint_path=(
+                Path(req.checkpoint_path)
+                if req.checkpoint_path is not None
+                else cfg.checkpoint_path
+            ),
+            model_type=req.model_type or cfg.model_type,
+            device=req.device or cfg.device,
+            batch_size=req.batch_size or cfg.batch_size,
+            score_threshold=(
+                req.score_threshold if req.score_threshold is not None else cfg.score_threshold
+            ),
+            max_disp=req.max_disp or cfg.max_disp,
+        )
+
+        clip_cfg = state.load_ball_clip_config()
+        meta = provider.info
+        if clip_cfg.start_frame + clip_cfg.clip_length > meta.frame_count:
+            raise HTTPException(status_code=400, detail="clip exceeds video length")
+
+        try:
+            annotations = run_ball_assist_for_clip(
+                provider=provider,
+                clip_cfg=clip_cfg,
+                assist_cfg=merged,
+            )
+        except FileNotFoundError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        except Exception as e:  # pragma: no cover - runtime inference errors
+            raise HTTPException(status_code=500, detail=str(e)) from e
+
+        assist_state = BallAssistState(
+            clip=clip_cfg,
+            meta=build_assist_meta(merged),
+            annotations=annotations,
+        )
+        state.save_ball_assist_state(assist_state)
+        return BallAssistRunResult(
+            clip=clip_cfg,
+            meta=assist_state.meta,
+            count=len(annotations),
+        )
+
     @app.get("/api/court/kp_names")
     def get_court_kp_names() -> list[str]:
         return list(COURT_KP_NAMES)
@@ -113,6 +253,27 @@ def create_app(video_path: str | Path, output_root: str | Path) -> FastAPI:
         state.save_court_annotation(ann)
         return ann
 
+    @app.delete("/api/court/annotations/{frame_idx}")
+    def delete_court_annotation(frame_idx: int) -> dict[str, bool]:
+        if frame_idx < 0:
+            raise HTTPException(status_code=400, detail="frame_idx out of range")
+        state.delete_court_annotation(frame_idx)
+        return {"ok": True}
+
+    @app.post("/api/court/homography", response_model=CourtFrameAnnotation)
+    def run_court_homography(ann: CourtFrameAnnotation) -> CourtFrameAnnotation:
+        if len(ann.keypoints) != NUM_COURT_KP:
+            raise HTTPException(
+                status_code=400,
+                detail=f"keypoints must have length {NUM_COURT_KP}",
+            )
+        try:
+            filled = fill_court_keypoints_from_homography(ann)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        state.save_court_annotation(filled)
+        return filled
+
     @app.get("/api/court/annotated_frames")
     def list_court_frames() -> list[int]:
         return state.list_court_annotated_frames()
@@ -124,10 +285,36 @@ def create_app(video_path: str | Path, output_root: str | Path) -> FastAPI:
         if cfg.start_frame + cfg.clip_length > meta.frame_count:
             raise HTTPException(status_code=400, detail="clip exceeds video length")
 
+        assist_state = state.load_ball_assist_state()
+        assist_ok = False
+        if assist_state is not None:
+            assist_ok = (
+                assist_state.clip.start_frame == cfg.start_frame
+                and assist_state.clip.clip_length == cfg.clip_length
+            )
+
         annotations: dict[int, tuple[float, float, int, float]] = {}
         for local_idx in range(cfg.clip_length):
-            ann = state.load_ball_annotation(local_idx)
-            annotations[local_idx] = (ann.x_px, ann.y_px, int(ann.visibility), ann.score)
+            if state.has_ball_annotation(local_idx):
+                ann = state.load_ball_annotation(local_idx)
+                annotations[local_idx] = (
+                    ann.x_px,
+                    ann.y_px,
+                    int(ann.visibility),
+                    ann.score,
+                )
+                continue
+            if assist_ok and assist_state is not None:
+                assist = assist_state.annotations.get(local_idx)
+                if assist is not None:
+                    annotations[local_idx] = (
+                        assist.x_px,
+                        assist.y_px,
+                        int(assist.visibility),
+                        assist.score,
+                    )
+                    continue
+            annotations[local_idx] = (0.0, 0.0, 0, 0.0)
 
         out_dir = export_wasb_clip(
             provider=provider,
@@ -169,6 +356,44 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--host", type=str, default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--reload", action="store_true")
+    parser.add_argument(
+        "--assist-checkpoint",
+        type=str,
+        default=None,
+        help="Path to WASB checkpoint for assist mode",
+    )
+    parser.add_argument(
+        "--assist-model",
+        type=str,
+        choices=["wasb", "hrcnet"],
+        default="wasb",
+        help="Model type for assist mode",
+    )
+    parser.add_argument(
+        "--assist-device",
+        type=str,
+        choices=["cpu", "cuda"],
+        default="cpu",
+        help="Device for assist inference",
+    )
+    parser.add_argument(
+        "--assist-batch-size",
+        type=int,
+        default=64,
+        help="Batch size for assist inference",
+    )
+    parser.add_argument(
+        "--assist-score-threshold",
+        type=float,
+        default=0.5,
+        help="Score threshold for assist inference",
+    )
+    parser.add_argument(
+        "--assist-max-disp",
+        type=int,
+        default=300,
+        help="Max tracker displacement for assist inference",
+    )
     return parser.parse_args()
 
 
@@ -177,7 +402,17 @@ def main() -> int:
     args = _parse_args()
     import uvicorn
 
-    app = create_app(args.video, args.out)
+    assist_cfg = BallAssistConfig(
+        checkpoint_path=Path(args.assist_checkpoint)
+        if args.assist_checkpoint
+        else None,
+        model_type=args.assist_model,
+        device=args.assist_device,
+        batch_size=args.assist_batch_size,
+        score_threshold=args.assist_score_threshold,
+        max_disp=args.assist_max_disp,
+    )
+    app = create_app(args.video, args.out, assist_cfg=assist_cfg)
     uvicorn.run(app, host=args.host, port=args.port, reload=bool(args.reload))
     return 0
 

--- a/src/tools/annotation/backend/ball_assist.py
+++ b/src/tools/annotation/backend/ball_assist.py
@@ -1,0 +1,153 @@
+"""Ball assist inference helpers for the annotation tool."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from functools import lru_cache
+from pathlib import Path
+from typing import Literal
+
+import cv2
+import numpy as np
+
+from src.tools.annotation.backend.models import (
+    BallAssistMeta,
+    BallClipConfig,
+    BallFrameAnnotation,
+)
+from src.tools.annotation.backend.video import VideoFrameProvider
+
+
+@dataclass(frozen=True)
+class BallAssistConfig:
+    """Configuration for running WASB ball assist."""
+
+    checkpoint_path: Path | None
+    model_type: Literal["wasb", "hrcnet"]
+    device: Literal["cpu", "cuda"]
+    batch_size: int
+    score_threshold: float
+    max_disp: int
+
+
+def build_assist_meta(cfg: BallAssistConfig) -> BallAssistMeta:
+    """Build metadata for a ball assist run."""
+    return BallAssistMeta(
+        checkpoint_path=str(cfg.checkpoint_path) if cfg.checkpoint_path else None,
+        model_type=cfg.model_type,
+        device=cfg.device,
+        batch_size=cfg.batch_size,
+        score_threshold=cfg.score_threshold,
+        max_disp=cfg.max_disp,
+        created_at=datetime.now().isoformat(),
+    )
+
+
+@lru_cache(maxsize=2)
+def _load_predictor(
+    checkpoint_path: str,
+    model_type: str,
+    device: str,
+    score_threshold: float,
+    max_disp: int,
+):
+    """Load and cache a WASB-compatible predictor."""
+    from src.wasb.inference import HRCNetWASBPredictor, WASBPredictor
+
+    if model_type == "hrcnet":
+        predictor_cls = HRCNetWASBPredictor
+    else:
+        predictor_cls = WASBPredictor
+
+    return predictor_cls.load_from_checkpoint(
+        checkpoint_path,
+        device=device,
+        score_threshold=score_threshold,
+        max_disp=max_disp,
+    )
+
+
+def run_ball_assist_for_clip(
+    *,
+    provider: VideoFrameProvider,
+    clip_cfg: BallClipConfig,
+    assist_cfg: BallAssistConfig,
+) -> dict[int, BallFrameAnnotation]:
+    """Run batched WASB inference for the current clip.
+
+    Args:
+        provider: Video frame provider.
+        clip_cfg: Clip configuration.
+        assist_cfg: Assist inference configuration.
+
+    Returns:
+        Mapping of local_idx -> BallFrameAnnotation.
+
+    """
+    if assist_cfg.checkpoint_path is None:
+        raise FileNotFoundError("WASB checkpoint is not configured")
+
+    checkpoint = Path(assist_cfg.checkpoint_path)
+    if not checkpoint.exists():
+        raise FileNotFoundError(f"WASB checkpoint not found: {checkpoint}")
+
+    predictor = _load_predictor(
+        str(checkpoint),
+        assist_cfg.model_type,
+        assist_cfg.device,
+        assist_cfg.score_threshold,
+        assist_cfg.max_disp,
+    )
+    predictor.reset_tracker()
+
+    clip_length = int(clip_cfg.clip_length)
+    start_frame = int(clip_cfg.start_frame)
+    batch_size = max(1, int(assist_cfg.batch_size))
+
+    results: dict[int, BallFrameAnnotation] = {}
+
+    for offset in range(0, clip_length, batch_size):
+        end = min(clip_length, offset + batch_size)
+        frames: list[np.ndarray] = []
+        for local_idx in range(offset, end):
+            frame_bgr = provider.read_frame_bgr(start_frame + local_idx)
+            frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+            frames.append(frame_rgb)
+
+        if not frames:
+            continue
+
+        frames_arr = np.stack(frames, axis=0)
+        preds = predictor.predict(frames_arr)
+
+        frame_indices = preds["frame_indices"]
+        ball_xy_px = preds["ball_xy_px"]
+        visibility = preds["visibility"]
+        scores = preds["score"]
+
+        for i, local_idx in enumerate(frame_indices):
+            idx = int(local_idx)
+            if idx < 0 or idx >= clip_length:
+                continue
+            visible = bool(visibility[i])
+            x_px, y_px = float(ball_xy_px[i][0]), float(ball_xy_px[i][1])
+            score = float(scores[i])
+            if not visible:
+                results[idx] = BallFrameAnnotation(
+                    visibility=0,
+                    x_px=0.0,
+                    y_px=0.0,
+                    score=0.0,
+                    source="assist",
+                )
+                continue
+            results[idx] = BallFrameAnnotation(
+                visibility=1,
+                x_px=x_px,
+                y_px=y_px,
+                score=score,
+                source="assist",
+            )
+
+    return results

--- a/src/tools/annotation/backend/homography.py
+++ b/src/tools/annotation/backend/homography.py
@@ -1,0 +1,99 @@
+"""Court homography completion helpers."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import cv2
+import numpy as np
+
+from src.tools.annotation.backend.models import CourtFrameAnnotation, CourtKeypoint
+from src.utils.geometry.court import court_keypoints_3d
+
+_TOP_BASE_IDX: dict[int, int] = {
+    16: 15,  # left_post_top -> left_post_base
+    18: 17,  # right_post_top -> right_post_base
+    19: 14,  # center_strap_top -> net_center
+}
+
+
+def _world_xy_for_index(kp_xyz: np.ndarray, idx: int) -> np.ndarray:
+    if idx in _TOP_BASE_IDX:
+        return kp_xyz[_TOP_BASE_IDX[idx], :2]
+    return kp_xyz[idx, :2]
+
+
+def _collect_manual_ground_points(
+    ann: CourtFrameAnnotation,
+    kp_xyz: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    world_pts: list[list[float]] = []
+    image_pts: list[list[float]] = []
+    for i, kp in enumerate(ann.keypoints):
+        if kp.visibility == 0 or kp.source != "manual":
+            continue
+        if abs(float(kp_xyz[i, 2])) > 1e-6:
+            continue
+        world_pts.append([float(kp_xyz[i, 0]), float(kp_xyz[i, 1])])
+        image_pts.append([float(kp.x_px), float(kp.y_px)])
+    return np.array(world_pts, dtype=np.float32), np.array(image_pts, dtype=np.float32)
+
+
+def _project_points(h: np.ndarray, xy: Iterable[float]) -> tuple[float, float]:
+    pts = np.array([[list(xy)]], dtype=np.float32)
+    projected = cv2.perspectiveTransform(pts, h)
+    return float(projected[0, 0, 0]), float(projected[0, 0, 1])
+
+
+def fill_court_keypoints_from_homography(
+    ann: CourtFrameAnnotation,
+) -> CourtFrameAnnotation:
+    """Fill missing court keypoints using homography from manual ground points.
+
+    Args:
+        ann: Current court annotation (manual keypoints required).
+
+    Returns:
+        Updated annotation with homography-filled keypoints.
+
+    Raises:
+        ValueError: If not enough manual points or homography fails.
+
+    """
+    kp_xyz = court_keypoints_3d().numpy()
+    world_pts, image_pts = _collect_manual_ground_points(ann, kp_xyz)
+    if len(world_pts) < 4:
+        raise ValueError("need >=4 manual ground keypoints for homography")
+
+    h, _ = cv2.findHomography(world_pts, image_pts, method=0)
+    if h is None:
+        raise ValueError("failed to estimate homography")
+
+    next_keypoints: list[CourtKeypoint] = []
+    for i, kp in enumerate(ann.keypoints):
+        should_update = kp.visibility == 0 or kp.source == "homography"
+        if not should_update:
+            next_keypoints.append(kp)
+            continue
+
+        if i in _TOP_BASE_IDX:
+            base_idx = _TOP_BASE_IDX[i]
+            base_kp = ann.keypoints[base_idx]
+            if base_kp.visibility > 0:
+                x_px, y_px = float(base_kp.x_px), float(base_kp.y_px)
+            else:
+                xy_world = _world_xy_for_index(kp_xyz, i)
+                x_px, y_px = _project_points(h, xy_world)
+        else:
+            xy_world = _world_xy_for_index(kp_xyz, i)
+            x_px, y_px = _project_points(h, xy_world)
+        next_keypoints.append(
+            CourtKeypoint(
+                x_px=x_px,
+                y_px=y_px,
+                visibility=1,
+                source="homography",
+            )
+        )
+
+    return CourtFrameAnnotation(frame_idx=ann.frame_idx, keypoints=next_keypoints)

--- a/src/tools/annotation/backend/models.py
+++ b/src/tools/annotation/backend/models.py
@@ -40,6 +40,61 @@ class BallFrameAnnotation(BaseModel):
     source: Literal["manual", "assist", "unknown"] = "manual"
 
 
+class BallAssistMeta(BaseModel):
+    """Metadata for a cached ball assist run."""
+
+    checkpoint_path: str | None = None
+    model_type: Literal["wasb", "hrcnet"] = "wasb"
+    device: Literal["cpu", "cuda"] = "cpu"
+    batch_size: int = Field(default=64, ge=1)
+    score_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
+    max_disp: int = Field(default=300, ge=1)
+    created_at: str = ""
+
+
+class BallAssistState(BaseModel):
+    """Cached ball assist annotations for a clip."""
+
+    clip: BallClipConfig
+    meta: BallAssistMeta
+    annotations: dict[int, BallFrameAnnotation] = Field(default_factory=dict)
+
+
+class BallAssistSummary(BaseModel):
+    """Summary of cached ball assist availability."""
+
+    available: bool
+    clip_matches_current: bool
+    clip: BallClipConfig | None = None
+    meta: BallAssistMeta | None = None
+    count: int = 0
+
+
+class BallAssistRunRequest(BaseModel):
+    """Optional overrides when running ball assist."""
+
+    checkpoint_path: str | None = None
+    model_type: Literal["wasb", "hrcnet"] | None = None
+    device: Literal["cpu", "cuda"] | None = None
+    batch_size: int | None = Field(default=None, ge=1)
+    score_threshold: float | None = Field(default=None, ge=0.0, le=1.0)
+    max_disp: int | None = Field(default=None, ge=1)
+
+
+class BallAssistRunResult(BaseModel):
+    """Result of a ball assist run."""
+
+    clip: BallClipConfig
+    meta: BallAssistMeta
+    count: int
+
+
+class BallAssistAll(BaseModel):
+    """Container for all cached assist annotations."""
+
+    annotations: dict[int, BallFrameAnnotation]
+
+
 class CourtKeypoint(BaseModel):
     """Court keypoint annotation in pixel coordinates."""
 

--- a/src/tools/annotation/backend/state.py
+++ b/src/tools/annotation/backend/state.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from src.tools.annotation.backend.models import (
+    BallAssistState,
     BallClipConfig,
     BallFrameAnnotation,
     CourtFrameAnnotation,
@@ -50,6 +51,10 @@ class StatePaths:
     def court_state_path(self) -> Path:
         return self.state_dir / "court.json"
 
+    @property
+    def ball_assist_path(self) -> Path:
+        return self.state_dir / "ball_assist.json"
+
 
 class AnnotationState:
     """Loads/saves ball and court annotations."""
@@ -84,6 +89,54 @@ class AnnotationState:
         annotations = data.setdefault("annotations", {})
         annotations[str(local_idx)] = ann.model_dump()
         _atomic_write_json(self._paths.ball_state_path, data)
+
+    def delete_ball_annotation(self, local_idx: int) -> None:
+        data = _read_json(self._paths.ball_state_path)
+        annotations = data.get("annotations") or {}
+        if str(local_idx) in annotations:
+            annotations.pop(str(local_idx), None)
+            data["annotations"] = annotations
+            _atomic_write_json(self._paths.ball_state_path, data)
+
+    def has_ball_annotation(self, local_idx: int) -> bool:
+        data = _read_json(self._paths.ball_state_path)
+        annotations = data.get("annotations") or {}
+        return str(local_idx) in annotations
+
+    def list_ball_annotated_frames(self) -> list[int]:
+        data = _read_json(self._paths.ball_state_path)
+        annotations = data.get("annotations") or {}
+        out: list[int] = []
+        for k in annotations.keys():
+            try:
+                out.append(int(k))
+            except ValueError:
+                continue
+        return sorted(out)
+
+    def load_ball_assist_state(self) -> BallAssistState | None:
+        data = _read_json(self._paths.ball_assist_path)
+        if not data:
+            return None
+        try:
+            return BallAssistState.model_validate(data)
+        except Exception:
+            return None
+
+    def save_ball_assist_state(self, state: BallAssistState) -> None:
+        _atomic_write_json(self._paths.ball_assist_path, state.model_dump())
+
+    def load_ball_assist_annotation(self, local_idx: int) -> BallFrameAnnotation | None:
+        data = _read_json(self._paths.ball_assist_path)
+        if not data:
+            return None
+        ann = (data.get("annotations") or {}).get(str(local_idx))
+        if not ann:
+            return None
+        try:
+            return BallFrameAnnotation.model_validate(ann)
+        except Exception:
+            return None
 
     def list_court_annotated_frames(self) -> list[int]:
         data = _read_json(self._paths.court_state_path)
@@ -125,4 +178,12 @@ class AnnotationState:
         annotations = data.setdefault("annotations", {})
         annotations[str(ann.frame_idx)] = ann.model_dump()
         _atomic_write_json(self._paths.court_state_path, data)
+
+    def delete_court_annotation(self, frame_idx: int) -> None:
+        data = _read_json(self._paths.court_state_path)
+        annotations = data.get("annotations") or {}
+        if str(frame_idx) in annotations:
+            annotations.pop(str(frame_idx), None)
+            data["annotations"] = annotations
+            _atomic_write_json(self._paths.court_state_path, data)
 

--- a/src/tools/annotation/frontend/app/components/BallPanel.tsx
+++ b/src/tools/annotation/frontend/app/components/BallPanel.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import React from "react";
+
+import type {
+  BallAssistSummary,
+  BallClipConfig,
+  BallFrameAnnotation,
+  VideoMeta
+} from "../shared/types";
+import { clamp, formatAssistMetaSummary } from "../shared/utils";
+
+type BallPanelProps = {
+  meta: VideoMeta | null;
+  ballCfg: BallClipConfig;
+  ballLocalIdx: number;
+  ballClipMarkStart: number | null;
+  ballClipMarkEnd: number | null;
+  assistSummary: BallAssistSummary | null;
+  assistLoading: boolean;
+  assistAnn: BallFrameAnnotation | null;
+  manualCount: number | null;
+  onBallCfgChange: (cfg: BallClipConfig) => void;
+  onSetClip: () => void;
+  onMarkStart: () => void;
+  onMarkEnd: () => void;
+  onApplyClipMarks: () => void;
+  onBallLocalIdxChange: (idx: number) => void;
+  onSaveBall: () => void;
+  onResetBall: () => void;
+  onExportBall: () => void;
+  onRunAssist: () => void;
+  onApplyAssist: () => void;
+};
+
+export default function BallPanel({
+  meta,
+  ballCfg,
+  ballLocalIdx,
+  ballClipMarkStart,
+  ballClipMarkEnd,
+  assistSummary,
+  assistLoading,
+  assistAnn,
+  manualCount,
+  onBallCfgChange,
+  onSetClip,
+  onMarkStart,
+  onMarkEnd,
+  onApplyClipMarks,
+  onBallLocalIdxChange,
+  onSaveBall,
+  onResetBall,
+  onExportBall,
+  onRunAssist,
+  onApplyAssist
+}: BallPanelProps) {
+  const assistAvailable = Boolean(
+    assistSummary && assistSummary.available && assistSummary.clip_matches_current
+  );
+  const assistCount = assistSummary?.count ?? 0;
+  const manualText =
+    manualCount === null
+      ? "manual: —"
+      : `manual: ${manualCount}/${ballCfg.clip_length}`;
+
+  return (
+    <>
+      <div className="row">
+        <label>clip start</label>
+        <input
+          type="number"
+          value={ballCfg.start_frame}
+          onChange={(e) =>
+            onBallCfgChange({
+              ...ballCfg,
+              start_frame: Number(e.target.value)
+            })
+          }
+        />
+        <label>clip length</label>
+        <input
+          type="number"
+          value={ballCfg.clip_length}
+          onChange={(e) =>
+            onBallCfgChange({
+              ...ballCfg,
+              clip_length: Number(e.target.value)
+            })
+          }
+        />
+        <button className="primary" onClick={onSetClip}>
+          Set clip
+        </button>
+      </div>
+
+      <div className="row">
+        <button onClick={onMarkStart}>Mark start [</button>
+        <button onClick={onMarkEnd}>Mark end ]</button>
+        <div className="small">
+          marked: {ballClipMarkStart ?? "—"} .. {ballClipMarkEnd ?? "—"}
+        </div>
+        <button className="primary" onClick={onApplyClipMarks}>
+          Apply (Enter)
+        </button>
+      </div>
+
+      <div className="row">
+        <label>local idx</label>
+        <input
+          type="number"
+          value={ballLocalIdx}
+          onChange={(e) => {
+            const v = Number(e.target.value);
+            onBallLocalIdxChange(
+              clamp(v, 0, Math.max(0, ballCfg.clip_length - 1))
+            );
+          }}
+        />
+        <button className="primary" onClick={onSaveBall}>
+          Save
+        </button>
+        <button onClick={onResetBall}>Reset</button>
+        <button onClick={onExportBall}>Export WASB</button>
+      </div>
+
+      <div className="row">
+        <button className="primary" onClick={onRunAssist} disabled={assistLoading}>
+          {assistLoading ? "Running assist..." : "Run assist"}
+        </button>
+        <button
+          onClick={onApplyAssist}
+          disabled={!assistAvailable || !assistAnn}
+        >
+          Apply assist (current)
+        </button>
+      </div>
+
+      <div className="row">
+        <div className={`badge ${assistAvailable ? "ok" : "warn"}`}>
+          assist: {assistAvailable ? "ready" : "not ready"}
+        </div>
+        <div className="small">
+          assist frames: {assistCount}/{ballCfg.clip_length}
+        </div>
+      </div>
+      <div className="row">
+        <div className="small">{manualText}</div>
+      </div>
+      <div className="row">
+        <div className="small">{formatAssistMetaSummary(assistSummary?.meta ?? null)}</div>
+      </div>
+
+      <div className="row">
+        <div className="small">
+          click to place; drag to move; auto-save on mouse up
+        </div>
+      </div>
+      <div className="row">
+        <div className="small">
+          keys: [ ] mark clip, Enter apply, S save, E export, ←/→ navigate
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/tools/annotation/frontend/app/components/CanvasStage.tsx
+++ b/src/tools/annotation/frontend/app/components/CanvasStage.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef } from "react";
+
+import { apiBase } from "../shared/api";
+import { clamp } from "../shared/utils";
+import type {
+  BallFrameAnnotation,
+  CourtFrameAnnotation,
+  VideoMeta
+} from "../shared/types";
+
+type CanvasStageProps = {
+  meta: VideoMeta | null;
+  mode: "ball" | "court";
+  globalFrameIdx: number;
+  ballAnn: BallFrameAnnotation;
+  ballAssistAnn: BallFrameAnnotation | null;
+  courtAnn: CourtFrameAnnotation | null;
+  activeKp: number;
+  isFrameLoading: boolean;
+  resetCacheToken: number;
+  onBallAnnChange: (ann: BallFrameAnnotation) => void;
+  onCourtAnnChange: (ann: CourtFrameAnnotation) => void;
+  onActiveKpChange: (idx: number) => void;
+  onBallSave: () => Promise<void>;
+  onCourtSave: (ann: CourtFrameAnnotation) => Promise<void>;
+  onFrameLoadingChange: (loading: boolean) => void;
+  onStatus: (msg: string) => void;
+};
+
+function nextUnsetKpIndex(
+  ann: CourtFrameAnnotation,
+  fromIdx: number
+): number | null {
+  for (let i = fromIdx + 1; i < ann.keypoints.length; i++) {
+    if (ann.keypoints[i].visibility === 0) return i;
+  }
+  for (let i = 0; i <= fromIdx; i++) {
+    if (ann.keypoints[i].visibility === 0) return i;
+  }
+  return null;
+}
+
+function findNearestCourtKp(
+  x: number,
+  y: number,
+  ann: CourtFrameAnnotation,
+  radiusPx: number
+): number {
+  let best = -1;
+  let bestD2 = radiusPx * radiusPx;
+  for (let i = 0; i < ann.keypoints.length; i++) {
+    const kp = ann.keypoints[i];
+    if (kp.visibility === 0) continue;
+    const dx = kp.x_px - x;
+    const dy = kp.y_px - y;
+    const d2 = dx * dx + dy * dy;
+    if (d2 <= bestD2) {
+      bestD2 = d2;
+      best = i;
+    }
+  }
+  return best;
+}
+
+function courtColor(source: string, isActive: boolean): string {
+  if (isActive) return "#FFB020";
+  if (source === "homography") return "#A855F7";
+  if (source === "assist") return "#60A5FA";
+  return "#22C55E";
+}
+
+export default function CanvasStage({
+  meta,
+  mode,
+  globalFrameIdx,
+  ballAnn,
+  ballAssistAnn,
+  courtAnn,
+  activeKp,
+  isFrameLoading,
+  resetCacheToken,
+  onBallAnnChange,
+  onCourtAnnChange,
+  onActiveKpChange,
+  onBallSave,
+  onCourtSave,
+  onFrameLoadingChange,
+  onStatus
+}: CanvasStageProps) {
+  const frameCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const overlayCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const renderTokenRef = useRef<number>(0);
+  const frameCacheRef = useRef<Map<number, HTMLImageElement>>(new Map());
+  const frameLoadRef = useRef<Map<number, Promise<HTMLImageElement>>>(new Map());
+  const preloadGenRef = useRef<number>(0);
+  const dragRef = useRef<{
+    kind: "ball" | "court" | null;
+    kpIndex: number;
+  }>({ kind: null, kpIndex: -1 });
+
+  const frameUrl = useMemo(() => {
+    return (idx: number) => `${apiBase()}/api/frame/${idx}.jpg`;
+  }, []);
+
+  useEffect(() => {
+    frameCacheRef.current.clear();
+    frameLoadRef.current.clear();
+    preloadGenRef.current += 1;
+  }, [resetCacheToken]);
+
+  useEffect(() => {
+    if (!meta) return;
+    const frameCanvas = frameCanvasRef.current;
+    const overlayCanvas = overlayCanvasRef.current;
+    if (frameCanvas) {
+      frameCanvas.width = meta.width;
+      frameCanvas.height = meta.height;
+    }
+    if (overlayCanvas) {
+      overlayCanvas.width = meta.width;
+      overlayCanvas.height = meta.height;
+    }
+  }, [meta]);
+
+  function getCachedFrame(idx: number): HTMLImageElement | null {
+    const cached = frameCacheRef.current.get(idx);
+    if (cached && cached.complete && cached.naturalWidth > 0) return cached;
+    return null;
+  }
+
+  function preloadFrame(idx: number): Promise<HTMLImageElement> {
+    const cached = getCachedFrame(idx);
+    if (cached) return Promise.resolve(cached);
+    const inflight = frameLoadRef.current.get(idx);
+    if (inflight) return inflight;
+
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    const promise = new Promise<HTMLImageElement>((resolve, reject) => {
+      img.onload = () => {
+        frameCacheRef.current.set(idx, img);
+        frameLoadRef.current.delete(idx);
+        resolve(img);
+      };
+      img.onerror = () => {
+        frameLoadRef.current.delete(idx);
+        reject(new Error(`failed to load frame ${idx}`));
+      };
+    });
+    frameLoadRef.current.set(idx, promise);
+    img.src = frameUrl(idx);
+    return promise;
+  }
+
+  function pruneFrameCache(centerIdx: number, maxSize: number) {
+    const cache = frameCacheRef.current;
+    if (cache.size <= maxSize) return;
+    const entries = Array.from(cache.keys());
+    entries.sort((a, b) => Math.abs(b - centerIdx) - Math.abs(a - centerIdx));
+    const toRemove = entries.slice(0, Math.max(0, entries.length - maxSize));
+    for (const idx of toRemove) cache.delete(idx);
+  }
+
+  function preloadRange(centerIdx: number, radius: number, maxSize: number) {
+    const gen = ++preloadGenRef.current;
+    const indices: number[] = [centerIdx];
+    for (let i = 1; i <= radius; i++) {
+      indices.push(centerIdx + i, centerIdx - i);
+    }
+    for (const idx of indices) {
+      if (!meta) return;
+      if (idx < 0 || idx >= meta.frame_count) continue;
+      if (getCachedFrame(idx)) continue;
+      void preloadFrame(idx).catch(() => {
+        if (gen !== preloadGenRef.current) return;
+      });
+    }
+    pruneFrameCache(centerIdx, maxSize);
+  }
+
+  useEffect(() => {
+    const frameCanvas = frameCanvasRef.current;
+    if (!frameCanvas || !meta) return;
+
+    const token = ++renderTokenRef.current;
+    let canceled = false;
+    const ctx = frameCanvas.getContext("2d");
+    if (!ctx) return;
+    const cached = getCachedFrame(globalFrameIdx);
+    if (cached) {
+      ctx.clearRect(0, 0, frameCanvas.width, frameCanvas.height);
+      ctx.drawImage(cached, 0, 0, frameCanvas.width, frameCanvas.height);
+      onFrameLoadingChange(false);
+    } else {
+      onFrameLoadingChange(true);
+      void preloadFrame(globalFrameIdx)
+        .then((img) => {
+          if (canceled) return;
+          if (token !== renderTokenRef.current) return;
+          ctx.clearRect(0, 0, frameCanvas.width, frameCanvas.height);
+          ctx.drawImage(img, 0, 0, frameCanvas.width, frameCanvas.height);
+          onFrameLoadingChange(false);
+        })
+        .catch(() => {
+          if (canceled) return;
+          if (token !== renderTokenRef.current) return;
+          onFrameLoadingChange(false);
+          onStatus("failed to load frame image (check backend / video / frame idx)");
+        });
+    }
+
+    preloadRange(globalFrameIdx, 6, 48);
+
+    return () => {
+      canceled = true;
+    };
+  }, [meta, globalFrameIdx, onFrameLoadingChange, onStatus]);
+
+  useEffect(() => {
+    const overlayCanvas = overlayCanvasRef.current;
+    if (!overlayCanvas || !meta) return;
+    const ctx = overlayCanvas.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height);
+
+    if (mode === "ball") {
+      if (ballAssistAnn && ballAssistAnn.visibility > 0) {
+        ctx.strokeStyle = "#A855F7";
+        ctx.lineWidth = 2;
+        ctx.setLineDash([4, 4]);
+        ctx.beginPath();
+        ctx.arc(ballAssistAnn.x_px, ballAssistAnn.y_px, 7, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.setLineDash([]);
+      }
+      if (ballAnn.visibility > 0) {
+        ctx.fillStyle = "#00E5FF";
+        ctx.strokeStyle = "#001018";
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(ballAnn.x_px, ballAnn.y_px, 8, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+      }
+      return;
+    }
+
+    if (mode === "court" && courtAnn) {
+      for (let i = 0; i < courtAnn.keypoints.length; i++) {
+        const kp = courtAnn.keypoints[i];
+        if (kp.visibility === 0) continue;
+        ctx.fillStyle = courtColor(kp.source, i === activeKp);
+        ctx.strokeStyle = "#111827";
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(kp.x_px, kp.y_px, 6, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+      }
+    }
+  }, [meta, mode, globalFrameIdx, ballAnn, ballAssistAnn, courtAnn, activeKp]);
+
+  function toCanvasXY(e: React.MouseEvent<HTMLCanvasElement>): {
+    x: number;
+    y: number;
+  } {
+    const canvas = e.currentTarget;
+    const rect = canvas.getBoundingClientRect();
+    const x = (e.clientX - rect.left) * (canvas.width / rect.width);
+    const y = (e.clientY - rect.top) * (canvas.height / rect.height);
+    return { x, y };
+  }
+
+  return (
+    <div className="canvasWrap">
+      <div
+        className="canvasStage"
+        style={{
+          aspectRatio: meta ? `${meta.width} / ${meta.height}` : "16 / 9"
+        }}
+      >
+        <div className={`loadingBadge ${isFrameLoading ? "show" : ""}`}>
+          Loading...
+        </div>
+        <canvas ref={frameCanvasRef} className="frameCanvas" />
+        <canvas
+          ref={overlayCanvasRef}
+          className="overlayCanvas"
+          onMouseDown={(e) => {
+            if (!meta) return;
+            const { x, y } = toCanvasXY(e);
+            if (mode === "ball") {
+              const dx = ballAnn.x_px - x;
+              const dy = ballAnn.y_px - y;
+              const near = ballAnn.visibility > 0 && dx * dx + dy * dy <= 12 * 12;
+              if (near) {
+                dragRef.current = { kind: "ball", kpIndex: -1 };
+              } else {
+                onBallAnnChange({
+                  ...ballAnn,
+                  visibility: 1,
+                  x_px: x,
+                  y_px: y,
+                  source: "manual"
+                });
+                dragRef.current = { kind: "ball", kpIndex: -1 };
+              }
+            } else if (mode === "court" && courtAnn) {
+              const nearest = findNearestCourtKp(x, y, courtAnn, 10);
+              if (nearest >= 0) {
+                dragRef.current = { kind: "court", kpIndex: nearest };
+                onActiveKpChange(nearest);
+              } else {
+                const autoNext = nextUnsetKpIndex(courtAnn, activeKp);
+                const next: CourtFrameAnnotation = {
+                  ...courtAnn,
+                  keypoints: courtAnn.keypoints.map((kp, i) =>
+                    i === activeKp
+                      ? {
+                          ...kp,
+                          visibility: 1,
+                          x_px: x,
+                          y_px: y,
+                          source: "manual"
+                        }
+                      : kp
+                  )
+                };
+                onCourtAnnChange(next);
+                dragRef.current = { kind: "court", kpIndex: activeKp };
+                if (autoNext !== null && autoNext !== activeKp)
+                  onActiveKpChange(autoNext);
+              }
+            }
+          }}
+          onMouseMove={(e) => {
+            if (!meta) return;
+            const drag = dragRef.current;
+            if (!drag.kind) return;
+            const { x, y } = toCanvasXY(e);
+            if (drag.kind === "ball") {
+              onBallAnnChange({
+                ...ballAnn,
+                visibility: 1,
+                x_px: x,
+                y_px: y,
+                source: "manual"
+              });
+            } else if (drag.kind === "court" && courtAnn) {
+              const idx = clamp(drag.kpIndex, 0, courtAnn.keypoints.length - 1);
+              const next: CourtFrameAnnotation = {
+                ...courtAnn,
+                keypoints: courtAnn.keypoints.map((kp, i) =>
+                  i === idx
+                    ? {
+                        ...kp,
+                        visibility: 1,
+                        x_px: x,
+                        y_px: y,
+                        source: "manual"
+                      }
+                    : kp
+                )
+              };
+              onCourtAnnChange(next);
+            }
+          }}
+          onMouseUp={async () => {
+            const drag = dragRef.current;
+            dragRef.current = { kind: null, kpIndex: -1 };
+            if (drag.kind === "ball") await onBallSave();
+            if (drag.kind === "court" && courtAnn) await onCourtSave(courtAnn);
+          }}
+          onMouseLeave={() => {
+            dragRef.current = { kind: null, kpIndex: -1 };
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/tools/annotation/frontend/app/components/CourtPanel.tsx
+++ b/src/tools/annotation/frontend/app/components/CourtPanel.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import React from "react";
+
+import type { CourtFrameAnnotation, VideoMeta } from "../shared/types";
+import { clamp } from "../shared/utils";
+
+type CourtPanelProps = {
+  meta: VideoMeta | null;
+  courtFrameIdx: number;
+  courtAnn: CourtFrameAnnotation | null;
+  kpNames: string[];
+  activeKp: number;
+  onCourtFrameIdxChange: (idx: number) => void;
+  onActiveKpChange: (idx: number) => void;
+  onSaveCourt: () => void;
+  onResetCourt: () => void;
+  onExportCourt: () => void;
+  onRunHomography: () => void;
+};
+
+export default function CourtPanel({
+  meta,
+  courtFrameIdx,
+  courtAnn,
+  kpNames,
+  activeKp,
+  onCourtFrameIdxChange,
+  onActiveKpChange,
+  onSaveCourt,
+  onResetCourt,
+  onExportCourt,
+  onRunHomography
+}: CourtPanelProps) {
+  const listNames =
+    kpNames.length > 0
+      ? kpNames
+      : Array.from({ length: 20 }, (_, i) => `kp_${i}`);
+
+  return (
+    <>
+      <div className="row">
+        <label>frame idx</label>
+        <input
+          type="number"
+          value={courtFrameIdx}
+          onChange={(e) => {
+            const v = Number(e.target.value);
+            if (!meta) return;
+            onCourtFrameIdxChange(clamp(v, 0, meta.frame_count - 1));
+          }}
+        />
+        <button className="primary" onClick={onSaveCourt} disabled={!courtAnn}>
+          Save
+        </button>
+        <button onClick={onResetCourt} disabled={!courtAnn}>
+          Reset
+        </button>
+        <button onClick={onExportCourt}>Export Court</button>
+      </div>
+
+      <div className="row">
+        <button onClick={onRunHomography} disabled={!courtAnn}>
+          Homography fill
+        </button>
+      </div>
+
+      <div className="small">
+        Select a keypoint, then click to place. Drag existing points to move.
+      </div>
+      <div className="small">
+        keys: Tab/Shift+Tab next/prev kp, N next unset, Backspace clear, S save, E
+        export
+      </div>
+
+      <div className="kpList">
+        {listNames.map((name, i) => {
+          const kp = courtAnn?.keypoints?.[i];
+          const status = kp?.visibility ? kp.source : "—";
+          return (
+            <div
+              key={i}
+              className={`kpItem ${i === activeKp ? "active" : ""}`}
+              onClick={() => onActiveKpChange(i)}
+            >
+              <div className="small">
+                {i}: {name}
+              </div>
+              <div className="small kpStatus">{status}</div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/tools/annotation/frontend/app/components/SeekBar.tsx
+++ b/src/tools/annotation/frontend/app/components/SeekBar.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React from "react";
+
+import type { VideoMeta } from "../shared/types";
+
+type SeekBarProps = {
+  meta: VideoMeta | null;
+  globalFrameIdx: number;
+  seekPreviewIdx: number | null;
+  isSeeking: boolean;
+  onSeekStart: () => void;
+  onSeekPreviewChange: (idx: number) => void;
+  onSeekCommit: (idx: number) => void;
+};
+
+export default function SeekBar({
+  meta,
+  globalFrameIdx,
+  seekPreviewIdx,
+  isSeeking,
+  onSeekStart,
+  onSeekPreviewChange,
+  onSeekCommit
+}: SeekBarProps) {
+  const previewValue = seekPreviewIdx ?? globalFrameIdx;
+  const max = meta ? meta.frame_count - 1 : 0;
+
+  return (
+    <div className="row">
+      <label>seek</label>
+      <input
+        type="range"
+        min={0}
+        max={max}
+        value={previewValue}
+        onMouseDown={onSeekStart}
+        onTouchStart={onSeekStart}
+        onChange={(e) => onSeekPreviewChange(Number(e.target.value))}
+        onMouseUp={() => onSeekCommit(previewValue)}
+        onTouchEnd={() => onSeekCommit(previewValue)}
+      />
+      <div className="small">
+        {previewValue}
+        {meta ? ` / ${max}` : ""}
+        {isSeeking ? " (seeking)" : ""}
+      </div>
+    </div>
+  );
+}

--- a/src/tools/annotation/frontend/app/globals.css
+++ b/src/tools/annotation/frontend/app/globals.css
@@ -121,6 +121,27 @@ button.primary {
   color: #6b7280;
 }
 
+.badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  color: #111827;
+}
+
+.badge.ok {
+  border-color: #86efac;
+  background: #dcfce7;
+  color: #166534;
+}
+
+.badge.warn {
+  border-color: #fcd34d;
+  background: #fef9c3;
+  color: #854d0e;
+}
+
 .kpList {
   display: grid;
   grid-template-columns: 1fr;
@@ -140,4 +161,8 @@ button.primary {
 
 .kpItem.active {
   border-color: #111827;
+}
+
+.kpStatus {
+  text-transform: none;
 }

--- a/src/tools/annotation/frontend/app/page.tsx
+++ b/src/tools/annotation/frontend/app/page.tsx
@@ -2,81 +2,24 @@
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
-type VideoMeta = {
-  fps: number;
-  frame_count: number;
-  width: number;
-  height: number;
-};
-
-type BallClipConfig = {
-  start_frame: number;
-  clip_length: number;
-};
-
-type BallFrameAnnotation = {
-  visibility: 0 | 1 | 2;
-  x_px: number;
-  y_px: number;
-  score: number;
-  source: "manual" | "assist" | "unknown";
-};
-
-type CourtKeypoint = {
-  x_px: number;
-  y_px: number;
-  visibility: 0 | 1;
-  source: "manual" | "assist" | "homography" | "unknown";
-};
-
-type CourtFrameAnnotation = {
-  frame_idx: number;
-  keypoints: CourtKeypoint[];
-};
-
-type ExportResult = { output_dir: string };
-
-function apiBase(): string {
-  return process.env.NEXT_PUBLIC_ANNOTATION_BACKEND ?? "http://127.0.0.1:8000";
-}
-
-async function apiGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${apiBase()}${path}`, { cache: "no-store" });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  return (await res.json()) as T;
-}
-
-async function apiPut<T>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${apiBase()}${path}`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body)
-  });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  return (await res.json()) as T;
-}
-
-async function apiPost<T>(path: string, body?: unknown): Promise<T> {
-  const res = await fetch(`${apiBase()}${path}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: body === undefined ? undefined : JSON.stringify(body)
-  });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  return (await res.json()) as T;
-}
-
-function clamp(v: number, lo: number, hi: number): number {
-  return Math.max(lo, Math.min(hi, v));
-}
+import { apiDelete, apiGet, apiPost, apiPut } from "./shared/api";
+import { clamp, isTypingInField } from "./shared/utils";
+import type {
+  BallAssistAll,
+  BallAssistRunResult,
+  BallAssistSummary,
+  BallClipConfig,
+  BallFrameAnnotation,
+  CourtFrameAnnotation,
+  ExportResult,
+  VideoMeta
+} from "./shared/types";
+import BallPanel from "./components/BallPanel";
+import CanvasStage from "./components/CanvasStage";
+import CourtPanel from "./components/CourtPanel";
+import SeekBar from "./components/SeekBar";
 
 export default function Page() {
-  const frameCanvasRef = useRef<HTMLCanvasElement | null>(null);
-  const overlayCanvasRef = useRef<HTMLCanvasElement | null>(null);
-  const renderTokenRef = useRef<number>(0);
-  const frameCacheRef = useRef<Map<number, HTMLImageElement>>(new Map());
-  const frameLoadRef = useRef<Map<number, Promise<HTMLImageElement>>>(new Map());
-  const preloadGenRef = useRef<number>(0);
   const [meta, setMeta] = useState<VideoMeta | null>(null);
   const [mode, setMode] = useState<"ball" | "court">("ball");
   const [status, setStatus] = useState<string>("");
@@ -84,6 +27,7 @@ export default function Page() {
   const statusTimeoutRef = useRef<number | null>(null);
   const [seekPreviewIdx, setSeekPreviewIdx] = useState<number | null>(null);
   const [isSeeking, setIsSeeking] = useState<boolean>(false);
+  const [resetCacheToken, setResetCacheToken] = useState<number>(0);
 
   // Ball (sequential clip)
   const [ballCfg, setBallCfg] = useState<BallClipConfig>({
@@ -100,6 +44,16 @@ export default function Page() {
   });
   const [ballClipMarkStart, setBallClipMarkStart] = useState<number | null>(null);
   const [ballClipMarkEnd, setBallClipMarkEnd] = useState<number | null>(null);
+  const [ballAssistSummary, setBallAssistSummary] = useState<
+    BallAssistSummary | null
+  >(null);
+  const [ballAssistMap, setBallAssistMap] = useState<
+    Map<number, BallFrameAnnotation>
+  >(new Map());
+  const [ballAssistLoading, setBallAssistLoading] = useState<boolean>(false);
+  const [ballAnnotatedFrames, setBallAnnotatedFrames] = useState<Set<number>>(
+    new Set()
+  );
 
   // Court (sparse frames)
   const [courtFrameIdx, setCourtFrameIdx] = useState<number>(0);
@@ -112,10 +66,17 @@ export default function Page() {
     return courtFrameIdx;
   }, [mode, ballCfg.start_frame, ballLocalIdx, courtFrameIdx]);
 
-  const dragRef = useRef<{
-    kind: "ball" | "court" | null;
-    kpIndex: number;
-  }>({ kind: null, kpIndex: -1 });
+  const ballAssistAnn = useMemo(() => {
+    return ballAssistMap.get(ballLocalIdx) ?? null;
+  }, [ballAssistMap, ballLocalIdx]);
+
+  const manualCount = useMemo(() => {
+    let count = 0;
+    for (const idx of ballAnnotatedFrames) {
+      if (idx >= 0 && idx < ballCfg.clip_length) count += 1;
+    }
+    return count;
+  }, [ballAnnotatedFrames, ballCfg.clip_length]);
 
   function setStatusWithTimeout(msg: string, ms: number = 1200) {
     setStatus(msg);
@@ -128,11 +89,33 @@ export default function Page() {
     }, ms);
   }
 
-  function isTypingInField(): boolean {
-    const el = document.activeElement;
-    if (!el) return false;
-    const tag = el.tagName.toLowerCase();
-    return tag === "input" || tag === "textarea" || tag === "select";
+  async function refreshBallAssistSummary(): Promise<BallAssistSummary | null> {
+    try {
+      const summary = await apiGet<BallAssistSummary>("/api/ball/assist/summary");
+      setBallAssistSummary(summary);
+      return summary;
+    } catch (e) {
+      setBallAssistSummary(null);
+      return null;
+    }
+  }
+
+  async function loadBallAssistAll(): Promise<void> {
+    const data = await apiGet<BallAssistAll>("/api/ball/assist/all");
+    const next = new Map<number, BallFrameAnnotation>();
+    for (const [k, v] of Object.entries(data.annotations)) {
+      next.set(Number(k), v);
+    }
+    setBallAssistMap(next);
+  }
+
+  async function refreshBallAnnotatedFrames(): Promise<void> {
+    try {
+      const frames = await apiGet<number[]>("/api/ball/annotated_frames");
+      setBallAnnotatedFrames(new Set(frames));
+    } catch (e) {
+      setBallAnnotatedFrames(new Set());
+    }
   }
 
   useEffect(() => {
@@ -145,78 +128,19 @@ export default function Page() {
         setBallLocalIdx(0);
         const names = await apiGet<string[]>("/api/court/kp_names");
         setKpNames(names);
+        await refreshBallAnnotatedFrames();
+        const summary = await refreshBallAssistSummary();
+        if (summary?.available && summary.clip_matches_current) {
+          await loadBallAssistAll();
+        } else {
+          setBallAssistMap(new Map());
+        }
         setStatus("");
       } catch (e) {
         setStatus(String(e));
       }
     })();
   }, []);
-
-  function frameUrl(idx: number): string {
-    return `${apiBase()}/api/frame/${idx}.jpg`;
-  }
-
-  function getCachedFrame(idx: number): HTMLImageElement | null {
-    const cached = frameCacheRef.current.get(idx);
-    if (cached && cached.complete && cached.naturalWidth > 0) return cached;
-    return null;
-  }
-
-  function preloadFrame(idx: number): Promise<HTMLImageElement> {
-    const cached = getCachedFrame(idx);
-    if (cached) return Promise.resolve(cached);
-    const inflight = frameLoadRef.current.get(idx);
-    if (inflight) return inflight;
-
-    const img = new Image();
-    img.crossOrigin = "anonymous";
-    const promise = new Promise<HTMLImageElement>((resolve, reject) => {
-      img.onload = () => {
-        frameCacheRef.current.set(idx, img);
-        frameLoadRef.current.delete(idx);
-        resolve(img);
-      };
-      img.onerror = () => {
-        frameLoadRef.current.delete(idx);
-        reject(new Error(`failed to load frame ${idx}`));
-      };
-    });
-    frameLoadRef.current.set(idx, promise);
-    img.src = frameUrl(idx);
-    return promise;
-  }
-
-  function pruneFrameCache(centerIdx: number, maxSize: number) {
-    const cache = frameCacheRef.current;
-    if (cache.size <= maxSize) return;
-    const entries = Array.from(cache.keys());
-    entries.sort((a, b) => Math.abs(b - centerIdx) - Math.abs(a - centerIdx));
-    const toRemove = entries.slice(0, Math.max(0, entries.length - maxSize));
-    for (const idx of toRemove) cache.delete(idx);
-  }
-
-  function preloadRange(centerIdx: number, radius: number, maxSize: number) {
-    const gen = ++preloadGenRef.current;
-    const indices: number[] = [centerIdx];
-    for (let i = 1; i <= radius; i++) {
-      indices.push(centerIdx + i, centerIdx - i);
-    }
-    for (const idx of indices) {
-      if (!meta) return;
-      if (idx < 0 || idx >= meta.frame_count) continue;
-      if (getCachedFrame(idx)) continue;
-      void preloadFrame(idx).catch(() => {
-        if (gen !== preloadGenRef.current) return;
-      });
-    }
-    pruneFrameCache(centerIdx, maxSize);
-  }
-
-  function resetFrameCache() {
-    frameCacheRef.current.clear();
-    frameLoadRef.current.clear();
-    preloadGenRef.current += 1;
-  }
 
   function setGlobalFrameIdx(next: number) {
     if (!meta) return;
@@ -263,96 +187,6 @@ export default function Page() {
     })();
   }, [mode, ballLocalIdx, courtFrameIdx]);
 
-  // Set canvas sizes once meta is loaded
-  useEffect(() => {
-    if (!meta) return;
-    const frameCanvas = frameCanvasRef.current;
-    const overlayCanvas = overlayCanvasRef.current;
-    if (frameCanvas) {
-      frameCanvas.width = meta.width;
-      frameCanvas.height = meta.height;
-    }
-    if (overlayCanvas) {
-      overlayCanvas.width = meta.width;
-      overlayCanvas.height = meta.height;
-    }
-  }, [meta]);
-
-  // Draw frame image (keeps previous frame until new one is ready)
-  useEffect(() => {
-    const frameCanvas = frameCanvasRef.current;
-    if (!frameCanvas || !meta) return;
-
-    const token = ++renderTokenRef.current;
-    let canceled = false;
-    const ctx = frameCanvas.getContext("2d");
-    if (!ctx) return;
-    const cached = getCachedFrame(globalFrameIdx);
-    if (cached) {
-      ctx.clearRect(0, 0, frameCanvas.width, frameCanvas.height);
-      ctx.drawImage(cached, 0, 0, frameCanvas.width, frameCanvas.height);
-      setIsFrameLoading(false);
-    } else {
-      setIsFrameLoading(true);
-      void preloadFrame(globalFrameIdx)
-        .then((img) => {
-          if (canceled) return;
-          if (token !== renderTokenRef.current) return;
-          ctx.clearRect(0, 0, frameCanvas.width, frameCanvas.height);
-          ctx.drawImage(img, 0, 0, frameCanvas.width, frameCanvas.height);
-          setIsFrameLoading(false);
-        })
-        .catch(() => {
-          if (canceled) return;
-          if (token !== renderTokenRef.current) return;
-          setIsFrameLoading(false);
-          setStatus("failed to load frame image (check backend / video / frame idx)");
-        });
-    }
-
-    preloadRange(globalFrameIdx, 6, 48);
-
-    return () => {
-      canceled = true;
-    };
-  }, [meta, globalFrameIdx]);
-
-  // Draw overlays (cleared immediately on frame change)
-  useEffect(() => {
-    const overlayCanvas = overlayCanvasRef.current;
-    if (!overlayCanvas || !meta) return;
-    const ctx = overlayCanvas.getContext("2d");
-    if (!ctx) return;
-    ctx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height);
-
-    if (mode === "ball") {
-      if (ballAnn.visibility > 0) {
-        ctx.fillStyle = "#00E5FF";
-        ctx.strokeStyle = "#001018";
-        ctx.lineWidth = 2;
-        ctx.beginPath();
-        ctx.arc(ballAnn.x_px, ballAnn.y_px, 8, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.stroke();
-      }
-      return;
-    }
-
-    if (mode === "court" && courtAnn) {
-      for (let i = 0; i < courtAnn.keypoints.length; i++) {
-        const kp = courtAnn.keypoints[i];
-        if (kp.visibility === 0) continue;
-        ctx.fillStyle = i === activeKp ? "#FFB020" : "#22C55E";
-        ctx.strokeStyle = "#111827";
-        ctx.lineWidth = 2;
-        ctx.beginPath();
-        ctx.arc(kp.x_px, kp.y_px, 6, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.stroke();
-      }
-    }
-  }, [meta, mode, globalFrameIdx, ballAnn, courtAnn, activeKp]);
-
   async function saveBall() {
     try {
       const saved = await apiPut<BallFrameAnnotation>(
@@ -360,7 +194,33 @@ export default function Page() {
         ballAnn
       );
       setBallAnn(saved);
+      setBallAnnotatedFrames((prev) => {
+        const next = new Set(prev);
+        next.add(ballLocalIdx);
+        return next;
+      });
       setStatusWithTimeout("saved");
+    } catch (e) {
+      setStatus(String(e));
+    }
+  }
+
+  async function resetBall() {
+    try {
+      await apiDelete<{ ok: boolean }>(`/api/ball/annotations/${ballLocalIdx}`);
+      setBallAnn({
+        visibility: 0,
+        x_px: 0,
+        y_px: 0,
+        score: 0,
+        source: "manual"
+      });
+      setBallAnnotatedFrames((prev) => {
+        const next = new Set(prev);
+        next.delete(ballLocalIdx);
+        return next;
+      });
+      setStatusWithTimeout("reset");
     } catch (e) {
       setStatus(String(e));
     }
@@ -374,6 +234,19 @@ export default function Page() {
       );
       setCourtAnn(saved);
       setStatusWithTimeout("saved");
+    } catch (e) {
+      setStatus(String(e));
+    }
+  }
+
+  async function resetCourt() {
+    try {
+      await apiDelete<{ ok: boolean }>(`/api/court/annotations/${courtFrameIdx}`);
+      const ann = await apiGet<CourtFrameAnnotation>(
+        `/api/court/annotations/${courtFrameIdx}`
+      );
+      setCourtAnn(ann);
+      setStatusWithTimeout("reset");
     } catch (e) {
       setStatus(String(e));
     }
@@ -431,10 +304,85 @@ export default function Page() {
       setBallCfg(saved);
       setBallLocalIdx(0);
       setStatusWithTimeout(`clip set: ${start}..${end}`);
+      await refreshBallAnnotatedFrames();
+      await refreshBallAssistSummary();
+      setBallAssistMap(new Map());
     } catch (e) {
       setStatus(String(e));
     }
   }
+
+  async function runBallAssist() {
+    setBallAssistLoading(true);
+    try {
+      const result = await apiPost<BallAssistRunResult>("/api/ball/assist/run");
+      setStatusWithTimeout(`assist done: ${result.count} frames`);
+      const summary = await refreshBallAssistSummary();
+      if (summary?.available && summary.clip_matches_current) {
+        await loadBallAssistAll();
+      }
+    } catch (e) {
+      setStatus(String(e));
+    } finally {
+      setBallAssistLoading(false);
+    }
+  }
+
+  async function applyAssistCurrent() {
+    if (!ballAssistAnn) {
+      setStatus("assist not available for current frame");
+      return;
+    }
+    const next: BallFrameAnnotation = {
+      ...ballAssistAnn,
+      source: "assist"
+    };
+    setBallAnn(next);
+    try {
+      const saved = await apiPut<BallFrameAnnotation>(
+        `/api/ball/annotations/${ballLocalIdx}`,
+        next
+      );
+      setBallAnn(saved);
+      setBallAnnotatedFrames((prev) => {
+        const updated = new Set(prev);
+        updated.add(ballLocalIdx);
+        return updated;
+      });
+      setStatusWithTimeout("assist applied");
+    } catch (e) {
+      setStatus(String(e));
+    }
+  }
+
+  async function runCourtHomography() {
+    if (!courtAnn) return;
+    try {
+      const filled = await apiPost<CourtFrameAnnotation>(
+        "/api/court/homography",
+        courtAnn
+      );
+      setCourtAnn(filled);
+      setStatusWithTimeout("homography filled");
+    } catch (e) {
+      setStatus(String(e));
+    }
+  }
+
+  useEffect(() => {
+    (async () => {
+      const summary = await refreshBallAssistSummary();
+      if (summary?.available && summary.clip_matches_current) {
+        try {
+          await loadBallAssistAll();
+        } catch (e) {
+          setBallAssistMap(new Map());
+        }
+        return;
+      }
+      setBallAssistMap(new Map());
+    })();
+  }, [ballCfg.start_frame, ballCfg.clip_length]);
 
   // Keyboard shortcuts (common + per-mode)
   useEffect(() => {
@@ -548,184 +496,46 @@ export default function Page() {
     ballClipMarkEnd
   ]);
 
-  function toCanvasXY(e: React.MouseEvent<HTMLCanvasElement>): {
-    x: number;
-    y: number;
-  } {
-    const canvas = e.currentTarget;
-    const rect = canvas.getBoundingClientRect();
-    const x = (e.clientX - rect.left) * (canvas.width / rect.width);
-    const y = (e.clientY - rect.top) * (canvas.height / rect.height);
-    return { x, y };
-  }
-
-  function findNearestCourtKp(
-    x: number,
-    y: number,
-    ann: CourtFrameAnnotation,
-    radiusPx: number
-  ): number {
-    let best = -1;
-    let bestD2 = radiusPx * radiusPx;
-    for (let i = 0; i < ann.keypoints.length; i++) {
-      const kp = ann.keypoints[i];
-      if (kp.visibility === 0) continue;
-      const dx = kp.x_px - x;
-      const dy = kp.y_px - y;
-      const d2 = dx * dx + dy * dy;
-      if (d2 <= bestD2) {
-        bestD2 = d2;
-        best = i;
-      }
-    }
-    return best;
-  }
-
   return (
     <div className="root">
-      <div className="canvasWrap">
-        <div
-          className="canvasStage"
-          style={{
-            aspectRatio: meta ? `${meta.width} / ${meta.height}` : "16 / 9"
-          }}
-        >
-          <div className={`loadingBadge ${isFrameLoading ? "show" : ""}`}>
-            Loading...
-          </div>
-          <canvas ref={frameCanvasRef} className="frameCanvas" />
-          <canvas
-            ref={overlayCanvasRef}
-            className="overlayCanvas"
-            onMouseDown={(e) => {
-            if (!meta) return;
-            const { x, y } = toCanvasXY(e);
-            if (mode === "ball") {
-              const dx = ballAnn.x_px - x;
-              const dy = ballAnn.y_px - y;
-              const near = ballAnn.visibility > 0 && dx * dx + dy * dy <= 12 * 12;
-              if (near) {
-                dragRef.current = { kind: "ball", kpIndex: -1 };
-              } else {
-                setBallAnn({
-                  ...ballAnn,
-                  visibility: 1,
-                  x_px: x,
-                  y_px: y,
-                  source: "manual"
-                });
-                dragRef.current = { kind: "ball", kpIndex: -1 };
-              }
-            } else if (mode === "court" && courtAnn) {
-              const nearest = findNearestCourtKp(x, y, courtAnn, 10);
-              if (nearest >= 0) {
-                dragRef.current = { kind: "court", kpIndex: nearest };
-                setActiveKp(nearest);
-              } else {
-                const autoNext = nextUnsetKpIndex(courtAnn, activeKp);
-                const next: CourtFrameAnnotation = {
-                  ...courtAnn,
-                  keypoints: courtAnn.keypoints.map((kp, i) =>
-                    i === activeKp
-                      ? {
-                          ...kp,
-                          visibility: 1 as const,
-                          x_px: x,
-                          y_px: y,
-                          source: "manual" as const
-                        }
-                      : kp
-                  )
-                };
-                setCourtAnn(next);
-                dragRef.current = { kind: "court", kpIndex: activeKp };
-                if (autoNext !== null && autoNext !== activeKp) setActiveKp(autoNext);
-              }
-            }
-          }}
-            onMouseMove={(e) => {
-            if (!meta) return;
-            const drag = dragRef.current;
-            if (!drag.kind) return;
-            const { x, y } = toCanvasXY(e);
-            if (drag.kind === "ball") {
-              setBallAnn({
-                ...ballAnn,
-                visibility: 1,
-                x_px: x,
-                y_px: y,
-                source: "manual"
-              });
-            } else if (drag.kind === "court" && courtAnn) {
-              const idx = drag.kpIndex;
-              if (idx < 0) return;
-              const next: CourtFrameAnnotation = {
-                ...courtAnn,
-                keypoints: courtAnn.keypoints.map((kp, i) =>
-                  i === idx
-                    ? {
-                        ...kp,
-                        visibility: 1 as const,
-                        x_px: x,
-                        y_px: y,
-                        source: "manual" as const
-                      }
-                    : kp
-                )
-              };
-              setCourtAnn(next);
-            }
-          }}
-            onMouseUp={async () => {
-            const drag = dragRef.current;
-            dragRef.current = { kind: null, kpIndex: -1 };
-            if (drag.kind === "ball") await saveBall();
-            if (drag.kind === "court" && courtAnn) await saveCourt(courtAnn);
-          }}
-            onMouseLeave={() => {
-            dragRef.current = { kind: null, kpIndex: -1 };
-          }}
-          />
-        </div>
-      </div>
+      <CanvasStage
+        meta={meta}
+        mode={mode}
+        globalFrameIdx={globalFrameIdx}
+        ballAnn={ballAnn}
+        ballAssistAnn={ballAssistAnn}
+        courtAnn={courtAnn}
+        activeKp={activeKp}
+        isFrameLoading={isFrameLoading}
+        resetCacheToken={resetCacheToken}
+        onBallAnnChange={setBallAnn}
+        onCourtAnnChange={setCourtAnn}
+        onActiveKpChange={setActiveKp}
+        onBallSave={saveBall}
+        onCourtSave={saveCourt}
+        onFrameLoadingChange={setIsFrameLoading}
+        onStatus={setStatus}
+      />
 
       <div className="panel">
-        <div className="row">
-          <label>seek</label>
-          <input
-            type="range"
-            min={0}
-            max={meta ? meta.frame_count - 1 : 0}
-            value={seekPreviewIdx ?? globalFrameIdx}
-            onMouseDown={() => setIsSeeking(true)}
-            onTouchStart={() => setIsSeeking(true)}
-            onChange={(e) => {
-              const v = Number(e.target.value);
-              setSeekPreviewIdx(v);
-              if (!isSeeking) setIsSeeking(true);
-            }}
-            onMouseUp={() => {
-              const target = seekPreviewIdx ?? globalFrameIdx;
-              const jump = Math.abs(target - globalFrameIdx);
-              if (jump > 18) resetFrameCache();
-              setGlobalFrameIdx(target);
-              setIsSeeking(false);
-              setSeekPreviewIdx(null);
-            }}
-            onTouchEnd={() => {
-              const target = seekPreviewIdx ?? globalFrameIdx;
-              const jump = Math.abs(target - globalFrameIdx);
-              if (jump > 18) resetFrameCache();
-              setGlobalFrameIdx(target);
-              setIsSeeking(false);
-              setSeekPreviewIdx(null);
-            }}
-          />
-          <div className="small">
-            {seekPreviewIdx ?? globalFrameIdx}
-            {meta ? ` / ${meta.frame_count - 1}` : ""}
-          </div>
-        </div>
+        <SeekBar
+          meta={meta}
+          globalFrameIdx={globalFrameIdx}
+          seekPreviewIdx={seekPreviewIdx}
+          isSeeking={isSeeking}
+          onSeekStart={() => setIsSeeking(true)}
+          onSeekPreviewChange={(idx) => {
+            setSeekPreviewIdx(idx);
+            if (!isSeeking) setIsSeeking(true);
+          }}
+          onSeekCommit={(target) => {
+            const jump = Math.abs(target - globalFrameIdx);
+            if (jump > 18) setResetCacheToken((v) => v + 1);
+            setGlobalFrameIdx(target);
+            setIsSeeking(false);
+            setSeekPreviewIdx(null);
+          }}
+        />
 
         <div className="row">
           <label>Mode</label>
@@ -749,169 +559,70 @@ export default function Page() {
         </div>
 
         {mode === "ball" ? (
-          <>
-            <div className="row">
-              <label>clip start</label>
-              <input
-                type="number"
-                value={ballCfg.start_frame}
-                onChange={(e) =>
-                  setBallCfg({
-                    ...ballCfg,
-                    start_frame: Number(e.target.value)
-                  })
-                }
-              />
-              <label>clip length</label>
-              <input
-                type="number"
-                value={ballCfg.clip_length}
-                onChange={(e) =>
-                  setBallCfg({
-                    ...ballCfg,
-                    clip_length: Number(e.target.value)
-                  })
-                }
-              />
-              <button
-                className="primary"
-                onClick={async () => {
-                  if (!meta) return;
-                  try {
-                    const next = {
-                      start_frame: clamp(ballCfg.start_frame, 0, meta.frame_count - 1),
-                      clip_length: clamp(
-                        ballCfg.clip_length,
-                        1,
-                        meta.frame_count
-                      )
-                    };
-                    const saved = await apiPut<BallClipConfig>(
-                      "/api/ball/clip_config",
-                      next
-                    );
-                    setBallCfg(saved);
-                    setBallLocalIdx(0);
-                    setStatusWithTimeout("clip config saved");
-                  } catch (e) {
-                    setStatus(String(e));
-                  }
-                }}
-              >
-                Set clip
-              </button>
-            </div>
-
-            <div className="row">
-              <button
-                onClick={() => {
-                  setBallClipMarkStart(globalFrameIdx);
-                  setStatusWithTimeout(`clip start = ${globalFrameIdx}`);
-                }}
-              >
-                Mark start [
-              </button>
-              <button
-                onClick={() => {
-                  setBallClipMarkEnd(globalFrameIdx);
-                  setStatusWithTimeout(`clip end = ${globalFrameIdx}`);
-                }}
-              >
-                Mark end ]
-              </button>
-              <div className="small">
-                marked: {ballClipMarkStart ?? "—"} .. {ballClipMarkEnd ?? "—"}
-              </div>
-              <button className="primary" onClick={applyBallClipMarks}>
-                Apply (Enter)
-              </button>
-            </div>
-
-            <div className="row">
-              <label>local idx</label>
-              <input
-                type="number"
-                value={ballLocalIdx}
-                onChange={(e) => {
-                  const v = Number(e.target.value);
-                  setBallLocalIdx(clamp(v, 0, ballCfg.clip_length - 1));
-                }}
-              />
-              <button className="primary" onClick={saveBall}>
-                Save
-              </button>
-              <button
-                onClick={exportCurrentMode}
-              >
-                Export WASB
-              </button>
-            </div>
-
-            <div className="row">
-              <div className="small">
-                click to place; drag to move; auto-save on mouse up
-              </div>
-            </div>
-            <div className="row">
-              <div className="small">
-                keys: [ ] mark clip, Enter apply, S save, E export, ←/→ navigate
-              </div>
-            </div>
-          </>
+          <BallPanel
+            meta={meta}
+            ballCfg={ballCfg}
+            ballLocalIdx={ballLocalIdx}
+            ballClipMarkStart={ballClipMarkStart}
+            ballClipMarkEnd={ballClipMarkEnd}
+            assistSummary={ballAssistSummary}
+            assistLoading={ballAssistLoading}
+            assistAnn={ballAssistAnn}
+            manualCount={manualCount}
+            onBallCfgChange={setBallCfg}
+            onSetClip={async () => {
+              if (!meta) return;
+              try {
+                const next = {
+                  start_frame: clamp(ballCfg.start_frame, 0, meta.frame_count - 1),
+                  clip_length: clamp(ballCfg.clip_length, 1, meta.frame_count)
+                };
+                const saved = await apiPut<BallClipConfig>(
+                  "/api/ball/clip_config",
+                  next
+                );
+                setBallCfg(saved);
+                setBallLocalIdx(0);
+                setStatusWithTimeout("clip config saved");
+                await refreshBallAnnotatedFrames();
+                await refreshBallAssistSummary();
+                setBallAssistMap(new Map());
+              } catch (e) {
+                setStatus(String(e));
+              }
+            }}
+            onMarkStart={() => {
+              setBallClipMarkStart(globalFrameIdx);
+              setStatusWithTimeout(`clip start = ${globalFrameIdx}`);
+            }}
+            onMarkEnd={() => {
+              setBallClipMarkEnd(globalFrameIdx);
+              setStatusWithTimeout(`clip end = ${globalFrameIdx}`);
+            }}
+            onApplyClipMarks={applyBallClipMarks}
+            onBallLocalIdxChange={setBallLocalIdx}
+            onSaveBall={saveBall}
+            onResetBall={resetBall}
+            onExportBall={exportCurrentMode}
+            onRunAssist={runBallAssist}
+            onApplyAssist={applyAssistCurrent}
+          />
         ) : (
-          <>
-            <div className="row">
-              <label>frame idx</label>
-              <input
-                type="number"
-                value={courtFrameIdx}
-                onChange={(e) => {
-                  const v = Number(e.target.value);
-                  if (!meta) return;
-                  setCourtFrameIdx(clamp(v, 0, meta.frame_count - 1));
-                }}
-              />
-              <button
-                className="primary"
-                onClick={async () => {
-                  if (courtAnn) await saveCourt(courtAnn);
-                }}
-              >
-                Save
-              </button>
-              <button
-                onClick={exportCurrentMode}
-              >
-                Export Court
-              </button>
-            </div>
-
-            <div className="small">
-              Select a keypoint, then click to place. Drag existing points to move.
-            </div>
-            <div className="small">
-              keys: Tab/Shift+Tab next/prev kp, N next unset, Backspace clear, S save, E export
-            </div>
-
-            <div className="kpList">
-              {(kpNames.length ? kpNames : Array.from({ length: 20 }, (_, i) => `kp_${i}`)).map(
-                (name, i) => (
-                  <div
-                    key={i}
-                    className={`kpItem ${i === activeKp ? "active" : ""}`}
-                    onClick={() => setActiveKp(i)}
-                  >
-                    <div className="small">
-                      {i}: {name}
-                    </div>
-                    <div className="small">
-                      {courtAnn?.keypoints?.[i]?.visibility ? "set" : "—"}
-                    </div>
-                  </div>
-                )
-              )}
-            </div>
-          </>
+          <CourtPanel
+            meta={meta}
+            courtFrameIdx={courtFrameIdx}
+            courtAnn={courtAnn}
+            kpNames={kpNames}
+            activeKp={activeKp}
+            onCourtFrameIdxChange={setCourtFrameIdx}
+            onActiveKpChange={setActiveKp}
+            onSaveCourt={() => {
+              if (courtAnn) void saveCourt(courtAnn);
+            }}
+            onResetCourt={resetCourt}
+            onExportCourt={exportCurrentMode}
+            onRunHomography={runCourtHomography}
+          />
         )}
 
         <div className="row">

--- a/src/tools/annotation/frontend/app/shared/api.ts
+++ b/src/tools/annotation/frontend/app/shared/api.ts
@@ -1,0 +1,38 @@
+export function apiBase(): string {
+  return process.env.NEXT_PUBLIC_ANNOTATION_BACKEND ?? "http://127.0.0.1:8000";
+}
+
+export async function apiGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${apiBase()}${path}`, { cache: "no-store" });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as T;
+}
+
+export async function apiPut<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${apiBase()}${path}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as T;
+}
+
+export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(`${apiBase()}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body)
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as T;
+}
+
+export async function apiDelete<T>(path: string): Promise<T> {
+  const res = await fetch(`${apiBase()}${path}`, {
+    method: "DELETE"
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}

--- a/src/tools/annotation/frontend/app/shared/types.ts
+++ b/src/tools/annotation/frontend/app/shared/types.ts
@@ -1,0 +1,61 @@
+export type VideoMeta = {
+  fps: number;
+  frame_count: number;
+  width: number;
+  height: number;
+};
+
+export type BallClipConfig = {
+  start_frame: number;
+  clip_length: number;
+};
+
+export type BallFrameAnnotation = {
+  visibility: 0 | 1 | 2;
+  x_px: number;
+  y_px: number;
+  score: number;
+  source: "manual" | "assist" | "unknown";
+};
+
+export type CourtKeypoint = {
+  x_px: number;
+  y_px: number;
+  visibility: 0 | 1;
+  source: "manual" | "assist" | "homography" | "unknown";
+};
+
+export type CourtFrameAnnotation = {
+  frame_idx: number;
+  keypoints: CourtKeypoint[];
+};
+
+export type ExportResult = { output_dir: string };
+
+export type BallAssistMeta = {
+  checkpoint_path: string | null;
+  model_type: "wasb" | "hrcnet";
+  device: "cpu" | "cuda";
+  batch_size: number;
+  score_threshold: number;
+  max_disp: number;
+  created_at: string;
+};
+
+export type BallAssistSummary = {
+  available: boolean;
+  clip_matches_current: boolean;
+  clip: BallClipConfig | null;
+  meta: BallAssistMeta | null;
+  count: number;
+};
+
+export type BallAssistRunResult = {
+  clip: BallClipConfig;
+  meta: BallAssistMeta;
+  count: number;
+};
+
+export type BallAssistAll = {
+  annotations: Record<string, BallFrameAnnotation>;
+};

--- a/src/tools/annotation/frontend/app/shared/utils.ts
+++ b/src/tools/annotation/frontend/app/shared/utils.ts
@@ -1,0 +1,21 @@
+export function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+export function isTypingInField(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select";
+}
+
+export function formatAssistMetaSummary(meta: {
+  model_type: string;
+  device: string;
+  score_threshold: number;
+  batch_size: number;
+  max_disp: number;
+} | null): string {
+  if (!meta) return "assist not configured";
+  return `model=${meta.model_type}, device=${meta.device}, score=${meta.score_threshold}, batch=${meta.batch_size}, max_disp=${meta.max_disp}`;
+}


### PR DESCRIPTION
## Summary
- ボールassistの推論/キャッシュ/APIを追加し、exportでmanual優先+assistフォールバックに対応
- コートhomography補完のZ>0点処理を修正し、Reset APIとUIボタンを追加
- フロントエンドをモジュール分割し、assist/homography UIを整備
- annotation READMEの手順を更新

## Testing
- 未実行
