### PR TITLE
#214 Unify training config format across all tasks

### DIFF
--- a/src/base/training/runner.py
+++ b/src/base/training/runner.py
@@ -303,14 +303,24 @@ class BaseTrainingRunner:
             "deterministic": True,
         }
 
-        trainer_cfg = _select("training.trainer", default={})
-        if trainer_cfg is not None:
-            if OmegaConf.is_config(trainer_cfg):
-                trainer_cfg = OmegaConf.to_container(trainer_cfg, resolve=True)
-            if isinstance(trainer_cfg, dict):
-                for key, value in trainer_cfg.items():
-                    if value is not None:
-                        base_kwargs[key] = value
+        # Prefer flattened `training.*` keys for Trainer configuration.
+        # Temporarily accept legacy `training.trainer.*` during migration.
+        trainer_keys = (
+            "precision",
+            "log_every_n_steps",
+            "deterministic",
+            "accumulate_grad_batches",
+            "val_check_interval",
+            "check_val_every_n_epoch",
+            "enable_progress_bar",
+            "strategy",
+        )
+        for key in trainer_keys:
+            value = _select(f"training.{key}", default=missing)
+            if value is missing:
+                value = _select(f"training.trainer.{key}", default=missing)
+            if value is not missing and value is not None:
+                base_kwargs[key] = value
 
         extra_kwargs = self.trainer_kwargs(config, accelerator, devices)
         for key, value in extra_kwargs.items():

--- a/src/blcs/configs/training/default.yaml
+++ b/src/blcs/configs/training/default.yaml
@@ -2,6 +2,7 @@
 max_epochs: 20
 gradient_clip_val: 1.0
 log_every_n_steps: 50
+deterministic: true
 
 # Use null for CPU compatibility. Override per run when using GPU:
 #   training.precision=16-mixed

--- a/src/court_detection/configs/training/default.yaml
+++ b/src/court_detection/configs/training/default.yaml
@@ -13,12 +13,27 @@ scheduler:
 
 gradient_clip_val: 1.0
 
+# ---- Lightning Trainer 相当（直下）----
+log_every_n_steps: 10
+check_val_every_n_epoch: 1
+precision: null
+deterministic: true
+
 early_stopping:
+  enabled: true
   patience: 20
   monitor: val/loss
   mode: min
+  min_delta: null
 
 checkpoint:
+  enabled: true
   save_top_k: 3
+  save_last: true
+  filename: "epoch_{epoch:03d}_pck_{val/pck:.4f}"
   monitor: val/pck
   mode: max
+
+lr_monitor:
+  enabled: true
+  interval: epoch

--- a/src/event_detection/configs/training/default.yaml
+++ b/src/event_detection/configs/training/default.yaml
@@ -9,3 +9,28 @@ scheduler: cosine
 # BCE-with-logits positive class weighting (per event)
 # Use 1.0 for neutral weighting.
 pos_weight: [5.0, 5.0]
+
+# ---- Lightning Trainer 相当（直下）----
+log_every_n_steps: 50
+precision: null
+deterministic: true
+
+# ---- Callbacks（BaseTrainingRunnerが参照）----
+checkpoint:
+  enabled: true
+  filename: "event-detection-{epoch:02d}"
+  monitor: val/loss
+  mode: min
+  save_top_k: 3
+  save_last: true
+
+early_stopping:
+  enabled: true
+  monitor: val/loss
+  mode: min
+  patience: 5
+  min_delta: 1.0e-3
+
+lr_monitor:
+  enabled: true
+  interval: step

--- a/src/mae/configs/training/default.yaml
+++ b/src/mae/configs/training/default.yaml
@@ -21,5 +21,27 @@ enable_progress_bar: true
 deterministic: false
 strategy: auto
 
+# ---- Callbacks（BaseTrainingRunnerが参照）----
+# NOTE: MAE also defines top-level `checkpoint`/`early_stopping` in `configs/train.yaml`.
+# These are mirrored here to standardize the per-task training format.
+checkpoint:
+  enabled: true
+  filename: "mae-{epoch:03d}-{val/loss:.4f}"
+  monitor: val/loss
+  mode: min
+  save_top_k: 3
+  save_last: true
+
+early_stopping:
+  enabled: false
+  monitor: val/loss
+  mode: min
+  patience: 50
+  min_delta: null
+
+lr_monitor:
+  enabled: true
+  interval: step
+
 # Logging
 log_reconstruction_every_n_epochs: 10

--- a/src/mae/configs/training/fast.yaml
+++ b/src/mae/configs/training/fast.yaml
@@ -21,5 +21,25 @@ enable_progress_bar: true
 deterministic: false
 strategy: auto
 
+# ---- Callbacks（BaseTrainingRunnerが参照）----
+checkpoint:
+  enabled: true
+  filename: "mae-{epoch:03d}-{val/loss:.4f}"
+  monitor: val/loss
+  mode: min
+  save_top_k: 3
+  save_last: true
+
+early_stopping:
+  enabled: false
+  monitor: val/loss
+  mode: min
+  patience: 50
+  min_delta: null
+
+lr_monitor:
+  enabled: true
+  interval: step
+
 # Logging
 log_reconstruction_every_n_epochs: 5

--- a/src/plcs/configs/training/default.yaml
+++ b/src/plcs/configs/training/default.yaml
@@ -7,3 +7,27 @@ gradient_clip_val: 1.0
 scheduler: cosine
 min_lr: 1.0e-6
 
+# ---- Lightning Trainer 相当（直下）----
+log_every_n_steps: 50
+precision: null
+deterministic: true
+
+# ---- Callbacks（BaseTrainingRunnerが参照）----
+checkpoint:
+  enabled: true
+  filename: "plcs-{epoch:02d}"
+  monitor: val/epoch_position_error_m
+  mode: min
+  save_top_k: 3
+  save_last: true
+
+early_stopping:
+  enabled: true
+  monitor: val/epoch_position_error_m
+  mode: min
+  patience: 10
+  min_delta: null
+
+lr_monitor:
+  enabled: true
+  interval: step

--- a/src/trajectory_completion/configs/training/default.yaml
+++ b/src/trajectory_completion/configs/training/default.yaml
@@ -12,3 +12,28 @@ loss:
   observed_weight: 0.1
   smoothness_weight: 0.0
   huber_delta: 0.02
+
+# ---- Lightning Trainer 相当（直下）----
+log_every_n_steps: 50
+precision: null
+deterministic: true
+
+# ---- Callbacks（BaseTrainingRunnerが参照）----
+checkpoint:
+  enabled: true
+  filename: "trajectory-completion-{epoch:02d}"
+  monitor: val/loss
+  mode: min
+  save_top_k: 3
+  save_last: true
+
+early_stopping:
+  enabled: true
+  monitor: val/loss
+  mode: min
+  patience: 5
+  min_delta: 1.0e-3
+
+lr_monitor:
+  enabled: true
+  interval: step

--- a/src/wasb/configs/training/ball_detection.yaml
+++ b/src/wasb/configs/training/ball_detection.yaml
@@ -15,9 +15,31 @@ temporal:
   beta: 25.0
   detach_conf: true
 precision: "bf16-mixed"
+log_every_n_steps: 50
+deterministic: false
 input_key: frames
 use_metrics: true
 resume:
   enabled: false
   ckpt_path: null
   auto_last: true
+
+# ---- Callbacks（BaseTrainingRunnerが参照）----
+checkpoint:
+  enabled: true
+  filename: "wasb-{epoch:02d}"
+  monitor: val/loss
+  mode: min
+  save_top_k: 3
+  save_last: true
+
+early_stopping:
+  enabled: false
+  monitor: val/loss
+  mode: min
+  patience: 0
+  min_delta: null
+
+lr_monitor:
+  enabled: true
+  interval: step


### PR DESCRIPTION
## 概要
Issue #214 の次ステップとして、全タスクの training config を同一フォーマットに揃えます。
（この後、Base runner のフォールバック削除＝完全移行に進む前提）

## 変更点
- 全タスクの `*/configs/training/*.yaml` に以下を追加/統一
  - Trainer 相当（直下）: `training.log_every_n_steps`, `training.precision`, `training.deterministic`（タスクにより必要最小限）
  - Callbacks: `training.checkpoint`, `training.early_stopping`, `training.lr_monitor`
- `src/base/training/runner.py`
  - `build_trainer()` が Trainer 設定を **`training.*` 直下を優先**して読むように変更
  - 移行期互換として `training.trainer.*` もフォールバックで受ける

## 対象タスク
- BLCS, PLCS, WASB, court_detection, trajectory_completion, event_detection, MAE

## メモ
- MAE は既存のトップレベル `checkpoint/early_stopping` も残しつつ、`training.*` にも同等設定を追加して形式統一（完全移行時に整理予定）
