### PR TITLE
trajectory_completion: staged masked loss and intermediate observed auxiliary supervision

### DIFF
--- a/src/trajectory_completion/README.md
+++ b/src/trajectory_completion/README.md
@@ -50,6 +50,34 @@ Inference visualization (distinguishes predictions at observed vs masked frames)
 - Save the figure:
     - `uv run python -m src.trajectory_completion.scripts.visualize visualization.save=outputs/tmp/vis.png`
 
+## Training design: observed drift mitigation
+
+`src/trajectory_completion/training/lightning_module.py` supports two mechanisms to reduce
+drift propagation from `observed` to `masked`.
+
+- Masked-loss schedule:
+    - `training.loss.masked_schedule.enabled`
+    - `training.loss.masked_schedule.start_epoch`
+    - `training.loss.masked_schedule.end_epoch`
+    - `training.loss.masked_schedule.weight_min`
+    - `training.loss.masked_schedule.weight_max`
+- Auxiliary observed loss on intermediate layers:
+    - `training.loss.auxiliary_observed.enabled`
+    - `training.loss.auxiliary_observed.weight`
+    - `training.loss.auxiliary_observed.depth_weighting` (`linear` or `exp`)
+    - `training.loss.auxiliary_observed.exp_gamma`
+    - `training.loss.auxiliary_observed.predictor_hidden_dim`
+
+Recommended recipe:
+- Early training: keep masked weight small (`weight_min`) and optimize observed + smoothness.
+- Later training: ramp masked weight to `weight_max`.
+- Keep auxiliary observed loss enabled to retain token-local coordinate information.
+
+New logs:
+- `train/val masked_weight_t`: effective masked loss weight after scheduling.
+- `train/val loss_aux`: summed auxiliary observed loss (before global aux scaling).
+- `train/val boundary_jump_pred`, `boundary_jump_gt`, `boundary_jump_error`: boundary jump diagnostics at observed/masked transitions.
+
 ## Data loading optimization
 
 - `data.cache_max_scenes`: LRU cache size for scene NPZ files.

--- a/src/trajectory_completion/configs/training/default.yaml
+++ b/src/trajectory_completion/configs/training/default.yaml
@@ -20,6 +20,18 @@ loss:
   observed_weight: 0.16
   smoothness_weight: 0.01
   huber_delta: 0.02
+  masked_schedule:
+    enabled: true
+    start_epoch: 0
+    end_epoch: 20
+    weight_min: 0.0
+    weight_max: 1.0
+  auxiliary_observed:
+    enabled: true
+    weight: 0.2
+    depth_weighting: linear  # linear | exp
+    exp_gamma: 1.5
+    predictor_hidden_dim: ${model.hidden_dim}
 
 # ---- Callbacks (BaseTrainingRunner references) ----
 checkpoint:

--- a/src/trajectory_completion/models/uv_completion_model.py
+++ b/src/trajectory_completion/models/uv_completion_model.py
@@ -184,7 +184,8 @@ class UVTrajectoryCompletionModel(nn.Module):
         court_vis: Tensor | None = None,
         seq_len: Tensor | None = None,
         ball_mask: Tensor | None = None,
-    ) -> Tensor:
+        return_intermediate_ball_hidden: bool = False,
+    ) -> Tensor | tuple[Tensor, list[Tensor]]:
         """Forward.
 
         Args:
@@ -194,9 +195,13 @@ class UVTrajectoryCompletionModel(nn.Module):
             court_vis: (B, 20) court visibility mask.
             seq_len: (B,) valid sequence lengths.
             ball_mask: (B, T) padding mask (1=valid).
+            return_intermediate_ball_hidden: If True, also return ball token
+                hidden states after each transformer block.
 
         Returns:
-            Completed UV predictions: (B, T, 2)
+            Completed UV predictions: (B, T, 2). If
+            ``return_intermediate_ball_hidden=True``, returns
+            ``(pred, intermediate_ball_hidden_list)``.
         """
         B, T, _ = ball_uv_in.shape
         if T > self.max_seq_len:
@@ -241,6 +246,7 @@ class UVTrajectoryCompletionModel(nn.Module):
             attn_mask = key_padding_mask[:, None, :].expand(B, S, S)
 
         residual = None
+        intermediate_ball_hidden: list[Tensor] = []
         for block in self.blocks:
             x, residual = block(
                 x,
@@ -250,6 +256,8 @@ class UVTrajectoryCompletionModel(nn.Module):
                 attn_mask=attn_mask,
                 is_causal=self.causal,
             )
+            if return_intermediate_ball_hidden:
+                intermediate_ball_hidden.append(x[:, NUM_COURT_KP:, :])
 
         if residual is None:
             x = self.final_norm(x)
@@ -257,7 +265,10 @@ class UVTrajectoryCompletionModel(nn.Module):
             x, _ = self.final_norm(x, residual)
 
         ball_h = x[:, NUM_COURT_KP:, :]
-        return self.head(ball_h)
+        pred = self.head(ball_h)
+        if return_intermediate_ball_hidden:
+            return pred, intermediate_ball_hidden
+        return pred
 
 
 if __name__ == "__main__":

--- a/src/trajectory_completion/training/lightning_module.py
+++ b/src/trajectory_completion/training/lightning_module.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import torch
 from torch import Tensor
+from torch import nn
 from torch.nn import functional as F
 
 from src.base.training.lightning_module import BaseLightningModule
@@ -32,6 +33,15 @@ def _smoothness_loss(pred: Tensor, mask: Tensor) -> Tensor:
     return (a.abs().sum(dim=-1) * m2).sum() / denom
 
 
+def _boundary_jump(pred: Tensor, valid: Tensor, observed: Tensor) -> Tensor:
+    if pred.shape[1] < 2:
+        return pred.new_tensor(0.0)
+    switch = valid[:, 1:] & valid[:, :-1] & (observed[:, 1:] != observed[:, :-1])
+    jump = torch.linalg.vector_norm(pred[:, 1:] - pred[:, :-1], dim=-1)
+    denom = switch.to(pred.dtype).sum().clamp_min(1.0)
+    return (jump * switch.to(pred.dtype)).sum() / denom
+
+
 class TrajectoryCompletionLightningModule(BaseLightningModule):
     """Train a UV trajectory completion model."""
 
@@ -48,6 +58,34 @@ class TrajectoryCompletionLightningModule(BaseLightningModule):
         self.smoothness_weight = float(loss_cfg.get("smoothness_weight", 0.0))
         self.huber_delta = float(loss_cfg.get("huber_delta", 0.02))
 
+        masked_schedule_cfg = loss_cfg.get("masked_schedule", {}) or {}
+        self.masked_schedule_enabled = bool(masked_schedule_cfg.get("enabled", False))
+        self.masked_schedule_start_epoch = int(masked_schedule_cfg.get("start_epoch", 0))
+        self.masked_schedule_end_epoch = int(masked_schedule_cfg.get("end_epoch", 0))
+        self.masked_weight_min = float(masked_schedule_cfg.get("weight_min", self.masked_weight))
+        self.masked_weight_max = float(masked_schedule_cfg.get("weight_max", self.masked_weight))
+
+        aux_cfg = loss_cfg.get("auxiliary_observed", {}) or {}
+        self.auxiliary_observed_enabled = bool(aux_cfg.get("enabled", False))
+        self.auxiliary_observed_weight = float(aux_cfg.get("weight", 0.0))
+        self.auxiliary_depth_weighting = str(aux_cfg.get("depth_weighting", "linear"))
+        self.auxiliary_exp_gamma = float(aux_cfg.get("exp_gamma", 1.5))
+        self.auxiliary_predictor_hidden_dim = int(aux_cfg.get("predictor_hidden_dim", self.model.hidden_dim))
+        self.auxiliary_layer_weights = self._build_auxiliary_layer_weights(len(self.model.blocks))
+
+        self.auxiliary_observed_heads: nn.ModuleList | None = None
+        if self.auxiliary_observed_enabled and len(self.model.blocks) > 0:
+            self.auxiliary_observed_heads = nn.ModuleList(
+                [
+                    nn.Sequential(
+                        nn.Linear(self.model.hidden_dim, self.auxiliary_predictor_hidden_dim),
+                        nn.GELU(),
+                        nn.Linear(self.auxiliary_predictor_hidden_dim, 2),
+                    )
+                    for _ in range(len(self.model.blocks))
+                ]
+            )
+
         self.masked_accuracy_threshold = float(metrics_cfg.get("masked_accuracy_threshold_px", 2.0))
         self.observed_accuracy_threshold = float(metrics_cfg.get("observed_accuracy_threshold_px", 2.0))
 
@@ -61,20 +99,104 @@ class TrajectoryCompletionLightningModule(BaseLightningModule):
             ball_mask=batch.get("ball_mask"),
         )
 
+    def _build_auxiliary_layer_weights(self, num_layers: int) -> Tensor:
+        if num_layers <= 0:
+            return torch.empty(0)
+        if self.auxiliary_depth_weighting == "exp":
+            raw = torch.tensor(
+                [self.auxiliary_exp_gamma ** i for i in range(num_layers)],
+                dtype=torch.float32,
+            )
+        elif self.auxiliary_depth_weighting == "linear":
+            raw = torch.arange(1, num_layers + 1, dtype=torch.float32)
+        else:
+            raise ValueError(
+                f"Invalid training.loss.auxiliary_observed.depth_weighting: "
+                f"{self.auxiliary_depth_weighting}. Use 'linear' or 'exp'."
+            )
+        return raw / raw.sum().clamp_min(1e-8)
+
+    def _current_masked_weight(self) -> float:
+        if not self.masked_schedule_enabled:
+            return self.masked_weight
+        if self.masked_schedule_end_epoch <= self.masked_schedule_start_epoch:
+            return self.masked_weight_max
+        epoch = int(self.current_epoch)
+        if epoch <= self.masked_schedule_start_epoch:
+            return self.masked_weight_min
+        if epoch >= self.masked_schedule_end_epoch:
+            return self.masked_weight_max
+        ratio = (epoch - self.masked_schedule_start_epoch) / float(
+            self.masked_schedule_end_epoch - self.masked_schedule_start_epoch
+        )
+        return self.masked_weight_min + ratio * (self.masked_weight_max - self.masked_weight_min)
+
+    def _forward_with_auxiliary(self, batch: dict[str, Tensor]) -> tuple[Tensor, list[Tensor] | None]:
+        if self.auxiliary_observed_enabled and self.auxiliary_observed_heads is not None:
+            pred, intermediate = self.model(
+                ball_uv_in=batch["ball_uv_in"],
+                ball_obs_mask=batch["ball_obs_mask"],
+                court_kp=batch["court_kp"],
+                court_vis=batch.get("court_vis"),
+                seq_len=batch.get("seq_len"),
+                ball_mask=batch.get("ball_mask"),
+                return_intermediate_ball_hidden=True,
+            )
+            return pred, intermediate
+        return self.forward(batch), None
+
+    def _compute_auxiliary_observed_loss(
+        self,
+        intermediate_ball_hidden: list[Tensor] | None,
+        ball_uv_gt: Tensor,
+        observed: Tensor,
+    ) -> tuple[Tensor, dict[str, Tensor]]:
+        loss_aux_total = ball_uv_gt.new_tensor(0.0)
+        logs: dict[str, Tensor] = {}
+        if (
+            not self.auxiliary_observed_enabled
+            or self.auxiliary_observed_heads is None
+            or not intermediate_ball_hidden
+            or self.auxiliary_observed_weight <= 0
+        ):
+            return loss_aux_total, logs
+
+        layer_weights = self.auxiliary_layer_weights.to(device=ball_uv_gt.device, dtype=ball_uv_gt.dtype)
+        if len(intermediate_ball_hidden) != len(self.auxiliary_observed_heads):
+            raise RuntimeError(
+                "Mismatch between intermediate hidden states and auxiliary heads: "
+                f"{len(intermediate_ball_hidden)} vs {len(self.auxiliary_observed_heads)}."
+            )
+
+        for idx, (hidden, head) in enumerate(zip(intermediate_ball_hidden, self.auxiliary_observed_heads, strict=True)):
+            pred_aux = head(hidden)
+            loss_aux_layer = _masked_huber(pred_aux, ball_uv_gt, observed, delta=self.huber_delta)
+            weighted = layer_weights[idx] * loss_aux_layer
+            loss_aux_total = loss_aux_total + weighted
+            logs[f"loss_aux_layer{idx + 1}"] = loss_aux_layer.detach()
+            logs[f"loss_aux_weight_layer{idx + 1}"] = layer_weights[idx].detach()
+        return loss_aux_total, logs
+
     def training_step(self, batch: dict[str, Tensor], batch_idx: int) -> Tensor:  # noqa: ARG002
-        pred = self.forward(batch)
-        loss, logs = self._compute_losses(pred, batch)
+        pred, intermediate = self._forward_with_auxiliary(batch)
+        loss, logs = self._compute_losses(pred, batch, intermediate_ball_hidden=intermediate)
         self.log_dict({f"train/{k}": v for k, v in logs.items()}, on_step=True, on_epoch=True)
         return loss
 
     def validation_step(self, batch: dict[str, Tensor], batch_idx: int) -> None:  # noqa: ARG002
-        pred = self.forward(batch)
-        loss, logs = self._compute_losses(pred, batch)
+        pred, intermediate = self._forward_with_auxiliary(batch)
+        loss, logs = self._compute_losses(pred, batch, intermediate_ball_hidden=intermediate)
         self.log("val/loss", loss, prog_bar=True, on_epoch=True)
         for k, v in logs.items():
             self.log(f"val/{k}", v, on_epoch=True)
 
-    def _compute_losses(self, pred: Tensor, batch: dict[str, Tensor]) -> tuple[Tensor, dict[str, Tensor]]:
+    def _compute_losses(
+        self,
+        pred: Tensor,
+        batch: dict[str, Tensor],
+        *,
+        intermediate_ball_hidden: list[Tensor] | None = None,
+    ) -> tuple[Tensor, dict[str, Tensor]]:
         ball_uv_gt = batch["ball_uv_gt"]
         ball_mask = batch["ball_mask"]
         ball_vis = batch["ball_vis"]
@@ -101,13 +223,18 @@ class TrajectoryCompletionLightningModule(BaseLightningModule):
 
         loss_masked = _masked_huber(pred, ball_uv_gt, masked, delta=self.huber_delta)
         loss_observed = _masked_huber(pred, ball_uv_gt, observed, delta=self.huber_delta)
+        masked_weight_t = self._current_masked_weight()
 
-        loss = self.masked_weight * loss_masked + self.observed_weight * loss_observed
+        loss = masked_weight_t * loss_masked + self.observed_weight * loss_observed
 
         loss_smooth = pred.new_tensor(0.0)
         if self.smoothness_weight > 0:
             loss_smooth = _smoothness_loss(pred, valid)
             loss = loss + self.smoothness_weight * loss_smooth
+
+        loss_aux, aux_logs = self._compute_auxiliary_observed_loss(intermediate_ball_hidden, ball_uv_gt, observed)
+        if self.auxiliary_observed_enabled and self.auxiliary_observed_weight > 0:
+            loss = loss + self.auxiliary_observed_weight * loss_aux
 
         acc_masked = pred.new_tensor(0.0)
         acc_observed = pred.new_tensor(0.0)
@@ -124,14 +251,23 @@ class TrajectoryCompletionLightningModule(BaseLightningModule):
 
         denom = valid.to(torch.float32).sum().clamp_min(1.0)
         masked_ratio = masked.to(torch.float32).sum() / denom
+        boundary_jump_pred = _boundary_jump(pred, valid, observed)
+        boundary_jump_gt = _boundary_jump(ball_uv_gt, valid, observed)
+        boundary_jump_error = (boundary_jump_pred - boundary_jump_gt).abs()
         logs = {
             "loss_masked": loss_masked.detach(),
             "loss_observed": loss_observed.detach(),
             "loss_smooth": loss_smooth.detach(),
+            "loss_aux": loss_aux.detach(),
+            "masked_weight_t": pred.new_tensor(float(masked_weight_t)).detach(),
             "masked_ratio": masked_ratio.detach(),
             "accuracy_masked": acc_masked.detach(),
             "accuracy_observed": acc_observed.detach(),
+            "boundary_jump_pred": boundary_jump_pred.detach(),
+            "boundary_jump_gt": boundary_jump_gt.detach(),
+            "boundary_jump_error": boundary_jump_error.detach(),
         }
+        logs.update(aux_logs)
         return loss, logs
 
     # configure_optimizers inherited from BaseLightningModule


### PR DESCRIPTION
## Summary
- add masked loss scheduling to gradually ramp `masked` contribution by epoch
- add intermediate-layer observed auxiliary supervision to preserve token-local coordinate memory
- add observed/masked boundary jump diagnostics and document the training recipe

## Changes
- `UVTrajectoryCompletionModel.forward` now optionally returns intermediate ball hidden states
- `TrajectoryCompletionLightningModule` now supports:
  - `training.loss.masked_schedule.*`
  - `training.loss.auxiliary_observed.*`
  - additional logs: `masked_weight_t`, `loss_aux`, `boundary_jump_*`
- update default training config with schedule/aux settings
- update README with usage and expected behavior

## Validation
- `python -m src.trajectory_completion.models.uv_completion_model`
- `python -m src.trajectory_completion.training.lightning_module`
- `python -m py_compile src/trajectory_completion/models/uv_completion_model.py src/trajectory_completion/training/lightning_module.py src/trajectory_completion/inference/uv_predictor.py`

Closes #241
