### PR TITLE
Set augmentation noise std to 1e-4

### DIFF
--- a/src/ball_multitask/configs/data/blcs_rally.yaml
+++ b/src/ball_multitask/configs/data/blcs_rally.yaml
@@ -24,7 +24,7 @@ supervise_visible_only: true
 
 corruption:
   enabled: true
-  noise_std: 0.01
+  noise_std: 0.0001
   clamp_unit: true
   point_dropout_prob: 0.05
   gap_dropout_prob: 0.1

--- a/src/blcs/configs/data/default.yaml
+++ b/src/blcs/configs/data/default.yaml
@@ -25,7 +25,7 @@ camera_mode: "random"
 
 # Augmentation
 augmentation:
-  uv_noise_std: 0.005
+  uv_noise_std: 0.0001
   visibility_drop_prob: 0.1
   temporal_dropout_prob: 0.05
   flip_horizontal: true

--- a/src/plcs/configs/data/frame.yaml
+++ b/src/plcs/configs/data/frame.yaml
@@ -12,5 +12,5 @@ chunk_max_scenes: 64
 mode: frame
 
 augmentation:
-  keypoint_noise_std: 0.01
+  keypoint_noise_std: 0.0001
   visibility_drop_prob: 0.05


### PR DESCRIPTION
This changes data-augmentation noise std values to reduce the risk of over-corrupting normalized coordinates.

- src/ball_multitask/configs/data/blcs_rally.yaml: corruption.noise_std 0.01 -> 0.0001
- src/blcs/configs/data/default.yaml: augmentation.uv_noise_std 0.005 -> 0.0001
- src/plcs/configs/data/frame.yaml: augmentation.keypoint_noise_std 0.01 -> 0.0001

References #220
References #219
