### PR TITLE
feat: add ball multi-task backbone and training

### DIFF
--- a/src/ball_multitask/__init__.py
+++ b/src/ball_multitask/__init__.py
@@ -1,0 +1,10 @@
+"""Ball multi-task models for UV completion, event detection, and 3D trajectory.
+
+This package provides a shared Transformer backbone with task-specific heads
+for offline inference and training across UV/3D tasks.
+"""
+
+from src.ball_multitask.models.multitask_model import BallMultitaskModel
+
+__all__ = ["BallMultitaskModel"]
+__version__ = "0.1.0"

--- a/src/ball_multitask/configs/data/blcs_rally.yaml
+++ b/src/ball_multitask/configs/data/blcs_rally.yaml
@@ -1,0 +1,38 @@
+# BLCS rally scene dataset for multi-task training.
+
+scene_dir: data/blcs
+split:
+  train_file: train.txt
+  val_file: val.txt
+  test_file: test.txt
+
+camera_mode: random
+max_seq_len: 1024
+min_seq_len: 16
+
+batch_size: 32
+num_workers: 4
+pin_memory: true
+cache_max_scenes: 128
+
+# Scene sampler settings: none | scene | mixed | chunked
+scene_sampler_mode: chunked
+scenes_per_batch: 1
+chunk_max_scenes: 64
+
+supervise_visible_only: true
+
+corruption:
+  enabled: true
+  noise_std: 0.01
+  clamp_unit: true
+  point_dropout_prob: 0.05
+  gap_dropout_prob: 0.1
+  max_gap_len: 8
+  max_masked_ratio: 0.3
+  outlier_prob: 0.0
+
+label:
+  sigma_frames: 2.5
+  shot_time_key: "t_start"
+  bounce_time_key: "t_bounce1"

--- a/src/ball_multitask/configs/inference/default.yaml
+++ b/src/ball_multitask/configs/inference/default.yaml
@@ -1,0 +1,9 @@
+scene_path: data/blcs/scenes/rally_000000.npz
+camera: 0
+checkpoint: outputs/ball_multitask/logs/version_0/checkpoints/last.ckpt
+device: cpu
+threshold: 0.5
+min_distance: 1
+top_k: null
+denormalize: true
+output: null

--- a/src/ball_multitask/configs/metrics/default.yaml
+++ b/src/ball_multitask/configs/metrics/default.yaml
@@ -1,0 +1,4 @@
+masked_accuracy_threshold_px: 2.0
+observed_accuracy_threshold_px: 2.0
+peak_threshold: 0.5
+match_tolerance_frames: 3

--- a/src/ball_multitask/configs/model/multitask_transformer.yaml
+++ b/src/ball_multitask/configs/model/multitask_transformer.yaml
@@ -1,0 +1,36 @@
+name: multitask_transformer
+
+hidden_dim: 256
+num_layers: 6
+num_heads: 8
+ffn_dim: null
+
+dropout: 0.1
+rope_theta: 10000.0
+yarn: null
+causal: false
+max_seq_len: 1024
+
+use_moe: false
+moe:
+  moe_inter_dim: 704
+  n_routed_experts: 8
+  n_shared_experts: 2
+  n_activated_experts: 4
+  n_expert_groups: 1
+  n_limited_groups: 1
+  score_func: softmax
+  route_scale: 1.0
+
+num_register_tokens: 4
+invisible_init_std: 0.02
+
+num_events: 2
+# event_names: [shot, bounce]
+
+uv_head_hidden_dim: null
+uv_head_dropout: 0.1
+traj_head_hidden_dim: null
+traj_head_dropout: 0.1
+traj_head_layers: 2
+event_head_dropout: 0.1

--- a/src/ball_multitask/configs/predict.yaml
+++ b/src/ball_multitask/configs/predict.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - inference: default
+  - run: predict
+  - _self_
+
+hydra:
+  run:
+    dir: outputs/hydra/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/ball_multitask/configs/run/predict.yaml
+++ b/src/ball_multitask/configs/run/predict.yaml
@@ -1,0 +1,6 @@
+output_dir: outputs/ball_multitask
+seed: 42
+gpus: 0
+resume: null
+fast_dev_run: false
+dry_run: false

--- a/src/ball_multitask/configs/run/train.yaml
+++ b/src/ball_multitask/configs/run/train.yaml
@@ -1,0 +1,6 @@
+output_dir: outputs/ball_multitask
+seed: 42
+gpus: 1
+resume: null
+fast_dev_run: false
+dry_run: false

--- a/src/ball_multitask/configs/train.yaml
+++ b/src/ball_multitask/configs/train.yaml
@@ -1,0 +1,14 @@
+defaults:
+  - model: multitask_transformer
+  - data: blcs_rally
+  - training: default
+  - metrics: default
+  - run: train
+  - _self_
+
+hydra:
+  run:
+    dir: ${run.output_dir}/${now:%Y-%m-%d_%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/ball_multitask/configs/training/default.yaml
+++ b/src/ball_multitask/configs/training/default.yaml
@@ -1,0 +1,53 @@
+trainer:
+  max_epochs: 20
+  gradient_clip_val: 1.0
+  deterministic: true
+  precision: "16-mixed"
+  log_every_n_steps: 50
+  check_val_every_n_epoch: 1
+
+learning_rate: 1.0e-4
+weight_decay: 1.0e-5
+warmup_steps: 200
+scheduler: cosine
+min_lr: 1.0e-6
+
+loss:
+  uv:
+    weight: 0.3
+    masked_weight: 1.0
+    observed_weight: 0.1
+    smoothness_weight: 0.0
+    huber_delta: 0.02
+  traj3d:
+    weight: 1.0
+    position_weight: 1.0
+    velocity_weight: 0.1
+    smoothness_weight: 0.05
+  event:
+    weight_uv: 0.2
+    weight_3d: 0.2
+    pos_weight: [1.0, 1.0]
+
+curriculum:
+  uv_steps_per_3d: 4
+  start_3d_epoch: 0
+
+checkpoint:
+  enabled: true
+  filename: "ball-multitask-{epoch:02d}"
+  monitor: val/loss
+  mode: min
+  save_top_k: 3
+  save_last: true
+
+early_stopping:
+  enabled: true
+  monitor: val/loss
+  mode: min
+  patience: 5
+  min_delta: 1.0e-3
+
+lr_monitor:
+  enabled: true
+  interval: step

--- a/src/ball_multitask/data/__init__.py
+++ b/src/ball_multitask/data/__init__.py
@@ -1,0 +1,6 @@
+"""Data loading for ball multi-task training."""
+
+from src.ball_multitask.data.dataset import BallMultitaskDataset
+from src.ball_multitask.data.datamodule import BallMultitaskDataModule
+
+__all__ = ["BallMultitaskDataset", "BallMultitaskDataModule"]

--- a/src/ball_multitask/data/datamodule.py
+++ b/src/ball_multitask/data/datamodule.py
@@ -1,0 +1,166 @@
+"""PyTorch Lightning DataModule for ball multi-task training."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytorch_lightning as pl
+import torch
+from torch import Tensor
+from torch.utils.data import DataLoader
+
+from src.ball_multitask.data.dataset import BallMultitaskDataset
+from src.common.data.scene_batch_sampler import build_scene_sampler, resolve_scene_sampler_mode
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+def collate_multitask(batch: list[dict[str, Tensor]]) -> dict[str, Tensor]:
+    """Pad variable-length sequences for multi-task batches."""
+    B = len(batch)
+    max_len = max(int(s["ball_uv_gt"].shape[0]) for s in batch)
+    E = int(batch[0]["event_targets"].shape[-1])
+
+    ball_uv_in = torch.zeros(B, max_len, 2)
+    ball_uv_gt = torch.zeros(B, max_len, 2)
+    ball_vis = torch.zeros(B, max_len)
+    ball_mask = torch.zeros(B, max_len)
+    court_kp = torch.zeros(B, 20, 2)
+    court_vis = torch.zeros(B, 20)
+    position_3d = torch.zeros(B, max_len, 3)
+    ball_pos_world = torch.zeros(B, max_len, 3)
+    event_targets = torch.zeros(B, max_len, E)
+    seq_len = torch.zeros(B, dtype=torch.long)
+
+    for i, s in enumerate(batch):
+        T = int(s["ball_uv_gt"].shape[0])
+        L = int(s["seq_len"].item())
+        ball_uv_in[i, :T] = s["ball_uv_in"]
+        ball_uv_gt[i, :T] = s["ball_uv_gt"]
+        ball_vis[i, :T] = s["ball_vis"]
+        ball_mask[i, :L] = 1.0
+        court_kp[i] = s["court_kp"]
+        court_vis[i] = s["court_vis"]
+        position_3d[i, :T] = s["position_3d"]
+        ball_pos_world[i, :T] = s["ball_pos_world"]
+        event_targets[i, :T] = s["event_targets"]
+        seq_len[i] = L
+
+    return {
+        "ball_uv_in": ball_uv_in,
+        "ball_uv_gt": ball_uv_gt,
+        "ball_vis": ball_vis,
+        "ball_mask": ball_mask,
+        "court_kp": court_kp,
+        "court_vis": court_vis,
+        "position_3d": position_3d,
+        "ball_pos_world": ball_pos_world,
+        "event_targets": event_targets,
+        "seq_len": seq_len,
+    }
+
+
+class BallMultitaskDataModule(pl.LightningDataModule):
+    """DataModule for unified multi-task training."""
+
+    def __init__(self, config: DictConfig) -> None:
+        super().__init__()
+        self.config = config
+        data_cfg = config.get("data", {}) or {}
+
+        self.scene_dir = Path(str(data_cfg.get("scene_dir", "data/blcs")))
+        split_cfg = data_cfg.get("split", {}) or {}
+        self.train_file = str(split_cfg.get("train_file", "train.txt"))
+        self.val_file = str(split_cfg.get("val_file", "val.txt"))
+
+        self.batch_size = int(data_cfg.get("batch_size", 16))
+        self.num_workers = int(data_cfg.get("num_workers", 4))
+        self.pin_memory = bool(data_cfg.get("pin_memory", torch.cuda.is_available()))
+        self.scene_sampler_mode = resolve_scene_sampler_mode(data_cfg)
+        self.scenes_per_batch = int(data_cfg.get("scenes_per_batch", 1))
+        self.chunk_max_scenes = int(data_cfg.get("chunk_max_scenes", 64))
+
+        self.train_dataset: BallMultitaskDataset | None = None
+        self.val_dataset: BallMultitaskDataset | None = None
+
+    def setup(self, stage: str | None = None) -> None:
+        if not self.scene_dir.exists():
+            raise RuntimeError(
+                f"scene_dir not found: {self.scene_dir}. Run src.blcs.scripts.generate_dataset."
+            )
+
+        if stage in ("fit", None):
+            self.train_dataset = BallMultitaskDataset(
+                scene_dir=self.scene_dir,
+                split_file=self.train_file,
+                config=self.config,
+                augment=True,
+            )
+            self.val_dataset = BallMultitaskDataset(
+                scene_dir=self.scene_dir,
+                split_file=self.val_file,
+                config=self.config,
+                augment=False,
+            )
+
+    def train_dataloader(self) -> DataLoader:
+        if self.train_dataset is None:
+            raise RuntimeError("Call setup() before train_dataloader().")
+        batch_sampler = build_scene_sampler(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            mode=self.scene_sampler_mode,
+            scenes_per_batch=self.scenes_per_batch,
+            chunk_max_scenes=self.chunk_max_scenes,
+            drop_last=True,
+            shuffle=True,
+        )
+        if batch_sampler is not None:
+            return DataLoader(
+                self.train_dataset,
+                batch_sampler=batch_sampler,
+                num_workers=self.num_workers,
+                pin_memory=self.pin_memory,
+                collate_fn=collate_multitask,
+            )
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            shuffle=True,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            drop_last=True,
+            collate_fn=collate_multitask,
+        )
+
+    def val_dataloader(self) -> DataLoader:
+        if self.val_dataset is None:
+            raise RuntimeError("Call setup() before val_dataloader().")
+        batch_sampler = build_scene_sampler(
+            self.val_dataset,
+            batch_size=self.batch_size,
+            mode=self.scene_sampler_mode,
+            scenes_per_batch=self.scenes_per_batch,
+            chunk_max_scenes=self.chunk_max_scenes,
+            drop_last=False,
+            shuffle=False,
+        )
+        if batch_sampler is not None:
+            return DataLoader(
+                self.val_dataset,
+                batch_sampler=batch_sampler,
+                num_workers=self.num_workers,
+                pin_memory=self.pin_memory,
+                collate_fn=collate_multitask,
+            )
+        return DataLoader(
+            self.val_dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            drop_last=False,
+            collate_fn=collate_multitask,
+        )

--- a/src/ball_multitask/data/dataset.py
+++ b/src/ball_multitask/data/dataset.py
@@ -1,0 +1,368 @@
+"""Dataset for unified UV completion + event + 3D trajectory training."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import torch
+from torch import Tensor
+from torch.utils.data import Dataset
+
+from src.common.data.scene_cache import get_scene_cache, load_npz_scene
+from src.common.dataset.augmentation import add_gaussian_noise
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+def _load_split_file(scene_dir: Path, split_file: str | Path) -> list[Path]:
+    split_path = Path(split_file)
+    if not split_path.is_absolute():
+        split_path = scene_dir / split_file
+    if not split_path.exists():
+        return []
+    scenes_base = scene_dir / "scenes" if (scene_dir / "scenes").exists() else scene_dir
+    files: list[Path] = []
+    for line in split_path.read_text().splitlines():
+        name = line.strip()
+        if name:
+            files.append(scenes_base / name)
+    return files
+
+
+def _resolve_scenes(scene_dir: Path, split_file: str | Path | None) -> list[Path]:
+    scenes_base = scene_dir / "scenes" if (scene_dir / "scenes").exists() else scene_dir
+    if split_file is not None:
+        scenes = _load_split_file(scene_dir, split_file)
+        if scenes:
+            return scenes
+    return sorted(scenes_base.glob("*.npz"))
+
+
+def _select_camera(camera_mode: Any, num_cameras: int) -> int:
+    if camera_mode == "random":
+        return int(np.random.randint(0, num_cameras))
+    if isinstance(camera_mode, int):
+        return min(int(camera_mode), max(num_cameras - 1, 0))
+    if isinstance(camera_mode, str) and camera_mode.isdigit():
+        return min(int(camera_mode), max(num_cameras - 1, 0))
+    return 0
+
+
+@dataclass(frozen=True)
+class CorruptionConfig:
+    """Configuration for generating corrupted UV inputs."""
+
+    enabled: bool = True
+    noise_std: float = 0.01
+    clamp_unit: bool = True
+    point_dropout_prob: float = 0.05
+    gap_dropout_prob: float = 0.25
+    max_gap_len: int = 12
+    max_masked_ratio: float = 0.6
+    outlier_prob: float = 0.0
+
+
+@dataclass(frozen=True)
+class LabelConfig:
+    """Configuration for event label generation."""
+
+    sigma_frames: float = 2.5
+    shot_time_key: str = "t_start"
+    bounce_time_key: str = "t_bounce1"
+
+
+def _apply_corruption(
+    *,
+    ball_uv_gt: Tensor,
+    ball_gt_visible: Tensor,
+    cfg: CorruptionConfig,
+) -> tuple[Tensor, Tensor]:
+    """Create (ball_uv_in, ball_obs_mask) from ground-truth UV and visibility."""
+    T = ball_uv_gt.shape[0]
+    ball_uv_in = ball_uv_gt.clone()
+    ball_obs_mask = ball_gt_visible.clone()
+
+    if not cfg.enabled:
+        return ball_uv_in, ball_obs_mask
+
+    if cfg.point_dropout_prob > 0:
+        drop = (torch.rand(T, device=ball_uv_gt.device) < float(cfg.point_dropout_prob)).to(ball_obs_mask.dtype)
+        ball_obs_mask = ball_obs_mask * (1.0 - drop)
+
+    if cfg.gap_dropout_prob > 0 and cfg.max_gap_len > 0:
+        if torch.rand(1).item() < float(cfg.gap_dropout_prob):
+            gap_len = int(torch.randint(1, int(cfg.max_gap_len) + 1, (1,)).item())
+            start = int(torch.randint(0, max(1, T - gap_len + 1), (1,)).item())
+            ball_obs_mask[start : start + gap_len] = 0.0
+
+    visible_idx = torch.where(ball_gt_visible > 0)[0]
+    if visible_idx.numel() > 0 and cfg.max_masked_ratio < 1.0:
+        num_visible = int(visible_idx.numel())
+        max_masked = int(round(float(cfg.max_masked_ratio) * num_visible))
+        masked_now = int((ball_obs_mask[visible_idx] <= 0).sum().item())
+        if masked_now > max_masked:
+            masked_idx = visible_idx[ball_obs_mask[visible_idx] <= 0]
+            perm = masked_idx[torch.randperm(masked_idx.numel(), device=masked_idx.device)]
+            enable = perm[: masked_now - max_masked]
+            ball_obs_mask[enable] = 1.0
+
+    if cfg.noise_std > 0:
+        obs = ball_obs_mask > 0
+        if obs.any():
+            noisy = add_gaussian_noise(ball_uv_in[obs], float(cfg.noise_std))
+            if cfg.clamp_unit:
+                noisy = noisy.clamp(0.0, 1.0)
+            ball_uv_in[obs] = noisy
+
+    if cfg.outlier_prob > 0:
+        obs = ball_obs_mask > 0
+        if obs.any():
+            outlier = (torch.rand(T, device=ball_uv_gt.device) < float(cfg.outlier_prob)) & obs
+            if outlier.any():
+                ball_uv_in[outlier] = torch.rand(int(outlier.sum().item()), 2, device=ball_uv_gt.device)
+
+    miss = ball_obs_mask <= 0
+    if miss.any():
+        ball_uv_in[miss] = 0.0
+
+    return ball_uv_in, ball_obs_mask
+
+
+def _gaussian_soft_labels(length: int, event_indices: list[int], sigma: float, device: torch.device) -> Tensor:
+    if length <= 0:
+        return torch.zeros((0,), device=device)
+    if not event_indices:
+        return torch.zeros((length,), device=device)
+
+    t = torch.arange(length, device=device, dtype=torch.float32)
+    out = torch.zeros((length,), device=device, dtype=torch.float32)
+    denom = 2.0 * float(sigma) * float(sigma)
+    for idx in event_indices:
+        if 0 <= idx < length:
+            out = torch.maximum(out, torch.exp(-((t - float(idx)) ** 2) / denom))
+    return out
+
+
+def _extract_event_indices(meta: dict, key: str) -> list[int]:
+    shots = meta.get("shots", []) or []
+    indices: list[int] = []
+    for s in shots:
+        if not isinstance(s, dict):
+            continue
+        t = int(s.get(key, -1))
+        if t >= 0:
+            indices.append(t)
+    return indices
+
+
+class BallMultitaskDataset(Dataset):
+    """Dataset that yields UV inputs, 3D targets, and event labels per scene."""
+
+    def __init__(
+        self,
+        *,
+        scene_dir: str | Path,
+        split_file: str | Path | None,
+        config: DictConfig | None = None,
+        augment: bool = True,
+    ) -> None:
+        super().__init__()
+        self.config = config or {}
+        data_cfg = self.config.get("data", {}) if hasattr(self.config, "get") else {}
+        data_cfg = data_cfg or {}
+
+        self.scene_dir = Path(scene_dir)
+        self.scenes = _resolve_scenes(self.scene_dir, split_file)
+        if not self.scenes:
+            raise RuntimeError(f"No scenes found under {self.scene_dir}")
+
+        self.camera_mode = data_cfg.get("camera_mode", "random")
+        self.max_seq_len = int(data_cfg.get("max_seq_len", 256))
+        self.min_seq_len = int(data_cfg.get("min_seq_len", 16))
+        self.supervise_visible_only = bool(data_cfg.get("supervise_visible_only", True))
+        self.augment = bool(augment)
+        self.cache_max_scenes = int(data_cfg.get("cache_max_scenes", 128))
+        self._scene_cache = (
+            get_scene_cache(load_fn=load_npz_scene, maxsize=self.cache_max_scenes)
+            if self.cache_max_scenes > 0
+            else None
+        )
+
+        corr_cfg = data_cfg.get("corruption", {}) or {}
+        self.corruption = CorruptionConfig(
+            enabled=bool(corr_cfg.get("enabled", True)),
+            noise_std=float(corr_cfg.get("noise_std", 0.01)),
+            clamp_unit=bool(corr_cfg.get("clamp_unit", True)),
+            point_dropout_prob=float(corr_cfg.get("point_dropout_prob", 0.05)),
+            gap_dropout_prob=float(corr_cfg.get("gap_dropout_prob", 0.25)),
+            max_gap_len=int(corr_cfg.get("max_gap_len", 12)),
+            max_masked_ratio=float(corr_cfg.get("max_masked_ratio", 0.6)),
+            outlier_prob=float(corr_cfg.get("outlier_prob", 0.0)),
+        )
+
+        label_cfg = data_cfg.get("label", {}) or {}
+        self.label_cfg = LabelConfig(
+            sigma_frames=float(label_cfg.get("sigma_frames", 2.5)),
+            shot_time_key=str(label_cfg.get("shot_time_key", "t_start")),
+            bounce_time_key=str(label_cfg.get("bounce_time_key", "t_bounce1")),
+        )
+
+    def __len__(self) -> int:
+        return len(self.scenes)
+
+    def _load_scene(self, path: Path) -> tuple[dict[str, Tensor], dict]:
+        data = self._scene_cache.get(path) if self._scene_cache is not None else load_npz_scene(path)
+
+        meta_raw: Any = data.get("meta", {})
+        if isinstance(meta_raw, (bytes, bytearray)):
+            meta_raw = meta_raw.decode("utf-8")
+        if isinstance(meta_raw, str):
+            meta = json.loads(meta_raw)
+        else:
+            meta = meta_raw if isinstance(meta_raw, dict) else {}
+
+        num_cameras = int(data["num_cameras"])
+        cam_idx = _select_camera(self.camera_mode, num_cameras)
+        prefix = f"cam_{cam_idx}_"
+
+        ball_uv = torch.from_numpy(data[f"{prefix}ball_uv"]).float()
+        ball_visible = torch.from_numpy(data[f"{prefix}ball_visible"]).to(torch.float32)
+        court_kp = torch.from_numpy(data[f"{prefix}court_kp_uv"]).float()
+        court_vis = torch.from_numpy(data[f"{prefix}court_kp_visible"]).to(torch.float32)
+
+        pos_norm = torch.from_numpy(data["ball_pos_norm"]).float()
+        if "ball_pos_world" in data:
+            pos_world = torch.from_numpy(data["ball_pos_world"]).float()
+        else:
+            pos_world = pos_norm.clone()
+
+        seq_len = int(meta.get("num_frames", ball_uv.shape[0]))
+        seq_len = min(seq_len, int(ball_uv.shape[0]))
+
+        return (
+            {
+                "ball_uv_gt": ball_uv,
+                "ball_visible": ball_visible,
+                "court_kp": court_kp,
+                "court_vis": court_vis,
+                "position_3d": pos_norm,
+                "ball_pos_world": pos_world,
+                "seq_len": torch.tensor(seq_len, dtype=torch.long),
+            },
+            meta,
+        )
+
+    def _crop(self, sample: dict[str, Tensor]) -> tuple[dict[str, Tensor], int]:
+        T = int(sample["ball_uv_gt"].shape[0])
+        seq_len = int(sample["seq_len"].item())
+
+        if seq_len < self.min_seq_len:
+            seq_len = min(self.min_seq_len, T)
+            sample["seq_len"] = torch.tensor(seq_len, dtype=torch.long)
+
+        if T <= self.max_seq_len:
+            return sample, 0
+
+        crop_len = self.max_seq_len
+        max_start = max(0, seq_len - crop_len)
+        if self.augment and max_start > 0:
+            start = int(torch.randint(0, max_start + 1, (1,)).item())
+        else:
+            start = max_start // 2
+        end = start + crop_len
+
+        sample["ball_uv_gt"] = sample["ball_uv_gt"][start:end]
+        sample["ball_visible"] = sample["ball_visible"][start:end]
+        sample["position_3d"] = sample["position_3d"][start:end]
+        sample["ball_pos_world"] = sample["ball_pos_world"][start:end]
+        sample["seq_len"] = torch.clamp(sample["seq_len"] - start, min=0, max=crop_len)
+        return sample, start
+
+    def __getitem__(self, idx: int) -> dict[str, Tensor]:
+        sample, meta = self._load_scene(self.scenes[idx])
+        sample, offset = self._crop(sample)
+
+        ball_uv_gt = sample["ball_uv_gt"]
+        seq_len = int(sample["seq_len"].item())
+        ball_visible = sample["ball_visible"]
+
+        valid_t = torch.arange(ball_uv_gt.shape[0]) < seq_len
+        if self.supervise_visible_only:
+            ball_gt_visible = (ball_visible > 0).to(torch.float32) * valid_t.to(torch.float32)
+        else:
+            ball_gt_visible = valid_t.to(torch.float32)
+
+        if self.augment:
+            ball_uv_in, ball_obs_mask = _apply_corruption(
+                ball_uv_gt=ball_uv_gt,
+                ball_gt_visible=ball_gt_visible,
+                cfg=self.corruption,
+            )
+        else:
+            ball_uv_in = ball_uv_gt.clone()
+            ball_obs_mask = ball_gt_visible.clone()
+
+        device = torch.device("cpu")
+        shot_indices = _extract_event_indices(meta, self.label_cfg.shot_time_key)
+        bounce_indices = _extract_event_indices(meta, self.label_cfg.bounce_time_key)
+        if offset > 0:
+            shot_indices = [t - offset for t in shot_indices if offset <= t < offset + ball_uv_gt.shape[0]]
+            bounce_indices = [t - offset for t in bounce_indices if offset <= t < offset + ball_uv_gt.shape[0]]
+
+        y_shot = _gaussian_soft_labels(
+            length=ball_uv_gt.shape[0],
+            event_indices=shot_indices,
+            sigma=self.label_cfg.sigma_frames,
+            device=device,
+        )
+        y_bounce = _gaussian_soft_labels(
+            length=ball_uv_gt.shape[0],
+            event_indices=bounce_indices,
+            sigma=self.label_cfg.sigma_frames,
+            device=device,
+        )
+        targets = torch.stack([y_shot, y_bounce], dim=-1)
+
+        return {
+            "ball_uv_in": ball_uv_in,
+            "ball_vis": ball_obs_mask,
+            "ball_uv_gt": ball_uv_gt,
+            "court_kp": sample["court_kp"],
+            "court_vis": sample["court_vis"],
+            "position_3d": sample["position_3d"],
+            "ball_pos_world": sample["ball_pos_world"],
+            "event_targets": targets,
+            "seq_len": sample["seq_len"],
+        }
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir)
+        scene = base / "scene_000.npz"
+        T = 8
+        meta = {"num_frames": T, "shots": [{"t_start": 2, "t_bounce1": 5}]}
+        np.savez(
+            scene,
+            meta=json.dumps(meta),
+            num_cameras=np.array(1),
+            cam_0_ball_uv=np.zeros((T, 2), dtype=np.float32),
+            cam_0_ball_visible=np.ones((T,), dtype=np.float32),
+            cam_0_court_kp_uv=np.zeros((20, 2), dtype=np.float32),
+            cam_0_court_kp_visible=np.ones((20,), dtype=np.float32),
+            ball_pos_norm=np.zeros((T, 3), dtype=np.float32),
+            ball_pos_world=np.zeros((T, 3), dtype=np.float32),
+        )
+        cfg = {"data": {"max_seq_len": 8, "cache_max_scenes": 0}}
+        ds = BallMultitaskDataset(scene_dir=base, split_file=None, config=cfg, augment=False)
+        sample = ds[0]
+        assert sample["ball_uv_in"].shape == (T, 2)
+        assert sample["event_targets"].shape == (T, 2)
+        print("ball_multitask.dataset smoke ok")

--- a/src/ball_multitask/inference/__init__.py
+++ b/src/ball_multitask/inference/__init__.py
@@ -1,0 +1,5 @@
+"""Inference utilities for ball multi-task models."""
+
+from src.ball_multitask.inference.predictor import BallMultitaskPredictor
+
+__all__ = ["BallMultitaskPredictor"]

--- a/src/ball_multitask/inference/predictor.py
+++ b/src/ball_multitask/inference/predictor.py
@@ -1,0 +1,154 @@
+"""Offline predictor for ball multi-task models."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Self
+
+import torch
+from torch import Tensor
+
+from src.base.inference.predictor import BasePredictor
+from src.ball_multitask.models.multitask_model import BallMultitaskModel
+from src.ball_multitask.training.lightning_module import BallMultitaskLightningModule
+from src.event_detection.utils.peaks import extract_event_peaks
+from src.utils.geometry.constants import COURT_COORD_SCALE_XYZ
+
+
+class BallMultitaskPredictor(BasePredictor):
+    """Offline predictor returning UV completion, 3D trajectory, and event peaks."""
+
+    def __init__(
+        self,
+        model: BallMultitaskModel,
+        device: torch.device,
+        *,
+        norm_scale_xyz: tuple[float, float, float] = COURT_COORD_SCALE_XYZ,
+        event_names: list[str] | None = None,
+    ) -> None:
+        self.model = model.to(device)
+        self.device = device
+        self.norm_scale_xyz = norm_scale_xyz
+        self.model.eval()
+        if event_names is None:
+            event_names = [f"event_{i}" for i in range(int(self.model.num_events))]
+        self.event_names = event_names
+
+    @classmethod
+    def load_from_checkpoint(
+        cls,
+        checkpoint_path: str | Path,
+        device: str | torch.device = "cpu",
+        **kwargs: Any,
+    ) -> Self:
+        _ = kwargs
+        checkpoints = cls._ensure_checkpoint(checkpoint_path)
+        if len(checkpoints) != 1:
+            raise ValueError("BallMultitaskPredictor expects a single checkpoint path.")
+        device = cls._resolve_device(device)
+        lightning_module = BallMultitaskLightningModule.load_from_checkpoint(
+            checkpoints[0],
+            map_location=device,
+        )
+        model = lightning_module.model
+        event_names = None
+        if hasattr(lightning_module, "config"):
+            model_cfg = lightning_module.config.get("model", {}) or {}
+            names = model_cfg.get("event_names")
+            if names:
+                event_names = [str(name) for name in names]
+        return cls(model=model, device=device, event_names=event_names)
+
+    @torch.no_grad()
+    def predict(
+        self,
+        ball_uv: Tensor,
+        court_kp: Tensor,
+        *,
+        ball_vis: Tensor | None = None,
+        ball_mask: Tensor | None = None,
+        court_vis: Tensor | None = None,
+        seq_len: Tensor | None = None,
+        threshold: float = 0.5,
+        min_distance: int = 1,
+        top_k: int | None = None,
+        denormalize: bool = True,
+    ) -> dict[str, Any]:
+        """Run offline inference on UV inputs."""
+        if ball_vis is None and ball_mask is not None:
+            ball_vis, ball_mask = ball_mask, None
+
+        if ball_uv.dim() == 2:
+            ball_uv = ball_uv.unsqueeze(0)
+        if court_kp.dim() == 2:
+            court_kp = court_kp.unsqueeze(0)
+        if ball_vis is not None and ball_vis.dim() == 1:
+            ball_vis = ball_vis.unsqueeze(0)
+        if ball_mask is not None and ball_mask.dim() == 1:
+            ball_mask = ball_mask.unsqueeze(0)
+        if court_vis is not None and court_vis.dim() == 1:
+            court_vis = court_vis.unsqueeze(0)
+        if seq_len is not None and seq_len.dim() == 0:
+            seq_len = seq_len.unsqueeze(0)
+
+        ball_uv, court_kp, ball_vis, court_vis = self._to_device(
+            self.device, ball_uv, court_kp, ball_vis, court_vis
+        )
+        if ball_mask is not None:
+            ball_mask = ball_mask.to(self.device)
+        if seq_len is not None:
+            seq_len = seq_len.to(self.device)
+
+        outputs = self.model.predict_uv(
+            ball_uv,
+            court_kp,
+            ball_vis=ball_vis,
+            ball_mask=ball_mask,
+            court_vis=court_vis,
+            seq_len=seq_len,
+        )
+
+        uv_completed = outputs["uv_completed"]
+        pos3d = outputs["position_3d"]
+        logits = outputs["event_logits"]
+        probs = torch.sigmoid(logits)
+
+        peaks, peak_scores = extract_event_peaks(
+            probs,
+            seq_len,
+            threshold=float(threshold),
+            min_distance=int(min_distance),
+            top_k=top_k,
+        )
+
+        if denormalize:
+            pos3d = self._denormalize_position(pos3d)
+
+        return {
+            "uv_completed": uv_completed.cpu(),
+            "position_3d": pos3d.cpu(),
+            "event_logits": logits.cpu(),
+            "event_probs": probs.cpu(),
+            "event_peaks": peaks,
+            "event_peak_scores": peak_scores,
+            "event_names": list(self.event_names),
+        }
+
+    def _denormalize_position(self, position: Tensor) -> Tensor:
+        scale = torch.tensor(
+            list(self.norm_scale_xyz),
+            device=position.device,
+            dtype=position.dtype,
+        )
+        return position * scale
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    model = BallMultitaskModel.from_config({"model": {"hidden_dim": 32, "num_layers": 2, "num_heads": 4}})
+    predictor = BallMultitaskPredictor(model=model, device=torch.device("cpu"))
+    ball_uv = torch.rand(1, 8, 2)
+    court_kp = torch.rand(1, 20, 2)
+    out = predictor.predict(ball_uv, court_kp)
+    assert out["uv_completed"].shape == (1, 8, 2)
+    print("ball_multitask.predictor smoke ok")

--- a/src/ball_multitask/models/__init__.py
+++ b/src/ball_multitask/models/__init__.py
@@ -1,0 +1,6 @@
+"""Model components for ball multi-task learning."""
+
+from src.ball_multitask.models.backbone import BallMultitaskBackbone
+from src.ball_multitask.models.multitask_model import BallMultitaskModel
+
+__all__ = ["BallMultitaskBackbone", "BallMultitaskModel"]

--- a/src/ball_multitask/models/adapters/__init__.py
+++ b/src/ball_multitask/models/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Adapters for converting inputs into backbone token embeddings."""
+
+from src.ball_multitask.models.adapters.ball_3d_adapter import Ball3DTokenAdapter
+
+__all__ = ["Ball3DTokenAdapter"]

--- a/src/ball_multitask/models/adapters/ball_3d_adapter.py
+++ b/src/ball_multitask/models/adapters/ball_3d_adapter.py
@@ -1,0 +1,39 @@
+"""3D ball trajectory adapter for token embeddings."""
+
+from __future__ import annotations
+
+from torch import Tensor
+import torch.nn as nn
+
+from src.common.models.embeddings import Ball3DEmbedding, InvisibleTokenEmbedding
+
+
+class Ball3DTokenAdapter(nn.Module):
+    """Adapter that maps 3D ball positions to backbone token embeddings."""
+
+    def __init__(self, dim: int, dropout: float, invisible_token: InvisibleTokenEmbedding) -> None:
+        super().__init__()
+        self.embed = Ball3DEmbedding(dim=int(dim), dropout=float(dropout), invisible_token=invisible_token)
+
+    def forward(self, ball_pos: Tensor, ball_vis: Tensor | None = None) -> Tensor:
+        """Forward.
+
+        Args:
+            ball_pos: Ball positions, shape (B, T, 3).
+            ball_vis: Optional visibility mask, shape (B, T).
+
+        Returns:
+            Embedded tokens, shape (B, T, D).
+        """
+        return self.embed(ball_pos, ball_vis)
+
+
+if __name__ == "__main__":
+    import torch
+
+    invisible = InvisibleTokenEmbedding(dim=16)
+    adapter = Ball3DTokenAdapter(dim=16, dropout=0.0, invisible_token=invisible)
+    x = torch.randn(2, 8, 3)
+    y = adapter(x)
+    assert y.shape == (2, 8, 16)
+    print("ball_3d_adapter smoke ok")

--- a/src/ball_multitask/models/backbone.py
+++ b/src/ball_multitask/models/backbone.py
@@ -1,0 +1,360 @@
+"""Shared backbone for ball multi-task learning."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from src.ball_multitask.models.adapters.ball_3d_adapter import Ball3DTokenAdapter
+from src.common.models import (
+    MoEConfig,
+    RMSNorm,
+    TransformerBlock,
+    TransformerBlockConfig,
+    YaRNConfig,
+    precompute_freqs_cis,
+)
+from src.common.models.embeddings import BallUVEmbedding, CourtKPUVEmbedding, InvisibleTokenEmbedding
+from src.utils.geometry import NUM_COURT_KP
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+class BallMultitaskBackbone(nn.Module):
+    """Shared Transformer backbone for UV/3D ball tasks.
+
+    Token layout: [REG*, COURT(20), BALL(T)]
+    Returns per-frame ball token features.
+    """
+
+    def __init__(
+        self,
+        *,
+        hidden_dim: int = 256,
+        num_layers: int = 6,
+        num_heads: int = 8,
+        ffn_dim: int | None = None,
+        dropout: float = 0.1,
+        rope_dim: int | None = None,
+        rope_theta: float = 10000.0,
+        yarn: YaRNConfig | None = None,
+        use_moe: bool = False,
+        moe_config: MoEConfig | None = None,
+        causal: bool = False,
+        max_seq_len: int = 256,
+        num_register_tokens: int = 0,
+        invisible_init_std: float = 0.02,
+    ) -> None:
+        super().__init__()
+
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads.")
+        if use_moe and moe_config is None:
+            raise ValueError("use_moe=True requires moe_config.")
+
+        self.hidden_dim = int(hidden_dim)
+        self.max_seq_len = int(max_seq_len)
+        self.num_register_tokens = int(num_register_tokens)
+        self.causal = bool(causal)
+
+        head_dim = int(hidden_dim // num_heads)
+        self.rope_dim = int(rope_dim) if rope_dim is not None else head_dim
+        self.rope_theta = float(rope_theta)
+        self.yarn = yarn
+        self.max_tokens = int(NUM_COURT_KP + self.max_seq_len)
+
+        if ffn_dim is None:
+            ffn_dim = int((8 * hidden_dim) / 3)
+            ffn_dim = (ffn_dim + 63) // 64 * 64
+
+        if moe_config is not None and moe_config.dim != hidden_dim:
+            raise ValueError("moe_config.dim must match hidden_dim.")
+        if self.num_register_tokens < 0:
+            raise ValueError("num_register_tokens must be >= 0.")
+
+        self.invisible_token = InvisibleTokenEmbedding(
+            dim=self.hidden_dim, init_std=float(invisible_init_std)
+        )
+        self.court_embed = CourtKPUVEmbedding(
+            dim=self.hidden_dim,
+            dropout=float(dropout),
+            invisible_token=self.invisible_token,
+        )
+        self.ball_uv_embed = BallUVEmbedding(
+            dim=self.hidden_dim,
+            dropout=float(dropout),
+            invisible_token=self.invisible_token,
+        )
+        self.ball_3d_adapter = Ball3DTokenAdapter(
+            dim=self.hidden_dim,
+            dropout=float(dropout),
+            invisible_token=self.invisible_token,
+        )
+
+        self.type_embed = nn.Embedding(2, self.hidden_dim)
+
+        if self.num_register_tokens > 0:
+            self.register_tokens = nn.Parameter(
+                torch.zeros(1, self.num_register_tokens, self.hidden_dim)
+            )
+            nn.init.trunc_normal_(self.register_tokens, std=0.02)
+
+        self.learned_court_tokens = nn.Parameter(
+            torch.zeros(1, NUM_COURT_KP, self.hidden_dim)
+        )
+        nn.init.trunc_normal_(self.learned_court_tokens, std=0.02)
+
+        self.blocks = nn.ModuleList(
+            [
+                TransformerBlock(
+                    TransformerBlockConfig(
+                        dim=self.hidden_dim,
+                        n_heads=int(num_heads),
+                        mlp_inter_dim=int(ffn_dim),
+                        head_dim=head_dim,
+                        rope_dim=self.rope_dim,
+                        attn_dropout=float(dropout),
+                        rope_base=self.rope_theta,
+                        yarn=self.yarn,
+                        use_moe=bool(use_moe),
+                        moe_config=moe_config,
+                    )
+                )
+                for _ in range(int(num_layers))
+            ]
+        )
+        self.final_norm = RMSNorm(self.hidden_dim)
+
+        freqs_cis = precompute_freqs_cis(
+            dim=self.rope_dim,
+            seqlen=self.max_tokens,
+            base=self.rope_theta,
+            yarn=self.yarn,
+            device=None,
+        )
+        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+
+    @classmethod
+    def from_config(cls, config: DictConfig) -> "BallMultitaskBackbone":
+        """Create backbone from configuration."""
+        model_cfg = config.get("model", {}) or {}
+        yarn_cfg = model_cfg.get("yarn")
+        yarn: YaRNConfig | None = None
+        if yarn_cfg is not None:
+            yarn_cfg = dict(yarn_cfg)
+            if yarn_cfg.get("original_seq_len", None) is not None:
+                yarn = YaRNConfig(**yarn_cfg)
+
+        use_moe = bool(model_cfg.get("use_moe", False))
+        moe_cfg = model_cfg.get("moe_config", None) or model_cfg.get("moe", None)
+        moe_config: MoEConfig | None = None
+        if use_moe and moe_cfg is not None:
+            moe_config = MoEConfig(dim=int(model_cfg.get("hidden_dim", 256)), **dict(moe_cfg))
+
+        return cls(
+            hidden_dim=int(model_cfg.get("hidden_dim", 256)),
+            num_layers=int(model_cfg.get("num_layers", 6)),
+            num_heads=int(model_cfg.get("num_heads", 8)),
+            ffn_dim=model_cfg.get("ffn_dim", None),
+            dropout=float(model_cfg.get("dropout", 0.1)),
+            rope_dim=model_cfg.get("rope_dim", None),
+            rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            yarn=yarn,
+            use_moe=use_moe,
+            moe_config=moe_config,
+            causal=bool(model_cfg.get("causal", False)),
+            max_seq_len=int(model_cfg.get("max_seq_len", 256)),
+            num_register_tokens=int(model_cfg.get("num_register_tokens", 0)),
+            invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
+        )
+
+    def forward_uv(
+        self,
+        ball_uv: Tensor,
+        court_kp: Tensor,
+        *,
+        ball_vis: Tensor | None = None,
+        ball_mask: Tensor | None = None,
+        court_vis: Tensor | None = None,
+        seq_len: Tensor | None = None,
+    ) -> Tensor:
+        """Encode UV input into ball token features."""
+        ball_uv, ball_vis, ball_mask, seq_len = self._clip_sequence(
+            ball_uv, ball_vis, ball_mask, seq_len
+        )
+        B, T, _ = ball_uv.shape
+
+        court_tokens = self.court_embed(court_kp, court_vis)
+        ball_tokens = self.ball_uv_embed(ball_uv, ball_vis)
+        return self._forward_tokens(
+            ball_tokens=ball_tokens,
+            court_tokens=court_tokens,
+            ball_mask=ball_mask,
+            seq_len=seq_len,
+            batch_size=B,
+            seq_len_t=T,
+        )
+
+    def forward_3d(
+        self,
+        ball_pos: Tensor,
+        *,
+        ball_vis: Tensor | None = None,
+        ball_mask: Tensor | None = None,
+        seq_len: Tensor | None = None,
+    ) -> Tensor:
+        """Encode 3D input into ball token features."""
+        ball_pos, ball_vis, ball_mask, seq_len = self._clip_sequence(
+            ball_pos, ball_vis, ball_mask, seq_len
+        )
+        B, T, _ = ball_pos.shape
+
+        court_tokens = self.learned_court_tokens.expand(B, -1, -1)
+        ball_tokens = self.ball_3d_adapter(ball_pos, ball_vis)
+        return self._forward_tokens(
+            ball_tokens=ball_tokens,
+            court_tokens=court_tokens,
+            ball_mask=ball_mask,
+            seq_len=seq_len,
+            batch_size=B,
+            seq_len_t=T,
+        )
+
+    def _forward_tokens(
+        self,
+        *,
+        ball_tokens: Tensor,
+        court_tokens: Tensor,
+        ball_mask: Tensor | None,
+        seq_len: Tensor | None,
+        batch_size: int,
+        seq_len_t: int,
+    ) -> Tensor:
+        court_type = self.type_embed(
+            torch.zeros(NUM_COURT_KP, device=ball_tokens.device, dtype=torch.long)
+        )[None, :, :]
+        ball_type = self.type_embed(
+            torch.ones(seq_len_t, device=ball_tokens.device, dtype=torch.long)
+        )[None, :, :]
+
+        token_body = torch.cat(
+            [court_tokens + court_type, ball_tokens + ball_type], dim=1
+        )
+        if self.num_register_tokens > 0:
+            reg = self.register_tokens.expand(batch_size, -1, -1)
+            x = torch.cat([reg, token_body], dim=1)
+        else:
+            x = token_body
+
+        freqs_cis = self._build_freqs(token_body, x.device)
+        attn_mask = self._build_attn_mask(
+            batch_size=batch_size,
+            seq_len_t=seq_len_t,
+            ball_mask=ball_mask,
+            seq_len=seq_len,
+            device=x.device,
+        )
+
+        residual = None
+        for block in self.blocks:
+            x, residual = block(
+                x,
+                residual,
+                start_pos=0,
+                freqs_cis=freqs_cis,
+                attn_mask=attn_mask,
+                is_causal=self.causal,
+            )
+
+        if residual is None:
+            x = self.final_norm(x)
+        else:
+            x, _ = self.final_norm(x, residual)
+
+        ball_start = self.num_register_tokens + NUM_COURT_KP
+        return x[:, ball_start:, :]
+
+    def _build_freqs(self, token_body: Tensor, device: torch.device) -> Tensor:
+        S_body = token_body.shape[1]
+        if S_body > self.freqs_cis.shape[0]:
+            raise ValueError(
+                "Sequence length exceeds cached freqs_cis length. Increase max_seq_len."
+            )
+        freqs_cis_body = self.freqs_cis[:S_body]
+        if freqs_cis_body.device != device:
+            freqs_cis_body = freqs_cis_body.to(device)
+        if self.num_register_tokens <= 0:
+            return freqs_cis_body
+
+        prefix_freqs = torch.ones(
+            self.num_register_tokens,
+            freqs_cis_body.shape[1],
+            device=device,
+            dtype=freqs_cis_body.dtype,
+        )
+        return torch.cat([prefix_freqs, freqs_cis_body], dim=0)
+
+    def _build_attn_mask(
+        self,
+        *,
+        batch_size: int,
+        seq_len_t: int,
+        ball_mask: Tensor | None,
+        seq_len: Tensor | None,
+        device: torch.device,
+    ) -> Tensor | None:
+        if ball_mask is None and seq_len is not None:
+            t = torch.arange(seq_len_t, device=device)[None, :]
+            ball_mask = t < seq_len.to(torch.long).view(batch_size, 1)
+
+        if ball_mask is None:
+            return None
+
+        court_valid = torch.ones(batch_size, NUM_COURT_KP, device=device, dtype=torch.bool)
+        ball_valid = ball_mask > 0
+        if self.num_register_tokens > 0:
+            reg_valid = torch.ones(
+                batch_size, self.num_register_tokens, device=device, dtype=torch.bool
+            )
+            key_padding_mask = torch.cat([reg_valid, court_valid, ball_valid], dim=1)
+        else:
+            key_padding_mask = torch.cat([court_valid, ball_valid], dim=1)
+
+        S = key_padding_mask.shape[1]
+        return key_padding_mask[:, None, :].expand(batch_size, S, S)
+
+    def _clip_sequence(
+        self,
+        ball_seq: Tensor,
+        ball_vis: Tensor | None,
+        ball_mask: Tensor | None,
+        seq_len: Tensor | None,
+    ) -> tuple[Tensor, Tensor | None, Tensor | None, Tensor | None]:
+        if ball_seq.shape[1] <= self.max_seq_len:
+            return ball_seq, ball_vis, ball_mask, seq_len
+
+        ball_seq = ball_seq[:, : self.max_seq_len]
+        if ball_vis is not None:
+            ball_vis = ball_vis[:, : self.max_seq_len]
+        if ball_mask is not None:
+            ball_mask = ball_mask[:, : self.max_seq_len]
+        if seq_len is not None:
+            seq_len = torch.clamp(seq_len, max=self.max_seq_len)
+        return ball_seq, ball_vis, ball_mask, seq_len
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    model = BallMultitaskBackbone(hidden_dim=64, num_layers=2, num_heads=4, max_seq_len=16)
+    ball_uv = torch.randn(2, 8, 2)
+    court_kp = torch.randn(2, NUM_COURT_KP, 2)
+    out = model.forward_uv(ball_uv, court_kp)
+    assert out.shape == (2, 8, 64)
+    ball_pos = torch.randn(2, 8, 3)
+    out3 = model.forward_3d(ball_pos)
+    assert out3.shape == (2, 8, 64)
+    print("backbone smoke ok")

--- a/src/ball_multitask/models/heads/__init__.py
+++ b/src/ball_multitask/models/heads/__init__.py
@@ -1,0 +1,7 @@
+"""Task-specific heads for ball multi-task models."""
+
+from src.ball_multitask.models.heads.trajectory_head import Trajectory3DHeadAdapter
+from src.ball_multitask.models.heads.uv_head import UVCompletionHead
+from src.ball_multitask.models.heads.event_head import EventLogitsHeadAdapter
+
+__all__ = ["UVCompletionHead", "Trajectory3DHeadAdapter", "EventLogitsHeadAdapter"]

--- a/src/ball_multitask/models/heads/event_head.py
+++ b/src/ball_multitask/models/heads/event_head.py
@@ -1,0 +1,41 @@
+"""Event logits head adapter for multi-task learning."""
+
+from __future__ import annotations
+
+import torch.nn as nn
+from torch import Tensor
+
+from src.event_detection.models.components.heads import EventLogitsHead
+
+
+class EventLogitsHeadAdapter(nn.Module):
+    """Predict per-frame event logits from sequence features."""
+
+    def __init__(self, input_dim: int, num_events: int, dropout: float = 0.1) -> None:
+        super().__init__()
+        self.head = EventLogitsHead(
+            input_dim=int(input_dim),
+            num_events=int(num_events),
+            dropout=float(dropout),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward.
+
+        Args:
+            x: Hidden states, shape (B, T, D).
+
+        Returns:
+            Event logits, shape (B, T, E).
+        """
+        return self.head(x)
+
+
+if __name__ == "__main__":
+    import torch
+
+    head = EventLogitsHeadAdapter(input_dim=32, num_events=2, dropout=0.0)
+    x = torch.randn(2, 8, 32)
+    y = head(x)
+    assert y.shape == (2, 8, 2)
+    print("event_head smoke ok")

--- a/src/ball_multitask/models/heads/trajectory_head.py
+++ b/src/ball_multitask/models/heads/trajectory_head.py
@@ -1,0 +1,54 @@
+"""Trajectory head adapter for multi-task learning."""
+
+from __future__ import annotations
+
+import torch.nn as nn
+from torch import Tensor
+
+from src.blcs.models.components.heads import Trajectory3DHead
+
+
+class Trajectory3DHeadAdapter(nn.Module):
+    """Predict 3D ball trajectories from sequence features.
+
+    Wraps the BLCS Trajectory3DHead to keep configuration local to
+    the multi-task model.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dim: int | None = None,
+        dropout: float = 0.1,
+        num_layers: int = 2,
+    ) -> None:
+        super().__init__()
+        hidden_dim_value = int(hidden_dim) if hidden_dim is not None else int(input_dim // 2)
+        self.head = Trajectory3DHead(
+            input_dim=int(input_dim),
+            hidden_dim=hidden_dim_value,
+            output_dim=3,
+            num_layers=int(num_layers),
+            dropout=float(dropout),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward.
+
+        Args:
+            x: Hidden states, shape (B, T, D).
+
+        Returns:
+            3D trajectory predictions, shape (B, T, 3).
+        """
+        return self.head(x)
+
+
+if __name__ == "__main__":
+    import torch
+
+    head = Trajectory3DHeadAdapter(input_dim=64, dropout=0.0)
+    x = torch.randn(2, 8, 64)
+    y = head(x)
+    assert y.shape == (2, 8, 3)
+    print("trajectory_head smoke ok")

--- a/src/ball_multitask/models/heads/uv_head.py
+++ b/src/ball_multitask/models/heads/uv_head.py
@@ -1,0 +1,47 @@
+"""UV completion head for multi-task learning."""
+
+from __future__ import annotations
+
+import torch.nn as nn
+from torch import Tensor
+
+
+class UVCompletionHead(nn.Module):
+    """Predict completed UV trajectories from sequence features.
+
+    Args:
+        input_dim: Input hidden dimension.
+        hidden_dim: Hidden dimension for the head MLP.
+        dropout: Dropout probability.
+    """
+
+    def __init__(self, input_dim: int, hidden_dim: int | None = None, dropout: float = 0.1) -> None:
+        super().__init__()
+        hidden_dim = int(hidden_dim) if hidden_dim is not None else int(input_dim)
+        self.net = nn.Sequential(
+            nn.Linear(int(input_dim), hidden_dim),
+            nn.GELU(),
+            nn.Dropout(float(dropout)),
+            nn.Linear(hidden_dim, 2),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward.
+
+        Args:
+            x: Hidden states, shape (B, T, D).
+
+        Returns:
+            Completed UV predictions, shape (B, T, 2).
+        """
+        return self.net(x)
+
+
+if __name__ == "__main__":
+    import torch
+
+    head = UVCompletionHead(input_dim=32, dropout=0.0)
+    x = torch.randn(2, 8, 32)
+    y = head(x)
+    assert y.shape == (2, 8, 2)
+    print("uv_head smoke ok")

--- a/src/ball_multitask/models/multitask_model.py
+++ b/src/ball_multitask/models/multitask_model.py
@@ -1,0 +1,191 @@
+"""Multi-task model that shares a backbone across UV/3D tasks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from src.ball_multitask.models.backbone import BallMultitaskBackbone
+from src.ball_multitask.models.heads.event_head import EventLogitsHeadAdapter
+from src.ball_multitask.models.heads.trajectory_head import Trajectory3DHeadAdapter
+from src.ball_multitask.models.heads.uv_head import UVCompletionHead
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+class BallMultitaskModel(nn.Module):
+    """Unified model for UV completion, UV→3D, and event detection."""
+
+    def __init__(
+        self,
+        *,
+        backbone: BallMultitaskBackbone,
+        num_events: int = 2,
+        uv_head_hidden_dim: int | None = None,
+        uv_head_dropout: float = 0.1,
+        traj_head_hidden_dim: int | None = None,
+        traj_head_dropout: float = 0.1,
+        traj_head_layers: int = 2,
+        event_head_dropout: float = 0.1,
+        event_names: list[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self.backbone = backbone
+        self.num_events = int(num_events)
+        self.event_names = event_names
+
+        self.uv_head = UVCompletionHead(
+            input_dim=int(backbone.hidden_dim),
+            hidden_dim=uv_head_hidden_dim,
+            dropout=uv_head_dropout,
+        )
+        self.traj_head = Trajectory3DHeadAdapter(
+            input_dim=int(backbone.hidden_dim),
+            hidden_dim=traj_head_hidden_dim,
+            dropout=traj_head_dropout,
+            num_layers=traj_head_layers,
+        )
+        self.event_head = EventLogitsHeadAdapter(
+            input_dim=int(backbone.hidden_dim),
+            num_events=self.num_events,
+            dropout=event_head_dropout,
+        )
+
+    @classmethod
+    def from_config(cls, config: DictConfig) -> "BallMultitaskModel":
+        """Create model from configuration."""
+        model_cfg = config.get("model", {}) or {}
+        backbone = BallMultitaskBackbone.from_config(config)
+        event_names = model_cfg.get("event_names")
+        if event_names is not None:
+            event_names = [str(name) for name in event_names]
+        return cls(
+            backbone=backbone,
+            num_events=int(model_cfg.get("num_events", 2)),
+            uv_head_hidden_dim=model_cfg.get("uv_head_hidden_dim"),
+            uv_head_dropout=float(model_cfg.get("uv_head_dropout", model_cfg.get("dropout", 0.1))),
+            traj_head_hidden_dim=model_cfg.get("traj_head_hidden_dim"),
+            traj_head_dropout=float(model_cfg.get("traj_head_dropout", model_cfg.get("dropout", 0.1))),
+            traj_head_layers=int(model_cfg.get("traj_head_layers", 2)),
+            event_head_dropout=float(model_cfg.get("event_head_dropout", model_cfg.get("dropout", 0.1))),
+            event_names=event_names,
+        )
+
+    def forward(
+        self,
+        *,
+        input_type: Literal["uv", "3d"] = "uv",
+        ball_uv: Tensor | None = None,
+        court_kp: Tensor | None = None,
+        ball_pos: Tensor | None = None,
+        ball_vis: Tensor | None = None,
+        ball_mask: Tensor | None = None,
+        court_vis: Tensor | None = None,
+        seq_len: Tensor | None = None,
+    ) -> dict[str, Tensor]:
+        """Forward with explicit input type."""
+        if input_type == "3d":
+            if ball_pos is None:
+                raise ValueError("ball_pos is required for input_type='3d'.")
+            return self.forward_3d_event(ball_pos, ball_vis=ball_vis, ball_mask=ball_mask, seq_len=seq_len)
+
+        if ball_uv is None or court_kp is None:
+            raise ValueError("ball_uv and court_kp are required for input_type='uv'.")
+        return self.forward_uv(
+            ball_uv,
+            court_kp,
+            ball_vis=ball_vis,
+            ball_mask=ball_mask,
+            court_vis=court_vis,
+            seq_len=seq_len,
+        )
+
+    def forward_uv(
+        self,
+        ball_uv: Tensor,
+        court_kp: Tensor,
+        *,
+        ball_vis: Tensor | None = None,
+        ball_mask: Tensor | None = None,
+        court_vis: Tensor | None = None,
+        seq_len: Tensor | None = None,
+    ) -> dict[str, Tensor]:
+        """Forward pass for UV inputs.
+
+        Returns a dict with keys:
+        - uv_completed
+        - position_3d
+        - event_logits
+        """
+        ball_h = self.backbone.forward_uv(
+            ball_uv,
+            court_kp,
+            ball_vis=ball_vis,
+            ball_mask=ball_mask,
+            court_vis=court_vis,
+            seq_len=seq_len,
+        )
+        return {
+            "uv_completed": self.uv_head(ball_h),
+            "position_3d": self.traj_head(ball_h),
+            "event_logits": self.event_head(ball_h),
+        }
+
+    def forward_3d_event(
+        self,
+        ball_pos: Tensor,
+        *,
+        ball_vis: Tensor | None = None,
+        ball_mask: Tensor | None = None,
+        seq_len: Tensor | None = None,
+    ) -> dict[str, Tensor]:
+        """Forward pass for 3D inputs (event-only)."""
+        ball_h = self.backbone.forward_3d(
+            ball_pos,
+            ball_vis=ball_vis,
+            ball_mask=ball_mask,
+            seq_len=seq_len,
+        )
+        return {"event_logits": self.event_head(ball_h)}
+
+    @torch.no_grad()
+    def predict_uv(
+        self,
+        ball_uv: Tensor,
+        court_kp: Tensor,
+        *,
+        ball_vis: Tensor | None = None,
+        ball_mask: Tensor | None = None,
+        court_vis: Tensor | None = None,
+        seq_len: Tensor | None = None,
+    ) -> dict[str, Tensor]:
+        """Inference for UV inputs."""
+        self.eval()
+        return self.forward_uv(
+            ball_uv,
+            court_kp,
+            ball_vis=ball_vis,
+            ball_mask=ball_mask,
+            court_vis=court_vis,
+            seq_len=seq_len,
+        )
+
+    def get_num_params(self) -> int:
+        """Return total trainable parameter count."""
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    model = BallMultitaskModel(backbone=BallMultitaskBackbone(hidden_dim=32, num_layers=2, num_heads=4))
+    ball_uv = torch.randn(2, 8, 2)
+    court_kp = torch.randn(2, 20, 2)
+    out = model.forward_uv(ball_uv, court_kp)
+    assert out["uv_completed"].shape == (2, 8, 2)
+    assert out["position_3d"].shape == (2, 8, 3)
+    assert out["event_logits"].shape == (2, 8, 2)
+    print("multitask_model smoke ok")

--- a/src/ball_multitask/scripts/__init__.py
+++ b/src/ball_multitask/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""CLI entry points for ball multi-task workflows."""

--- a/src/ball_multitask/scripts/predict.py
+++ b/src/ball_multitask/scripts/predict.py
@@ -1,0 +1,102 @@
+"""Run offline inference for the ball multi-task model.
+
+Example:
+    `uv run python -m src.ball_multitask.scripts.predict`
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import hydra
+import numpy as np
+import torch
+from omegaconf import DictConfig
+
+from src.ball_multitask.inference.predictor import BallMultitaskPredictor
+from src.common.data.scene_cache import load_npz_scene
+
+
+def _load_scene_inputs(scene_path: Path, camera: int) -> dict[str, torch.Tensor]:
+    scene = load_npz_scene(scene_path)
+    meta = scene.get("meta", {}) if isinstance(scene.get("meta", {}), dict) else {}
+
+    num_cameras = int(scene.get("num_cameras", 1))
+    cam_idx = min(max(int(camera), 0), max(num_cameras - 1, 0))
+    prefix = f"cam_{cam_idx}_"
+
+    ball_uv = torch.from_numpy(scene[f"{prefix}ball_uv"]).float()
+    ball_vis = torch.from_numpy(scene[f"{prefix}ball_visible"]).float()
+    court_kp = torch.from_numpy(scene[f"{prefix}court_kp_uv"]).float()
+    court_vis = torch.from_numpy(scene[f"{prefix}court_kp_visible"]).float()
+
+    seq_len = int(meta.get("num_frames", ball_uv.shape[0]))
+    seq_len = min(seq_len, int(ball_uv.shape[0]))
+
+    return {
+        "ball_uv": ball_uv[:seq_len],
+        "ball_vis": ball_vis[:seq_len],
+        "court_kp": court_kp,
+        "court_vis": court_vis,
+        "seq_len": torch.tensor(seq_len, dtype=torch.long),
+    }
+
+
+def _save_outputs(output_path: Path, outputs: dict[str, object]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        output_path,
+        uv_completed=outputs["uv_completed"],
+        position_3d=outputs["position_3d"],
+        event_logits=outputs["event_logits"],
+        event_probs=outputs["event_probs"],
+    )
+    peaks_path = output_path.with_suffix(".events.json")
+    peaks_payload = {
+        "event_names": outputs["event_names"],
+        "event_peaks": outputs["event_peaks"],
+        "event_peak_scores": outputs["event_peak_scores"],
+    }
+    peaks_path.write_text(json.dumps(peaks_payload, indent=2))
+
+
+@hydra.main(config_path="../configs", config_name="predict", version_base="1.3")
+def main(cfg: DictConfig) -> None:  # pragma: no cover - CLI entry point
+    infer_cfg = cfg.get("inference", {}) or {}
+    scene_path = Path(str(infer_cfg.get("scene_path", "data/blcs/scenes/rally_000000.npz")))
+    checkpoint = str(infer_cfg.get("checkpoint", ""))
+    if not checkpoint:
+        raise ValueError("inference.checkpoint is required")
+
+    predictor = BallMultitaskPredictor.load_from_checkpoint(
+        checkpoint_path=checkpoint,
+        device=str(infer_cfg.get("device", "cpu")),
+    )
+
+    inputs = _load_scene_inputs(scene_path, camera=int(infer_cfg.get("camera", 0)))
+    outputs = predictor.predict(
+        inputs["ball_uv"],
+        inputs["court_kp"],
+        ball_vis=inputs.get("ball_vis"),
+        court_vis=inputs.get("court_vis"),
+        seq_len=inputs.get("seq_len"),
+        threshold=float(infer_cfg.get("threshold", 0.5)),
+        min_distance=int(infer_cfg.get("min_distance", 1)),
+        top_k=infer_cfg.get("top_k"),
+        denormalize=bool(infer_cfg.get("denormalize", True)),
+    )
+
+    output_path = infer_cfg.get("output")
+    if output_path:
+        _save_outputs(Path(str(output_path)), outputs)
+        print(f"Saved outputs to {output_path}")
+    else:
+        print("Inference complete.")
+        print(f"uv_completed: {tuple(outputs['uv_completed'].shape)}")
+        print(f"position_3d: {tuple(outputs['position_3d'].shape)}")
+        print(f"event_logits: {tuple(outputs['event_logits'].shape)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ball_multitask/scripts/train.py
+++ b/src/ball_multitask/scripts/train.py
@@ -1,0 +1,23 @@
+"""Train the ball multi-task model with Hydra configuration.
+
+Example commands:
+    `uv run python -m src.ball_multitask.scripts.train`
+    `uv run python -m src.ball_multitask.scripts.train run.dry_run=true`
+"""
+
+from __future__ import annotations
+
+import hydra
+from omegaconf import DictConfig
+
+from src.ball_multitask.training.runner import BallMultitaskTrainingRunner
+
+
+@hydra.main(config_path="../configs", config_name="train", version_base="1.3")
+def main(cfg: DictConfig) -> None:  # pragma: no cover - CLI entry point
+    runner = BallMultitaskTrainingRunner()
+    runner.run(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ball_multitask/training/__init__.py
+++ b/src/ball_multitask/training/__init__.py
@@ -1,0 +1,6 @@
+"""Training components for ball multi-task learning."""
+
+from src.ball_multitask.training.lightning_module import BallMultitaskLightningModule
+from src.ball_multitask.training.runner import BallMultitaskTrainingRunner
+
+__all__ = ["BallMultitaskLightningModule", "BallMultitaskTrainingRunner"]

--- a/src/ball_multitask/training/lightning_module.py
+++ b/src/ball_multitask/training/lightning_module.py
@@ -1,0 +1,316 @@
+"""PyTorch Lightning module for ball multi-task learning."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from torch import Tensor
+from torch.nn import functional as F
+
+from src.base.training.lightning_module import BaseLightningModule
+from src.ball_multitask.models.multitask_model import BallMultitaskModel
+from src.blcs.training.losses import BLCSLoss
+from src.event_detection.utils.peaks import extract_event_peaks
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+def _masked_huber(pred: Tensor, target: Tensor, mask: Tensor, *, delta: float) -> Tensor:
+    mask_f = mask.to(pred.dtype).unsqueeze(-1)
+    denom = mask_f.sum().clamp_min(1.0)
+    loss = F.huber_loss(pred, target, reduction="none", delta=float(delta))
+    return (loss * mask_f).sum() / denom
+
+
+def _smoothness_loss(pred: Tensor, mask: Tensor) -> Tensor:
+    if pred.shape[1] < 3:
+        return pred.new_tensor(0.0)
+    m = mask.to(pred.dtype)
+    a = pred[:, 2:] - 2.0 * pred[:, 1:-1] + pred[:, :-2]
+    m2 = m[:, 2:] * m[:, 1:-1] * m[:, :-2]
+    denom = m2.sum().clamp_min(1.0)
+    return (a.abs().sum(dim=-1) * m2).sum() / denom
+
+
+def _make_time_mask(seq_len: Tensor, T: int) -> Tensor:
+    B = seq_len.shape[0]
+    t = torch.arange(T, device=seq_len.device)[None, :]
+    return t < seq_len.to(torch.long).view(B, 1)
+
+
+class BallMultitaskLightningModule(BaseLightningModule):
+    """Lightning module for unified UV/3D/event training."""
+
+    def __init__(self, config: DictConfig) -> None:
+        super().__init__(config)
+        self.model = BallMultitaskModel.from_config(config)
+
+        train_cfg = config.get("training", {}) or {}
+        loss_cfg = train_cfg.get("loss", {}) or {}
+        uv_cfg = loss_cfg.get("uv", {}) or {}
+        traj_cfg = loss_cfg.get("traj3d", {}) or {}
+        evt_cfg = loss_cfg.get("event", {}) or {}
+        metrics_cfg = config.get("metrics", {}) or {}
+
+        self.uv_loss_weight = float(uv_cfg.get("weight", 1.0))
+        self.uv_masked_weight = float(uv_cfg.get("masked_weight", 1.0))
+        self.uv_observed_weight = float(uv_cfg.get("observed_weight", 0.1))
+        self.uv_smoothness_weight = float(uv_cfg.get("smoothness_weight", 0.0))
+        self.uv_huber_delta = float(uv_cfg.get("huber_delta", 0.02))
+
+        self.traj_loss_weight = float(traj_cfg.get("weight", 1.0))
+        self.traj_loss = BLCSLoss(
+            position_weight=float(traj_cfg.get("position_weight", 1.0)),
+            velocity_weight=float(traj_cfg.get("velocity_weight", 0.1)),
+            smoothness_weight=float(traj_cfg.get("smoothness_weight", 0.05)),
+        )
+
+        self.event_weight_uv = float(evt_cfg.get("weight_uv", 0.2))
+        self.event_weight_3d = float(evt_cfg.get("weight_3d", 0.2))
+        pos_weight_cfg = evt_cfg.get("pos_weight", [1.0, 1.0])
+        pos_weight = torch.tensor(pos_weight_cfg, dtype=torch.float32)
+        self.register_buffer("pos_weight", pos_weight, persistent=False)
+
+        self.masked_accuracy_threshold = float(
+            metrics_cfg.get("masked_accuracy_threshold_px", 0.0)
+        )
+        self.observed_accuracy_threshold = float(
+            metrics_cfg.get("observed_accuracy_threshold_px", 0.0)
+        )
+        self.peak_threshold = float(metrics_cfg.get("peak_threshold", 0.5))
+        self.match_tolerance_frames = int(metrics_cfg.get("match_tolerance_frames", 3))
+
+        curriculum_cfg = train_cfg.get("curriculum", {}) or {}
+        self.uv_steps_per_3d = int(curriculum_cfg.get("uv_steps_per_3d", 4))
+        self.start_3d_epoch = int(curriculum_cfg.get("start_3d_epoch", 0))
+
+    def training_step(self, batch: dict[str, Tensor], batch_idx: int) -> Tensor:
+        if self._is_3d_step(batch_idx):
+            outputs = self.model.forward_3d_event(
+                batch["ball_pos_world"],
+                seq_len=batch.get("seq_len"),
+                ball_mask=batch.get("ball_mask"),
+            )
+            logits = outputs["event_logits"]
+            event_targets, seq_len = self._slice_event_targets(batch, logits.shape[1])
+            loss_event = self._event_loss(logits, event_targets, seq_len)
+            total = self.event_weight_3d * loss_event
+            self.log("train/loss", total, prog_bar=True)
+            self.log("train/event_loss_3d", loss_event, prog_bar=True)
+            return total
+
+        outputs = self.model.forward_uv(
+            batch["ball_uv_in"],
+            batch["court_kp"],
+            ball_vis=batch.get("ball_vis"),
+            ball_mask=batch.get("ball_mask"),
+            court_vis=batch.get("court_vis"),
+            seq_len=batch.get("seq_len"),
+        )
+        total, logs = self._compute_uv_losses(outputs, batch)
+        self.log("train/loss", total, prog_bar=True)
+        for key, value in logs.items():
+            self.log(f"train/{key}", value, prog_bar=False)
+        return total
+
+    def validation_step(self, batch: dict[str, Tensor], batch_idx: int) -> None:
+        _ = batch_idx
+        outputs = self.model.forward_uv(
+            batch["ball_uv_in"],
+            batch["court_kp"],
+            ball_vis=batch.get("ball_vis"),
+            ball_mask=batch.get("ball_mask"),
+            court_vis=batch.get("court_vis"),
+            seq_len=batch.get("seq_len"),
+        )
+        total, logs = self._compute_uv_losses(outputs, batch)
+        self.log("val/loss", total, prog_bar=True)
+        for key, value in logs.items():
+            self.log(f"val/{key}", value, prog_bar=False)
+
+        logits_3d = self.model.forward_3d_event(
+            batch["ball_pos_world"],
+            seq_len=batch.get("seq_len"),
+            ball_mask=batch.get("ball_mask"),
+        )["event_logits"]
+        event_targets_3d, seq_len_3d = self._slice_event_targets(batch, logits_3d.shape[1])
+        loss_event_3d = self._event_loss(logits_3d, event_targets_3d, seq_len_3d)
+        self.log("val/event_loss_3d", loss_event_3d, prog_bar=False)
+
+        event_targets_uv, seq_len_uv = self._slice_event_targets(
+            batch, outputs["event_logits"].shape[1]
+        )
+        acc_uv = self._peak_match_accuracy(outputs["event_logits"], event_targets_uv, seq_len_uv)
+        acc_3d = self._peak_match_accuracy(logits_3d, event_targets_3d, seq_len_3d)
+        self.log("val/event_accuracy_uv", acc_uv, prog_bar=False)
+        self.log("val/event_accuracy_3d", acc_3d, prog_bar=False)
+
+    def _compute_uv_losses(
+        self, outputs: dict[str, Tensor], batch: dict[str, Tensor]
+    ) -> tuple[Tensor, dict[str, Tensor]]:
+        uv_pred = outputs["uv_completed"]
+        pos_pred = outputs["position_3d"]
+        evt_logits = outputs["event_logits"]
+
+        T = uv_pred.shape[1]
+        ball_uv_gt = batch["ball_uv_gt"][:, :T]
+        ball_vis = batch["ball_vis"][:, :T]
+        ball_mask = batch["ball_mask"][:, :T]
+        position_3d = batch["position_3d"][:, :T]
+        event_targets = batch["event_targets"][:, :T]
+        seq_len = batch.get("seq_len")
+        if seq_len is not None:
+            seq_len = torch.clamp(seq_len, max=T)
+
+        B = uv_pred.shape[0]
+        if seq_len is None:
+            valid = ball_mask > 0
+        else:
+            t = torch.arange(T, device=uv_pred.device)[None, :]
+            valid = (t < seq_len.to(torch.long).view(B, 1)) & (ball_mask > 0)
+
+        masked = valid & (ball_vis <= 0)
+        observed = valid & (ball_vis > 0)
+
+        loss_masked = _masked_huber(uv_pred, ball_uv_gt, masked, delta=self.uv_huber_delta)
+        loss_observed = _masked_huber(uv_pred, ball_uv_gt, observed, delta=self.uv_huber_delta)
+        loss_uv = self.uv_masked_weight * loss_masked + self.uv_observed_weight * loss_observed
+
+        loss_smooth = uv_pred.new_tensor(0.0)
+        if self.uv_smoothness_weight > 0:
+            loss_smooth = _smoothness_loss(uv_pred, valid)
+            loss_uv = loss_uv + self.uv_smoothness_weight * loss_smooth
+
+        loss_traj = self.traj_loss(pred_position=pos_pred, target_position=position_3d, mask=valid)["total"]
+        loss_event = self._event_loss(evt_logits, event_targets, seq_len)
+
+        total = (
+            self.uv_loss_weight * loss_uv
+            + self.traj_loss_weight * loss_traj
+            + self.event_weight_uv * loss_event
+        )
+
+        logs: dict[str, Tensor] = {
+            "uv_loss": loss_uv.detach(),
+            "uv_loss_masked": loss_masked.detach(),
+            "uv_loss_observed": loss_observed.detach(),
+            "uv_loss_smooth": loss_smooth.detach(),
+            "traj_loss": loss_traj.detach(),
+            "event_loss_uv": loss_event.detach(),
+        }
+
+        if self.masked_accuracy_threshold > 0 or self.observed_accuracy_threshold > 0:
+            error = torch.linalg.vector_norm(uv_pred - ball_uv_gt, dim=-1)
+            if self.masked_accuracy_threshold > 0:
+                masked_denom = masked.to(torch.float32).sum().clamp_min(1.0)
+                acc_masked = (error <= self.masked_accuracy_threshold).to(torch.float32)
+                acc_masked = (acc_masked * masked.to(torch.float32)).sum() / masked_denom
+                logs["uv_accuracy_masked"] = acc_masked.detach()
+            if self.observed_accuracy_threshold > 0:
+                observed_denom = observed.to(torch.float32).sum().clamp_min(1.0)
+                acc_observed = (error <= self.observed_accuracy_threshold).to(torch.float32)
+                acc_observed = (acc_observed * observed.to(torch.float32)).sum() / observed_denom
+                logs["uv_accuracy_observed"] = acc_observed.detach()
+
+        return total, logs
+
+    def _event_loss(self, logits: Tensor, targets: Tensor, seq_len: Tensor | None) -> Tensor:
+        B, T, E = logits.shape
+        pos_weight = self.pos_weight
+        if pos_weight.numel() != E:
+            raise ValueError(f"event pos_weight length {pos_weight.numel()} != num_events {E}")
+
+        loss_per = F.binary_cross_entropy_with_logits(
+            logits,
+            targets.to(logits.dtype),
+            reduction="none",
+            pos_weight=pos_weight.to(device=logits.device, dtype=logits.dtype),
+        )
+        if seq_len is None:
+            return loss_per.mean()
+        time_mask = _make_time_mask(seq_len, T).to(loss_per.dtype)
+        denom = time_mask.sum().clamp_min(1.0) * E
+        return (loss_per * time_mask.unsqueeze(-1)).sum() / denom
+
+    def _slice_event_targets(
+        self, batch: dict[str, Tensor], T: int
+    ) -> tuple[Tensor, Tensor | None]:
+        targets = batch["event_targets"][:, :T]
+        seq_len = batch.get("seq_len")
+        if seq_len is not None:
+            seq_len = torch.clamp(seq_len, max=T)
+        return targets, seq_len
+
+    def _is_3d_step(self, batch_idx: int) -> bool:
+        _ = batch_idx
+        if self.current_epoch < self.start_3d_epoch:
+            return False
+        if self.uv_steps_per_3d <= 0:
+            return False
+        cycle = self.uv_steps_per_3d + 1
+        return ((int(self.global_step) + 1) % cycle) == 0
+
+    def _peak_match_accuracy(self, logits: Tensor, targets: Tensor, seq_len: Tensor | None) -> Tensor:
+        probs = torch.sigmoid(logits)
+        pred_peaks, _ = extract_event_peaks(
+            probs,
+            seq_len,
+            threshold=self.peak_threshold,
+            min_distance=max(self.match_tolerance_frames, 1),
+            top_k=None,
+        )
+        gt_peaks, _ = extract_event_peaks(
+            targets,
+            seq_len,
+            threshold=self.peak_threshold,
+            min_distance=1,
+            top_k=None,
+        )
+
+        B, _, E = probs.shape
+        correct = 0
+        total = B * E
+        tolerance = max(self.match_tolerance_frames, 0)
+        for b in range(B):
+            for e in range(E):
+                pred = pred_peaks[b][e]
+                gt = gt_peaks[b][e]
+                if not gt and not pred:
+                    correct += 1
+                    continue
+                if not gt or not pred:
+                    continue
+                matched = False
+                for g in gt:
+                    if any(abs(g - p) <= tolerance for p in pred):
+                        matched = True
+                        break
+                if matched:
+                    correct += 1
+        return logits.new_tensor(correct / max(total, 1))
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    cfg = {
+        "model": {"hidden_dim": 32, "num_layers": 2, "num_heads": 4, "max_seq_len": 16, "num_events": 2},
+        "training": {"loss": {"event": {"pos_weight": [1.0, 1.0]}}},
+    }
+    module = BallMultitaskLightningModule(cfg)  # type: ignore[arg-type]
+    batch = {
+        "ball_uv_in": torch.rand(2, 16, 2),
+        "ball_uv_gt": torch.rand(2, 16, 2),
+        "ball_vis": torch.ones(2, 16),
+        "ball_mask": torch.ones(2, 16),
+        "court_kp": torch.rand(2, 20, 2),
+        "court_vis": torch.ones(2, 20),
+        "position_3d": torch.rand(2, 16, 3),
+        "ball_pos_world": torch.rand(2, 16, 3),
+        "event_targets": torch.zeros(2, 16, 2),
+        "seq_len": torch.tensor([16, 12]),
+    }
+    loss = module.training_step(batch, 0)
+    assert torch.isfinite(loss)
+    print("ball_multitask.lightning smoke ok")

--- a/src/ball_multitask/training/runner.py
+++ b/src/ball_multitask/training/runner.py
@@ -1,0 +1,28 @@
+"""Training runner for ball multi-task models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytorch_lightning as pl
+
+from src.base.training.runner import BaseTrainingRunner
+from src.ball_multitask.data.datamodule import BallMultitaskDataModule
+from src.ball_multitask.training.lightning_module import BallMultitaskLightningModule
+
+
+class BallMultitaskTrainingRunner(BaseTrainingRunner):
+    """Training runner for multi-task models."""
+
+    def build_datamodule(self, config: Any) -> pl.LightningDataModule:
+        return BallMultitaskDataModule(config)
+
+    def build_lightning_module(
+        self,
+        config: Any,
+        datamodule: pl.LightningDataModule,
+        *,
+        steps_per_epoch: int | None = None,
+    ) -> pl.LightningModule:
+        _ = datamodule, steps_per_epoch
+        return BallMultitaskLightningModule(config)


### PR DESCRIPTION
## 概要
issue #212 のMVPとして、オフライン統合マルチタスク（UV補完/UV→3D/イベント + 3D→イベント）を新規パッケージ src/ball_multitask に実装。

## 主要変更
- 共有backbone: tokens=[Reg,Court,Ball]、3D入力はlearned court tokens + Ball3D adapterで統合
- Head: UV completion / 3D trajectory / event logits をball_hから出力
- Dataset: BLCS NPZから UV腐食、3D教師、event教師(soft label)を同時生成
- Training: UVステップと3Dステップをカリキュラムで交互実行（既定 3D:UV=1:4）
- Inference: 1回のforwardで uv_completed / position_3d / event_peaks を返す予測器
- Hydra configs + CLI train/predict を追加

## 実装詳細
- backbone: RoPE/SDPA, register tokens, learned court tokens for 3D, ball_h抽出
- eventピーク抽出は既存 utils を再利用

## 設定/使い方
- train: src/ball_multitask/configs/train.yaml
- predict: src/ball_multitask/configs/predict.yaml

## テスト
- 未実施（必要なら指示ください）

Closes #212