### PR TITLE
#214 BLCS: training cfgでcallbacks/trainer設定を駆動（BaseRunnerはcfg優先+フォールバック）

### DIFF
--- a/src/base/training/runner.py
+++ b/src/base/training/runner.py
@@ -154,31 +154,119 @@ class BaseTrainingRunner:
     def build_callbacks(
         self, config: Any, datamodule: pl.LightningDataModule, logger: TensorBoardLogger
     ) -> list[Any]:
-        checkpoint_dir = Path(logger.log_dir) / "checkpoints"
-        callbacks: list[Any] = [
-            ModelCheckpoint(
-                dirpath=checkpoint_dir,
-                filename=f"{self.checkpoint_prefix(config)}-{{epoch:02d}}",
-                monitor=self.checkpoint_monitor(config),
-                mode=self.checkpoint_mode(config),
-                save_top_k=self.checkpoint_save_top_k(config),
-                save_last=self.checkpoint_save_last(config),
-            )
-        ]
+        """Build callbacks for training.
 
-        if self.early_stopping_enabled(config):
+        Callback settings can be provided via `config.training.*` and take precedence
+        over runner hook methods. For backward compatibility, missing values fall back
+        to the hook defaults.
+        """
+        missing = object()
+
+        def _select(path: str, *, default: Any = missing) -> Any:
+            if OmegaConf.is_config(config):
+                value = OmegaConf.select(config, path, default=missing)
+                if value is not missing:
+                    return value
+                return default
+
+            current: Any = config
+            for key in path.split("."):
+                if isinstance(current, dict) and key in current:
+                    current = current[key]
+                else:
+                    return default
+            return current
+
+        checkpoint_dir = Path(logger.log_dir) / "checkpoints"
+        callbacks: list[Any] = []
+
+        ckpt_enabled = bool(_select("training.checkpoint.enabled", default=True))
+        if ckpt_enabled:
+            callbacks.append(
+                ModelCheckpoint(
+                    dirpath=checkpoint_dir,
+                    filename=str(
+                        _select(
+                            "training.checkpoint.filename",
+                            default=f"{self.checkpoint_prefix(config)}-{{epoch:02d}}",
+                        )
+                    ),
+                    monitor=str(
+                        _select(
+                            "training.checkpoint.monitor",
+                            default=self.checkpoint_monitor(config),
+                        )
+                    ),
+                    mode=str(
+                        _select(
+                            "training.checkpoint.mode",
+                            default=self.checkpoint_mode(config),
+                        )
+                    ),
+                    save_top_k=int(
+                        _select(
+                            "training.checkpoint.save_top_k",
+                            default=self.checkpoint_save_top_k(config),
+                        )
+                    ),
+                    save_last=bool(
+                        _select(
+                            "training.checkpoint.save_last",
+                            default=self.checkpoint_save_last(config),
+                        )
+                    ),
+                )
+            )
+
+        early_enabled = bool(
+            _select(
+                "training.early_stopping.enabled",
+                default=self.early_stopping_enabled(config),
+            )
+        )
+        if early_enabled:
             kwargs: dict[str, Any] = {
-                "monitor": self.early_stopping_monitor(config),
-                "patience": self.early_stopping_patience(config),
-                "mode": self.early_stopping_mode(config),
+                "monitor": str(
+                    _select(
+                        "training.early_stopping.monitor",
+                        default=self.early_stopping_monitor(config),
+                    )
+                ),
+                "patience": int(
+                    _select(
+                        "training.early_stopping.patience",
+                        default=self.early_stopping_patience(config),
+                    )
+                ),
+                "mode": str(
+                    _select(
+                        "training.early_stopping.mode",
+                        default=self.early_stopping_mode(config),
+                    )
+                ),
             }
-            min_delta = self.early_stopping_min_delta(config)
+            min_delta = _select(
+                "training.early_stopping.min_delta",
+                default=self.early_stopping_min_delta(config),
+            )
             if min_delta is not None:
                 kwargs["min_delta"] = min_delta
             callbacks.append(EarlyStopping(**kwargs))
 
-        if self.lr_monitor_enabled(config):
-            callbacks.append(LearningRateMonitor(logging_interval=self.lr_monitor_interval(config)))
+        lr_enabled = bool(
+            _select("training.lr_monitor.enabled", default=self.lr_monitor_enabled(config))
+        )
+        if lr_enabled:
+            callbacks.append(
+                LearningRateMonitor(
+                    logging_interval=str(
+                        _select(
+                            "training.lr_monitor.interval",
+                            default=self.lr_monitor_interval(config),
+                        )
+                    )
+                )
+            )
 
         callbacks.extend(self.callbacks_extra(config, datamodule, logger))
         return callbacks
@@ -187,6 +275,23 @@ class BaseTrainingRunner:
         self, config: Any, callbacks: list[Any], logger: TensorBoardLogger
     ) -> pl.Trainer:
         accelerator, devices = self.select_devices(config)
+        missing = object()
+
+        def _select(path: str, *, default: Any = missing) -> Any:
+            if OmegaConf.is_config(config):
+                value = OmegaConf.select(config, path, default=missing)
+                if value is not missing:
+                    return value
+                return default
+
+            current: Any = config
+            for key in path.split("."):
+                if isinstance(current, dict) and key in current:
+                    current = current[key]
+                else:
+                    return default
+            return current
+
         base_kwargs: dict[str, Any] = {
             "max_epochs": int(getattr(config.training, "max_epochs", 1)),
             "accelerator": accelerator,
@@ -197,8 +302,19 @@ class BaseTrainingRunner:
             "fast_dev_run": bool(getattr(config.run, "fast_dev_run", False)),
             "deterministic": True,
         }
+
+        trainer_cfg = _select("training.trainer", default={})
+        if trainer_cfg is not None:
+            if OmegaConf.is_config(trainer_cfg):
+                trainer_cfg = OmegaConf.to_container(trainer_cfg, resolve=True)
+            if isinstance(trainer_cfg, dict):
+                for key, value in trainer_cfg.items():
+                    if value is not None:
+                        base_kwargs[key] = value
+
         extra_kwargs = self.trainer_kwargs(config, accelerator, devices)
-        base_kwargs.update(extra_kwargs)
+        for key, value in extra_kwargs.items():
+            base_kwargs.setdefault(key, value)
         return pl.Trainer(**base_kwargs)
 
     def select_devices(self, config: Any) -> tuple[str, int]:

--- a/src/blcs/configs/training/default.yaml
+++ b/src/blcs/configs/training/default.yaml
@@ -1,15 +1,40 @@
+# ---- Trainer (Lightning Trainer settings) ----
 max_epochs: 20
+gradient_clip_val: 1.0
+log_every_n_steps: 50
+
+# Use null for CPU compatibility. Override per run when using GPU:
+#   training.precision=16-mixed
+precision: null
+
+# ---- Optimizer / schedule（LightningModuleが参照）----
 learning_rate: 1.0e-4
 weight_decay: 1.0e-5
 warmup_steps: 2000
-gradient_clip_val: 1.0
+scheduler: cosine
+min_lr: 1.0e-6
 
-# Loss weights
+# ---- Loss weights（task-specific）----
 position_loss_weight: 1.0
 velocity_loss_weight: 0.0
 smoothness_loss_weight: 0.0
 
-# Scheduler
-scheduler: cosine
-min_lr: 1.0e-6
+# ---- Callbacks（BaseTrainingRunnerが参照）----
+checkpoint:
+  enabled: true
+  filename: "blcs-{epoch:02d}"
+  monitor: val/loss
+  mode: min
+  save_top_k: 3
+  save_last: true
 
+early_stopping:
+  enabled: true
+  monitor: val/pos_error_m
+  mode: min
+  patience: 5
+  min_delta: 1.0e-3
+
+lr_monitor:
+  enabled: true
+  interval: step

--- a/src/blcs/training/runner.py
+++ b/src/blcs/training/runner.py
@@ -30,37 +30,6 @@ class BLCSTrainingRunner(BaseTrainingRunner):
         """Build BLCS lightning module."""
         return BLCSLightningModule(config)
 
-    def checkpoint_prefix(self, config: Any) -> str:
-        """Return checkpoint filename prefix."""
-        return "blcs"
-
-    def checkpoint_monitor(self, config: Any) -> str:
-        """Return metric to monitor for checkpointing."""
-        return "val/loss"
-
-    def early_stopping_monitor(self, config: Any) -> str:
-        """Return metric to monitor for early stopping."""
-        return "val/pos_error_m"
-
-    def early_stopping_patience(self, config: Any) -> int:
-        """Return early stopping patience."""
-        return 5
-
-    def early_stopping_min_delta(self, config: Any) -> float | None:
-        """Return early stopping min_delta."""
-        return 1.0e-3
-
-    def trainer_kwargs(
-        self, config: Any, accelerator: str, devices: int
-    ) -> dict[str, Any]:
-        """Return additional trainer kwargs."""
-        kwargs: dict[str, Any] = {
-            "log_every_n_steps": 50,
-        }
-        if accelerator == "gpu":
-            kwargs["precision"] = "16-mixed"
-        return kwargs
-
     def dry_run_postprocess(self, batch: Any, output_dir: Path) -> None:
         """Log model parameters after dry run batch loading."""
         # Model parameter logging is handled in build_lightning_module
@@ -83,30 +52,3 @@ class BLCSMultiViewTrainingRunner(BaseTrainingRunner):
     ) -> pl.LightningModule:
         """Build BLCS multi-view lightning module."""
         return BLCSMultiViewLightningModule(config)
-
-    def checkpoint_prefix(self, config: Any) -> str:
-        """Return checkpoint filename prefix."""
-        return "blcs-multiview"
-
-    def checkpoint_monitor(self, config: Any) -> str:
-        """Return metric to monitor for checkpointing."""
-        return "val/loss"
-
-    def early_stopping_monitor(self, config: Any) -> str:
-        """Return metric to monitor for early stopping."""
-        return "val/loss"
-
-    def early_stopping_patience(self, config: Any) -> int:
-        """Return early stopping patience."""
-        return 20
-
-    def trainer_kwargs(
-        self, config: Any, accelerator: str, devices: int
-    ) -> dict[str, Any]:
-        """Return additional trainer kwargs."""
-        kwargs: dict[str, Any] = {
-            "log_every_n_steps": 50,
-        }
-        if accelerator == "gpu":
-            kwargs["precision"] = "16-mixed"
-        return kwargs


### PR DESCRIPTION
## 概要
Issue #214 の段階移行として、まず BLCS だけ「cfg を正」にして callbacks / trainer 設定を config から駆動できるようにします。

## 変更点
- `src/base/training/runner.py`
  - `build_callbacks()` が `training.{checkpoint,early_stopping,lr_monitor}` を優先して読む（未設定は従来 hook にフォールバック）
  - `build_trainer()` が `training.trainer` を読む（未設定は `runner.trainer_kwargs()` を fallback-only で補完）
- `src/blcs/configs/training/default.yaml`
  - `training.checkpoint` / `training.early_stopping` / `training.lr_monitor` を追加
  - 提案フォーマットに合わせて、`training.log_every_n_steps` / `training.precision` を直下に追加
- `src/blcs/training/runner.py`
  - BLCS 側の callback / trainer 設定 override を削除（cfg 側に寄せる）

## 動作確認
- CPU で `run.fast_dev_run=true` の最小実行で確認
  - この環境では CUDA が不安定だったため `CUDA_VISIBLE_DEVICES=-1` を付与

## 次ステップ
- BLCS で問題なければ、他タスクも `training.*` に順次寄せ、最終的に BaseRunner のフォールバックを削除する計画です。
