### PR TITLE
PLCS: add kp3d frame model while preserving existing CLS pipeline

### DIFF
--- a/src/plcs/__init__.py
+++ b/src/plcs/__init__.py
@@ -5,13 +5,19 @@ and rotation in tennis court coordinates from 2D pose observations.
 """
 
 from src.plcs.inference.predictor import PLCSPredictor
+from src.plcs.inference.predictor_kp3d import PLCSKeypoint3DPredictor
+from src.plcs.models.plcs_kp3d_model import PLCSKeypoint3DModel
 from src.plcs.models.plcs_model import PLCSModel
 from src.plcs.training.lightning_module import PLCSLightningModule
+from src.plcs.training.lightning_module_kp3d import PLCSKeypoint3DLightningModule
 
 __all__ = [
     "PLCSModel",
+    "PLCSKeypoint3DModel",
     "PLCSLightningModule",
+    "PLCSKeypoint3DLightningModule",
     "PLCSPredictor",
+    "PLCSKeypoint3DPredictor",
 ]
 
 

--- a/src/plcs/configs/loss/frame_kp3d.yaml
+++ b/src/plcs/configs/loss/frame_kp3d.yaml
@@ -1,0 +1,2 @@
+# Frame-level PLCS keypoint-3D loss configuration.
+keypoint_3d_weight: 1.0

--- a/src/plcs/configs/model/frame_kp3d.yaml
+++ b/src/plcs/configs/model/frame_kp3d.yaml
@@ -1,0 +1,30 @@
+## PLCS frame keypoint-3D model configuration
+## Reuses PLCS transformer backbone and predicts per-keypoint 3D directly.
+
+name: plcs_kp3d
+
+hidden_dim: 256
+num_layers: 4
+num_heads: 8
+ffn_dim: null
+dropout: 0.1
+invisible_init_std: 0.02
+
+num_register_tokens: 4
+use_kp_id_embedding: true
+use_rope: false
+
+rope_dim: null
+rope_theta: 10000.0
+yarn: null
+
+use_moe: true
+moe_config:
+  moe_inter_dim: 704
+  n_routed_experts: 8
+  n_shared_experts: 2
+  n_activated_experts: 2
+  n_expert_groups: 1
+  n_limited_groups: 1
+  score_func: softmax
+  route_scale: 1.0

--- a/src/plcs/configs/run/train_kp3d.yaml
+++ b/src/plcs/configs/run/train_kp3d.yaml
@@ -1,0 +1,6 @@
+output_dir: outputs/plcs/frame_kp3d
+seed: 42
+gpus: 1
+resume: null
+fast_dev_run: false
+dry_run: false

--- a/src/plcs/configs/train_kp3d.yaml
+++ b/src/plcs/configs/train_kp3d.yaml
@@ -1,0 +1,15 @@
+defaults:
+  - model: frame_kp3d
+  - data: frame
+  - training: default
+  - loss: frame_kp3d
+  - metrics: default
+  - run: train_kp3d
+  - _self_
+
+hydra:
+  run:
+    dir: ${run.output_dir}/${now:%Y-%m-%d_%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/plcs/data/dataset.py
+++ b/src/plcs/data/dataset.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 import torch
 from torch.utils.data import Dataset
 
-from src.common.dataset.augmentation import augment_keypoints
 from src.common.data.index_cache import (
     compute_config_hash,
     compute_scene_files_hash,
@@ -21,8 +20,10 @@ from src.common.data.scene_cache import (
     extract_scene_meta_parallel,
     get_scene_cache,
 )
-from src.plcs.generate_dataset.io.scene_loader import load_scene
+from src.common.dataset.augmentation import augment_keypoints
+from src.plcs.data.targets import build_coco17_world_targets
 from src.plcs.data.types import PLCSFrameBatch
+from src.plcs.generate_dataset.io.scene_loader import load_scene
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -182,6 +183,9 @@ class SceneDataset(Dataset[PLCSFrameBatch]):
         # Get targets
         position = torch.from_numpy(scene["position"][frame_idx].copy())
         rotation = torch.from_numpy(scene["rotation"][frame_idx].copy())
+        if "human_kp_3d" not in scene:
+            scene["human_kp_3d"] = build_coco17_world_targets(scene)
+        human_kp_3d = torch.from_numpy(scene["human_kp_3d"][frame_idx].copy())
 
         # Apply augmentation
         if self.augment:
@@ -199,6 +203,7 @@ class SceneDataset(Dataset[PLCSFrameBatch]):
             "court_vis": court_vis.float(),  # (20,)
             "position": position.float(),  # (3,)
             "rotation": rotation.float(),  # (2,)
+            "human_kp_3d": human_kp_3d.float(),  # (17, 3)
         }
 
 

--- a/src/plcs/data/targets.py
+++ b/src/plcs/data/targets.py
@@ -1,0 +1,87 @@
+"""Target-generation utilities for PLCS datasets."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+from src.utils.geometry import FACE_KEYPOINT_OFFSETS, SMPLH_TO_COCO17_MAPPING
+from src.utils.geometry.constants import (
+    COURT_COORD_SCALE_X,
+    COURT_COORD_SCALE_Y,
+    COURT_COORD_SCALE_Z,
+)
+
+
+def _smplh_to_coco17(joints_3d: np.ndarray, yaw: float) -> np.ndarray:
+    """Convert SMPL-H joints to COCO17 with synthetic face keypoints."""
+    T = joints_3d.shape[0]
+    coco17 = np.zeros((T, 17, 3), dtype=np.float32)
+
+    for coco_idx, smplh_idx in SMPLH_TO_COCO17_MAPPING.items():
+        if 0 <= smplh_idx < joints_3d.shape[1]:
+            coco17[:, coco_idx, :] = joints_3d[:, smplh_idx, :]
+
+    head_idx = min(15, joints_3d.shape[1] - 1)
+    head_pos = joints_3d[:, head_idx, :]
+    cos_yaw = math.cos(yaw)
+    sin_yaw = math.sin(yaw)
+    rot = np.array(
+        [
+            [cos_yaw, -sin_yaw, 0],
+            [sin_yaw, cos_yaw, 0],
+            [0, 0, 1],
+        ],
+        dtype=np.float32,
+    )
+
+    for coco_idx, offset in FACE_KEYPOINT_OFFSETS.items():
+        offset_arr = np.array(offset, dtype=np.float32)
+        rotated_offset = offset_arr @ rot.T
+        coco17[:, coco_idx, :] = head_pos + rotated_offset
+
+    return coco17
+
+
+def build_coco17_world_targets(scene: dict[str, Any]) -> np.ndarray:
+    """Build world/court-coordinate COCO17 targets from a loaded scene.
+
+    Returns:
+        np.ndarray: Shape (T, 17, 3), in meters.
+
+    """
+    if "human_kp_3d" in scene:
+        kp = np.asarray(scene["human_kp_3d"], dtype=np.float32)
+        if kp.ndim == 2:
+            kp = kp[None, ...]
+        return kp
+
+    canonical = np.asarray(scene["canonical_pose_3d"], dtype=np.float32)
+    if canonical.ndim == 2:
+        canonical = canonical[None, ...]
+
+    position_norm = np.asarray(scene["position"], dtype=np.float32)
+    if position_norm.ndim == 1:
+        position_norm = position_norm[None, ...]
+    pelvis_world = np.zeros_like(position_norm, dtype=np.float32)
+    pelvis_world[:, 0] = position_norm[:, 0] * COURT_COORD_SCALE_X
+    pelvis_world[:, 1] = position_norm[:, 1] * COURT_COORD_SCALE_Y
+    pelvis_world[:, 2] = position_norm[:, 2] * COURT_COORD_SCALE_Z
+
+    meta = scene.get("meta", {})
+    yaw = float(meta.get("initial_yaw", 0.0))
+    cos_yaw = math.cos(yaw)
+    sin_yaw = math.sin(yaw)
+    rot = np.array(
+        [
+            [cos_yaw, -sin_yaw, 0.0],
+            [sin_yaw, cos_yaw, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
+
+    world_smplh = np.einsum("tji,ki->tjk", canonical, rot) + pelvis_world[:, None, :]
+    return _smplh_to_coco17(world_smplh, yaw)

--- a/src/plcs/data/types.py
+++ b/src/plcs/data/types.py
@@ -25,6 +25,7 @@ class PLCSFrameBatch(TypedDict):
     court_vis: torch.Tensor  # (20,) visibility flags for court keypoints
     position: torch.Tensor  # (3,) normalized court position [x_norm, y_norm, z_norm]
     rotation: torch.Tensor  # (2,) player orientation [sin(yaw), cos(yaw)]
+    human_kp_3d: torch.Tensor  # (17, 3) COCO17 world/court-coordinate keypoints
 
 
 class PLCSSequenceBatch(TypedDict):

--- a/src/plcs/inference/__init__.py
+++ b/src/plcs/inference/__init__.py
@@ -1,6 +1,7 @@
 """Inference utilities for PLCS."""
 
 from src.plcs.inference.predictor import PLCSPredictor
+from src.plcs.inference.predictor_kp3d import PLCSKeypoint3DPredictor
 from src.plcs.inference.sequence_predictor import PLCSSequencePredictor
 from src.plcs.inference.visualization import (
     visualize_batch,
@@ -11,6 +12,7 @@ from src.plcs.inference.visualization import (
 
 __all__ = [
     "PLCSPredictor",
+    "PLCSKeypoint3DPredictor",
     "PLCSSequencePredictor",
     "visualize_prediction",
     "visualize_batch",

--- a/src/plcs/inference/predictor_kp3d.py
+++ b/src/plcs/inference/predictor_kp3d.py
@@ -1,0 +1,58 @@
+"""PLCS keypoint-3D inference predictor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Self
+
+import torch
+from torch import Tensor
+
+from src.base.inference.predictor import BasePredictor
+from src.plcs.models.plcs_kp3d_model import PLCSKeypoint3DModel
+from src.plcs.training.lightning_module_kp3d import PLCSKeypoint3DLightningModule
+
+
+class PLCSKeypoint3DPredictor(BasePredictor):
+    """Predict per-keypoint 3D coordinates from 2D keypoints."""
+
+    def __init__(self, model: PLCSKeypoint3DModel, device: torch.device) -> None:
+        self.model = model.to(device)
+        self.device = device
+        self.model.eval()
+
+    @classmethod
+    def load_from_checkpoint(
+        cls,
+        checkpoint_path: str | Path,
+        device: str | torch.device = "cpu",
+        **kwargs: Any,
+    ) -> Self:
+        checkpoint_path = Path(checkpoint_path)
+        if not checkpoint_path.exists():
+            raise FileNotFoundError(f"Checkpoint not found: {checkpoint_path}")
+
+        device = torch.device(device)
+        lightning_module = PLCSKeypoint3DLightningModule.load_from_checkpoint(
+            checkpoint_path,
+            map_location=device,
+        )
+        return cls(model=lightning_module.model, device=device)
+
+    @torch.no_grad()
+    def predict(
+        self,
+        human_kp: Tensor,
+        court_kp: Tensor,
+        human_vis: Tensor | None = None,
+        court_vis: Tensor | None = None,
+    ) -> dict[str, Tensor]:
+        human_kp = human_kp.to(self.device)
+        court_kp = court_kp.to(self.device)
+        if human_vis is not None:
+            human_vis = human_vis.to(self.device)
+        if court_vis is not None:
+            court_vis = court_vis.to(self.device)
+
+        outputs = self.model(human_kp, court_kp, human_vis, court_vis)
+        return {"player_kp_3d": outputs["player_kp_3d"].cpu()}

--- a/src/plcs/models/__init__.py
+++ b/src/plcs/models/__init__.py
@@ -2,14 +2,18 @@
 
 from src.plcs.models.components import (
     KeypointEncoder,
+    PerTokenKeypoint3DHead,
     PositionHead,
     RotationHead,
 )
+from src.plcs.models.plcs_kp3d_model import PLCSKeypoint3DModel
 from src.plcs.models.plcs_model import PLCSModel
 
 __all__ = [
     "PLCSModel",
+    "PLCSKeypoint3DModel",
     "KeypointEncoder",
+    "PerTokenKeypoint3DHead",
     "PositionHead",
     "RotationHead",
 ]

--- a/src/plcs/models/components/__init__.py
+++ b/src/plcs/models/components/__init__.py
@@ -1,10 +1,15 @@
 """Reusable model components for PLCS."""
 
 from src.plcs.models.components.encoders import KeypointEncoder
-from src.plcs.models.components.heads import PositionHead, RotationHead
+from src.plcs.models.components.heads import (
+    PerTokenKeypoint3DHead,
+    PositionHead,
+    RotationHead,
+)
 
 __all__ = [
     "KeypointEncoder",
+    "PerTokenKeypoint3DHead",
     "PositionHead",
     "RotationHead",
 ]

--- a/src/plcs/models/components/heads.py
+++ b/src/plcs/models/components/heads.py
@@ -197,3 +197,59 @@ class CombinedHead(nn.Module):
         rotation = torch.nn.functional.normalize(rotation, dim=-1)
 
         return position, rotation
+
+
+class PerTokenKeypoint3DHead(nn.Module):
+    """Predict per-token 3D keypoints from token features.
+
+    Applies a shared MLP to each token independently.
+    """
+
+    def __init__(
+        self,
+        input_dim: int = 256,
+        hidden_dim: int = 128,
+        output_dim: int = 3,
+        num_layers: int = 2,
+        dropout: float = 0.1,
+    ) -> None:
+        """Initialize per-token 3D head.
+
+        Args:
+            input_dim: Input feature dimension per token.
+            hidden_dim: Hidden layer dimension.
+            output_dim: Output dimension (default 3 for x, y, z).
+            num_layers: Number of hidden layers.
+            dropout: Dropout probability.
+
+        """
+        super().__init__()
+
+        layers: list[nn.Module] = []
+        in_dim = input_dim
+
+        for _ in range(num_layers):
+            layers.extend(
+                [
+                    nn.Linear(in_dim, hidden_dim),
+                    nn.LayerNorm(hidden_dim),
+                    nn.GELU(),
+                    nn.Dropout(dropout),
+                ]
+            )
+            in_dim = hidden_dim
+
+        layers.append(nn.Linear(hidden_dim, output_dim))
+        self.mlp = nn.Sequential(*layers)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Predict per-token 3D coordinates.
+
+        Args:
+            x: Input token features, shape (batch, num_tokens, input_dim).
+
+        Returns:
+            Tensor: Predicted 3D coordinates, shape (batch, num_tokens, 3).
+
+        """
+        return self.mlp(x)

--- a/src/plcs/models/plcs_kp3d_model.py
+++ b/src/plcs/models/plcs_kp3d_model.py
@@ -1,0 +1,77 @@
+"""PLCS keypoint-3D model implementation.
+
+This variant keeps the same tokenization + transformer backbone as PLCSModel
+but predicts per-player-token 3D keypoints directly instead of CLS-based
+position/rotation.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from src.plcs.models.components.heads import PerTokenKeypoint3DHead
+from src.plcs.models.plcs_model import PLCSModel
+from src.utils.geometry import NUM_HUMAN_KP
+
+
+class PLCSKeypoint3DModel(PLCSModel):
+    """PLCS model variant that directly regresses 3D keypoints from player tokens."""
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        head_dropout = float(kwargs.get("dropout", 0.1))
+        super().__init__(*args, **kwargs)
+        self.kp3d_head = PerTokenKeypoint3DHead(
+            input_dim=self.hidden_dim,
+            hidden_dim=self.hidden_dim // 2,
+            output_dim=3,
+            num_layers=2,
+            dropout=head_dropout,
+        )
+
+    def forward(
+        self,
+        human_kp: Tensor,
+        court_kp: Tensor,
+        human_vis: Tensor | None = None,
+        court_vis: Tensor | None = None,
+    ) -> dict[str, Tensor]:
+        """Forward pass returning per-keypoint 3D predictions.
+
+        Returns:
+            dict: Dictionary with 'player_kp_3d' shape (B, 17, 3).
+
+        """
+        x, player_start_idx = self._encode_tokens(
+            human_kp=human_kp,
+            court_kp=court_kp,
+            human_vis=human_vis,
+            court_vis=court_vis,
+        )
+        player_tokens = x[:, player_start_idx:player_start_idx + NUM_HUMAN_KP, :]
+        player_kp_3d = self.kp3d_head(player_tokens)
+        return {"player_kp_3d": player_kp_3d}
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+
+    model = PLCSKeypoint3DModel(
+        hidden_dim=64,
+        num_layers=2,
+        num_heads=4,
+        dropout=0.0,
+    )
+
+    B = 2
+    human_kp = torch.randn(B, NUM_HUMAN_KP, 2)
+    court_kp = torch.randn(B, 20, 2)
+    human_vis = (torch.rand(B, NUM_HUMAN_KP) > 0.2).to(torch.float32)
+    court_vis = (torch.rand(B, 20) > 0.1).to(torch.float32)
+
+    with torch.no_grad():
+        out = model(human_kp=human_kp, court_kp=court_kp, human_vis=human_vis, court_vis=court_vis)
+
+    print("PLCSKeypoint3DModel:")
+    for key, value in out.items():
+        print(f"  {key}: {tuple(value.shape)}")

--- a/src/plcs/models/plcs_model.py
+++ b/src/plcs/models/plcs_model.py
@@ -35,7 +35,11 @@ from src.common.models import (
     YaRNConfig,
     precompute_freqs_cis,
 )
-from src.common.models.embeddings import CourtKPUVEmbedding, InvisibleTokenEmbedding, PlayerKPUVEmbedding
+from src.common.models.embeddings import (
+    CourtKPUVEmbedding,
+    InvisibleTokenEmbedding,
+    PlayerKPUVEmbedding,
+)
 from src.plcs.models.components.heads import PositionHead, RotationHead
 from src.utils.geometry import NUM_COURT_KP, NUM_HUMAN_KP
 
@@ -227,7 +231,7 @@ class PLCSModel(nn.Module):
         yarn: YaRNConfig | None = None
         if yarn_cfg is not None:
             yarn_cfg = dict(yarn_cfg)
-            if yarn_cfg.get("original_seq_len", None) is not None:
+            if yarn_cfg.get("original_seq_len") is not None:
                 yarn = YaRNConfig(**yarn_cfg)
 
         use_moe = bool(model_cfg.get("use_moe", False))
@@ -253,27 +257,14 @@ class PLCSModel(nn.Module):
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
         )
 
-    def forward(
+    def _build_body_tokens(
         self,
         human_kp: Tensor,
         court_kp: Tensor,
         human_vis: Tensor | None = None,
         court_vis: Tensor | None = None,
-    ) -> dict[str, Tensor]:
-        """Forward pass.
-
-        Args:
-            human_kp: Human keypoints, shape (B, 34) or (B, 17, 2).
-            court_kp: Court keypoints, shape (B, 40) or (B, 20, 2).
-            human_vis: Human visibility mask, shape (B, 17). Optional.
-            court_vis: Court visibility mask, shape (B, 20). Optional.
-
-        Returns:
-            dict: Dictionary with 'position' (B, 3) and 'rotation' (B, 2).
-
-        """
-        B = human_kp.size(0)
-
+    ) -> Tensor:
+        """Build body tokens (court + player), excluding CLS/register tokens."""
         # Tokenize court and player keypoints
         court_tok = self.court_embed(court_kp, court_vis)  # (B, 20, D)
         player_tok = self.player_embed(human_kp, human_vis)  # (B, 17, D)
@@ -299,14 +290,20 @@ class PLCSModel(nn.Module):
         token_body = torch.cat(
             [court_tok + court_type, player_tok + player_type], dim=1
         )  # (B, 37, D)
-        S_body = token_body.shape[1]
+        return token_body
 
+    def _add_prefix_tokens(self, token_body: Tensor) -> Tensor:
+        """Add CLS/register prefix tokens to body tokens."""
+        B = token_body.size(0)
         cls = self.cls_token.expand(B, -1, -1)
         if self.num_register_tokens > 0:
             reg = self.register_tokens.expand(B, -1, -1)
-            x = torch.cat([cls, reg, token_body], dim=1)  # (B, 1+R+37, D)
-        else:
-            x = torch.cat([cls, token_body], dim=1)  # (B, 38, D)
+            return torch.cat([cls, reg, token_body], dim=1)  # (B, 1+R+37, D)
+        return torch.cat([cls, token_body], dim=1)  # (B, 38, D)
+
+    def _forward_transformer(self, x: Tensor, S_body: int) -> Tensor:
+        """Run transformer stack and final normalization."""
+        prefix_len = x.size(1) - S_body
 
         freqs_cis: Tensor | None = None
         if self.use_rope:
@@ -319,7 +316,6 @@ class PLCSModel(nn.Module):
             if freqs_cis_body.device != x.device:
                 freqs_cis_body = freqs_cis_body.to(x.device)
 
-            prefix_len = 1 + self.num_register_tokens
             prefix_freqs = torch.ones(
                 prefix_len, freqs_cis_body.shape[1], device=x.device, dtype=freqs_cis_body.dtype
             )
@@ -342,6 +338,53 @@ class PLCSModel(nn.Module):
             x = self.final_norm(x)
         else:
             x, _ = self.final_norm(x, residual)
+        return x
+
+    def _encode_tokens(
+        self,
+        human_kp: Tensor,
+        court_kp: Tensor,
+        human_vis: Tensor | None = None,
+        court_vis: Tensor | None = None,
+    ) -> tuple[Tensor, int]:
+        """Encode tokens and return contextualized outputs and player start index."""
+        token_body = self._build_body_tokens(
+            human_kp=human_kp,
+            court_kp=court_kp,
+            human_vis=human_vis,
+            court_vis=court_vis,
+        )
+        S_body = token_body.shape[1]
+        x = self._add_prefix_tokens(token_body)
+        x = self._forward_transformer(x=x, S_body=S_body)
+        player_start_idx = 1 + self.num_register_tokens + NUM_COURT_KP
+        return x, player_start_idx
+
+    def forward(
+        self,
+        human_kp: Tensor,
+        court_kp: Tensor,
+        human_vis: Tensor | None = None,
+        court_vis: Tensor | None = None,
+    ) -> dict[str, Tensor]:
+        """Forward pass.
+
+        Args:
+            human_kp: Human keypoints, shape (B, 34) or (B, 17, 2).
+            court_kp: Court keypoints, shape (B, 40) or (B, 20, 2).
+            human_vis: Human visibility mask, shape (B, 17). Optional.
+            court_vis: Court visibility mask, shape (B, 20). Optional.
+
+        Returns:
+            dict: Dictionary with 'position' (B, 3) and 'rotation' (B, 2).
+
+        """
+        x, _ = self._encode_tokens(
+            human_kp=human_kp,
+            court_kp=court_kp,
+            human_vis=human_vis,
+            court_vis=court_vis,
+        )
 
         # Extract CLS token
         cls_out = x[:, 0, :]  # (B, D)

--- a/src/plcs/scripts/train_kp3d.py
+++ b/src/plcs/scripts/train_kp3d.py
@@ -1,0 +1,36 @@
+"""Train PLCS keypoint-3D model with Hydra-managed configuration.
+
+Example:
+    `uv run python -m src.plcs.scripts.train_kp3d`
+"""
+
+# mypy: disable-error-code=misc
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar, cast
+
+import hydra
+from omegaconf import DictConfig
+
+from src.plcs.training.runner import PLCSTrainingRunner
+
+F = TypeVar("F", bound=Callable[..., object])
+hydra.main = cast(Callable[..., Callable[[F], F]], hydra.main)
+
+
+def run_training(config: DictConfig) -> None:
+    """Execute PLCS kp3d training with provided configuration."""
+    runner = PLCSTrainingRunner()
+    runner.run(config)
+
+
+@hydra.main(config_path="../configs", config_name="train_kp3d", version_base="1.3")
+def main(config: DictConfig) -> None:  # pragma: no cover - CLI entry point
+    """Hydra entry point for kp3d training."""
+    run_training(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/plcs/training/__init__.py
+++ b/src/plcs/training/__init__.py
@@ -1,13 +1,19 @@
 """Training utilities for PLCS."""
 
 from src.plcs.training.lightning_module import PLCSLightningModule
+from src.plcs.training.lightning_module_kp3d import PLCSKeypoint3DLightningModule
 from src.plcs.training.losses import PLCSLoss, position_loss, rotation_loss
+from src.plcs.training.losses_kp3d import PLCSKeypoint3DLoss
 from src.plcs.training.metrics import PLCSMetrics
+from src.plcs.training.metrics_kp3d import PLCSKeypoint3DMetrics
 
 __all__ = [
     "PLCSLightningModule",
+    "PLCSKeypoint3DLightningModule",
     "PLCSLoss",
+    "PLCSKeypoint3DLoss",
     "PLCSMetrics",
+    "PLCSKeypoint3DMetrics",
     "position_loss",
     "rotation_loss",
 ]

--- a/src/plcs/training/lightning_module_kp3d.py
+++ b/src/plcs/training/lightning_module_kp3d.py
@@ -1,0 +1,119 @@
+"""PyTorch Lightning module for PLCS keypoint-3D training."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from torch import Tensor
+
+from src.base.training.lightning_module import BaseLightningModule
+from src.plcs.models.plcs_kp3d_model import PLCSKeypoint3DModel
+from src.plcs.training.losses_kp3d import PLCSKeypoint3DLoss
+from src.plcs.training.metrics_kp3d import PLCSKeypoint3DMetrics
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+class PLCSKeypoint3DLightningModule(BaseLightningModule):
+    """Lightning module for keypoint-3D variant of PLCS frame model."""
+
+    def __init__(self, config: DictConfig | None = None) -> None:
+        super().__init__(config)
+
+        self.model: PLCSKeypoint3DModel = PLCSKeypoint3DModel.from_config(self.config)
+
+        loss_cfg = self.config.get("loss", {})
+        self.loss_fn = PLCSKeypoint3DLoss(
+            keypoint_weight=float(loss_cfg.get("keypoint_3d_weight", 1.0))
+        )
+
+        self.train_metrics = PLCSKeypoint3DMetrics()
+        self.val_metrics = PLCSKeypoint3DMetrics()
+        self.test_metrics = PLCSKeypoint3DMetrics()
+
+    def forward(
+        self,
+        human_kp: Tensor,
+        court_kp: Tensor,
+        human_vis: Tensor | None = None,
+        court_vis: Tensor | None = None,
+    ) -> dict[str, Tensor]:
+        return cast(dict[str, Tensor], self.model(human_kp, court_kp, human_vis, court_vis))
+
+    def _shared_step(
+        self, batch: dict[str, Tensor], stage: str
+    ) -> tuple[Tensor, dict[str, float]]:
+        outputs = self.model(
+            human_kp=batch["human_kp"],
+            court_kp=batch["court_kp"],
+            human_vis=batch.get("human_vis"),
+            court_vis=batch.get("court_vis"),
+        )
+
+        losses = self.loss_fn(
+            pred_player_kp_3d=outputs["player_kp_3d"],
+            target_player_kp_3d=batch["human_kp_3d"],
+            human_vis=batch.get("human_vis"),
+        )
+
+        if stage == "train":
+            metrics = self.train_metrics.update(
+                outputs["player_kp_3d"],
+                batch["human_kp_3d"],
+                human_vis=batch.get("human_vis"),
+            )
+        elif stage == "val":
+            metrics = self.val_metrics.update(
+                outputs["player_kp_3d"],
+                batch["human_kp_3d"],
+                human_vis=batch.get("human_vis"),
+            )
+        else:
+            metrics = self.test_metrics.update(
+                outputs["player_kp_3d"],
+                batch["human_kp_3d"],
+                human_vis=batch.get("human_vis"),
+            )
+
+        return losses["total"], {
+            **metrics,
+            **{f"loss_{k}": v.item() for k, v in losses.items()},
+        }
+
+    def training_step(self, batch: dict[str, Tensor], batch_idx: int) -> Tensor:
+        loss, metrics = self._shared_step(batch, "train")
+        self.log("train/loss", loss, prog_bar=True)
+        self.log("train/mpjpe_m", metrics["mpjpe_m"], prog_bar=True)
+        self.log("train/pelvis_error_m", metrics["pelvis_error_m"])
+        return loss
+
+    def on_train_epoch_end(self) -> None:
+        metrics = self.train_metrics.compute()
+        for name, value in metrics.items():
+            self.log(f"train/epoch_{name}", value)
+        self.train_metrics.reset()
+
+    def validation_step(self, batch: dict[str, Tensor], batch_idx: int) -> None:
+        loss, metrics = self._shared_step(batch, "val")
+        self.log("val/loss", loss, prog_bar=True)
+        self.log("val/mpjpe_m", metrics["mpjpe_m"], prog_bar=True)
+        self.log("val/pelvis_error_m", metrics["pelvis_error_m"])
+
+    def on_validation_epoch_end(self) -> None:
+        metrics = self.val_metrics.compute()
+        for name, value in metrics.items():
+            self.log(f"val/epoch_{name}", value)
+        self.val_metrics.reset()
+
+    def test_step(self, batch: dict[str, Tensor], batch_idx: int) -> None:
+        loss, metrics = self._shared_step(batch, "test")
+        self.log("test/loss", loss)
+        self.log("test/mpjpe_m", metrics["mpjpe_m"])
+        self.log("test/pelvis_error_m", metrics["pelvis_error_m"])
+
+    def on_test_epoch_end(self) -> None:
+        metrics = self.test_metrics.compute()
+        for name, value in metrics.items():
+            self.log(f"test/{name}", value)
+        self.test_metrics.reset()

--- a/src/plcs/training/losses_kp3d.py
+++ b/src/plcs/training/losses_kp3d.py
@@ -1,0 +1,60 @@
+"""Loss functions for PLCS keypoint-3D training."""
+
+from __future__ import annotations
+
+import torch.nn as nn
+from torch import Tensor
+
+
+def _masked_joint_mean(values: Tensor, mask: Tensor | None) -> Tensor:
+    """Mean over joints with optional visibility mask.
+
+    Args:
+        values: Tensor of shape (B, J) or (B, T, J).
+        mask: Visibility mask with matching leading dims (B, J) or (B, T, J).
+
+    """
+    if mask is None:
+        return values.mean()
+    mask_f = mask.to(dtype=values.dtype)
+    denom = mask_f.sum().clamp_min(1.0)
+    return (values * mask_f).sum() / denom
+
+
+class PLCSKeypoint3DLoss(nn.Module):
+    """Smooth-L1 loss for per-keypoint 3D regression."""
+
+    def __init__(self, keypoint_weight: float = 1.0) -> None:
+        super().__init__()
+        self.keypoint_weight = float(keypoint_weight)
+
+    def forward(
+        self,
+        pred_player_kp_3d: Tensor,
+        target_player_kp_3d: Tensor,
+        *,
+        human_vis: Tensor | None = None,
+    ) -> dict[str, Tensor]:
+        """Compute masked keypoint loss.
+
+        Args:
+            pred_player_kp_3d: Predicted 3D keypoints, shape (B, J, 3) or (B, T, J, 3).
+            target_player_kp_3d: Target 3D keypoints, same shape as prediction.
+            human_vis: Optional visibility mask, shape (B, J) or (B, T, J).
+
+        Returns:
+            dict: Dictionary with `total` and `keypoint_3d`.
+
+        """
+        per_elem = nn.functional.smooth_l1_loss(
+            pred_player_kp_3d,
+            target_player_kp_3d,
+            reduction="none",
+        )
+        per_joint = per_elem.mean(dim=-1)
+        kp3d_loss = _masked_joint_mean(per_joint, human_vis)
+        total = self.keypoint_weight * kp3d_loss
+        return {
+            "total": total,
+            "keypoint_3d": kp3d_loss,
+        }

--- a/src/plcs/training/metrics_kp3d.py
+++ b/src/plcs/training/metrics_kp3d.py
@@ -1,0 +1,69 @@
+"""Evaluation metrics for PLCS keypoint-3D models."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def _masked_mean(values: Tensor, mask: Tensor | None) -> Tensor:
+    if mask is None:
+        return values.mean()
+    mask_f = mask.to(dtype=values.dtype)
+    denom = mask_f.sum().clamp_min(1.0)
+    return (values * mask_f).sum() / denom
+
+
+class PLCSKeypoint3DMetrics:
+    """Compute and track keypoint-level 3D errors."""
+
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self._mpjpe_values: list[Tensor] = []
+        self._pelvis_values: list[Tensor] = []
+
+    def update(
+        self,
+        pred_player_kp_3d: Tensor,
+        target_player_kp_3d: Tensor,
+        *,
+        human_vis: Tensor | None = None,
+    ) -> dict[str, float]:
+        """Update running metrics.
+
+        Args:
+            pred_player_kp_3d: Predicted 3D keypoints, shape (B, J, 3).
+            target_player_kp_3d: Target 3D keypoints, shape (B, J, 3).
+            human_vis: Optional visibility mask, shape (B, J).
+
+        Returns:
+            dict: Batch-level metrics.
+
+        """
+        per_joint_error = (pred_player_kp_3d - target_player_kp_3d).norm(dim=-1)
+        mpjpe = _masked_mean(per_joint_error, human_vis)
+        pelvis_error = (pred_player_kp_3d[:, 0, :] - target_player_kp_3d[:, 0, :]).norm(dim=-1).mean()
+
+        self._mpjpe_values.append(mpjpe.detach().cpu().reshape(1))
+        self._pelvis_values.append(pelvis_error.detach().cpu().reshape(1))
+
+        return {
+            "mpjpe_m": mpjpe.item(),
+            "pelvis_error_m": pelvis_error.item(),
+        }
+
+    def compute(self) -> dict[str, float]:
+        """Compute aggregated metrics."""
+        if not self._mpjpe_values:
+            return {
+                "mpjpe_m": 0.0,
+                "pelvis_error_m": 0.0,
+            }
+        mpjpe = torch.cat(self._mpjpe_values).mean().item()
+        pelvis = torch.cat(self._pelvis_values).mean().item()
+        return {
+            "mpjpe_m": mpjpe,
+            "pelvis_error_m": pelvis,
+        }

--- a/src/plcs/training/runner.py
+++ b/src/plcs/training/runner.py
@@ -14,6 +14,7 @@ from src.plcs.data.datamodule import (
     PLCSSequenceDataModule,
 )
 from src.plcs.training.lightning_module import PLCSLightningModule
+from src.plcs.training.lightning_module_kp3d import PLCSKeypoint3DLightningModule
 from src.plcs.training.multiview_lightning_module import PLCSMultiViewLightningModule
 from src.plcs.training.sequence_lightning_module import PLCSSequenceLightningModule
 
@@ -29,6 +30,10 @@ class PLCSTrainingRunner(BaseTrainingRunner):
     def _is_sequence_mode(self, config: Any) -> bool:
         """Check if running in sequence mode."""
         return str(getattr(config.data, "mode", "frame")) == "sequence"
+
+    def _is_kp3d_model(self, config: Any) -> bool:
+        """Check if running keypoint-3D frame model."""
+        return str(getattr(config.model, "name", "")) == "plcs_kp3d"
 
     def build_datamodule(self, config: Any) -> pl.LightningDataModule:
         """Build PLCS data module based on config.data.mode."""
@@ -46,6 +51,8 @@ class PLCSTrainingRunner(BaseTrainingRunner):
         """Build PLCS lightning module based on config.data.mode."""
         if self._is_sequence_mode(config):
             return PLCSSequenceLightningModule(config)
+        if self._is_kp3d_model(config):
+            return PLCSKeypoint3DLightningModule(config)
         return PLCSLightningModule(config)
 
 


### PR DESCRIPTION
## Summary
- add new frame model `PLCSKeypoint3DModel` that reuses `PLCSModel` token/transformer path and predicts `player_kp_3d (B,17,3)`
- keep existing `PLCSModel` behavior unchanged (`position` / `rotation`) while extracting reusable encoder helpers
- add kp3d-specific training/inference/config pipeline (`losses_kp3d`, `metrics_kp3d`, `lightning_module_kp3d`, `predictor_kp3d`, `train_kp3d`)
- add dataset-side 3D target path (`human_kp_3d`) with backward-compatible reconstruction from existing scene fields

## Changes
- model
  - `src/plcs/models/plcs_model.py`
  - `src/plcs/models/plcs_kp3d_model.py`
  - `src/plcs/models/components/heads.py`
- training
  - `src/plcs/training/losses_kp3d.py`
  - `src/plcs/training/metrics_kp3d.py`
  - `src/plcs/training/lightning_module_kp3d.py`
  - `src/plcs/training/runner.py`
- data
  - `src/plcs/data/targets.py`
  - `src/plcs/data/dataset.py`
  - `src/plcs/data/types.py`
- inference/config/scripts
  - `src/plcs/inference/predictor_kp3d.py`
  - `src/plcs/configs/train_kp3d.yaml`
  - `src/plcs/configs/model/frame_kp3d.yaml`
  - `src/plcs/configs/loss/frame_kp3d.yaml`
  - `src/plcs/configs/run/train_kp3d.yaml`
  - `src/plcs/scripts/train_kp3d.py`

## Validation
- `ruff check` (changed files)
- `python -m compileall src/plcs`
- smoke checks:
  - `PLCSModel` output shape remains `(B,3)/(B,2)`
  - `PLCSKeypoint3DModel` output shape is `(B,17,3)`
  - `PLCSKeypoint3DLightningModule._shared_step` executes with dummy batch

Closes #235
