### PR TITLE
PLCS: separate vis semantics from padding masks in sequence/multiview

### DIFF
--- a/src/plcs/data/multiview_dataset.py
+++ b/src/plcs/data/multiview_dataset.py
@@ -270,6 +270,7 @@ def collate_multiview(
     position_batch = []
     rotation_batch = []
     num_views_batch = []
+    view_mask_batch = []
 
     for sample in batch:
         n_views = sample["num_views"].item()
@@ -311,6 +312,9 @@ def collate_multiview(
             human_vis = sample["human_vis"]
             court_vis = sample["court_vis"]
 
+        view_mask = torch.zeros(max_views, dtype=torch.bool)
+        view_mask[:n_views] = True
+
         human_kp_batch.append(human_kp)
         court_kp_batch.append(court_kp)
         human_vis_batch.append(human_vis)
@@ -318,6 +322,7 @@ def collate_multiview(
         position_batch.append(sample["position"])
         rotation_batch.append(sample["rotation"])
         num_views_batch.append(sample["num_views"])
+        view_mask_batch.append(view_mask)
 
     return {
         "human_kp": torch.stack(human_kp_batch, dim=0),  # (B, N_max, 17, 2)
@@ -326,6 +331,7 @@ def collate_multiview(
         "court_vis": torch.stack(court_vis_batch, dim=0),  # (B, N_max, 20)
         "camera_params": [s["camera_params"] for s in batch],  # List of lists
         "num_views": torch.stack(num_views_batch, dim=0),  # (B,)
+        "view_mask": torch.stack(view_mask_batch, dim=0),  # (B, N_max)
         "position": torch.stack(position_batch, dim=0),  # (B, 3)
         "rotation": torch.stack(rotation_batch, dim=0),  # (B, 2)
     }

--- a/src/plcs/data/types.py
+++ b/src/plcs/data/types.py
@@ -90,6 +90,7 @@ class PLCSMultiViewBatchCollated(TypedDict):
     court_vis: torch.Tensor  # (B, N_cam, 20) visibility flags for court keypoints
     camera_params: list[list[dict]]  # Per-sample list of camera parameter dicts
     num_views: torch.Tensor  # (B,) number of views in each sample
+    view_mask: torch.Tensor  # (B, N_cam) True for valid camera views
     position: torch.Tensor  # (B, 3) normalized court position (shared GT)
     rotation: torch.Tensor  # (B, 2) player orientation (shared GT)
 

--- a/src/plcs/inference/multiview_predictor.py
+++ b/src/plcs/inference/multiview_predictor.py
@@ -103,8 +103,8 @@ class PLCSMultiViewPredictor(BasePredictor):
         self,
         human_kp: Tensor,
         court_kp: Tensor,
-        human_kp_mask: Tensor | None = None,
-        court_kp_mask: Tensor | None = None,
+        human_vis: Tensor | None = None,
+        court_vis: Tensor | None = None,
         view_mask: Tensor | None = None,
         seq_mask: Tensor | None = None,
         denormalize: bool = True,
@@ -121,8 +121,8 @@ class PLCSMultiViewPredictor(BasePredictor):
         Args:
             human_kp: Human keypoints. Shape (B, N, T, 17, 2) or (N, T, 17, 2).
             court_kp: Court keypoints. Shape (B, N, T, 20, 2) or (N, T, 20, 2).
-            human_kp_mask: Human keypoint visibility mask. Shape (B, N, T, 17).
-            court_kp_mask: Court keypoint visibility mask. Shape (B, N, T, 20).
+            human_vis: Human keypoint visibility mask. Shape (B, N, T, 17).
+            court_vis: Court keypoint visibility mask. Shape (B, N, T, 20).
             view_mask: Valid view mask. Shape (B, N) where True = valid view.
             seq_mask: Valid sequence mask. Shape (B, T) where True = valid frame.
             denormalize: If True, convert positions to meters.
@@ -140,10 +140,10 @@ class PLCSMultiViewPredictor(BasePredictor):
             human_kp = human_kp.unsqueeze(0)
         if court_kp.dim() == 4:
             court_kp = court_kp.unsqueeze(0)
-        if human_kp_mask is not None and human_kp_mask.dim() == 3:
-            human_kp_mask = human_kp_mask.unsqueeze(0)
-        if court_kp_mask is not None and court_kp_mask.dim() == 3:
-            court_kp_mask = court_kp_mask.unsqueeze(0)
+        if human_vis is not None and human_vis.dim() == 3:
+            human_vis = human_vis.unsqueeze(0)
+        if court_vis is not None and court_vis.dim() == 3:
+            court_vis = court_vis.unsqueeze(0)
         if view_mask is not None and view_mask.dim() == 1:
             view_mask = view_mask.unsqueeze(0)
         if seq_mask is not None and seq_mask.dim() == 1:
@@ -152,10 +152,10 @@ class PLCSMultiViewPredictor(BasePredictor):
         # Move to device
         human_kp = human_kp.to(self.device)
         court_kp = court_kp.to(self.device)
-        if human_kp_mask is not None:
-            human_kp_mask = human_kp_mask.to(self.device)
-        if court_kp_mask is not None:
-            court_kp_mask = court_kp_mask.to(self.device)
+        if human_vis is not None:
+            human_vis = human_vis.to(self.device)
+        if court_vis is not None:
+            court_vis = court_vis.to(self.device)
         if view_mask is not None:
             view_mask = view_mask.to(self.device)
         if seq_mask is not None:
@@ -166,9 +166,10 @@ class PLCSMultiViewPredictor(BasePredictor):
         outputs = self.model(
             human_kp=human_kp,
             court_kp=court_kp,
-            human_vis=human_kp_mask,
-            court_vis=court_kp_mask,
-            num_views=None,
+            human_vis=human_vis,
+            court_vis=court_vis,
+            view_mask=view_mask,
+            seq_mask=seq_mask,
             camera_params=None,
         )
 

--- a/src/plcs/inference/sequence_predictor.py
+++ b/src/plcs/inference/sequence_predictor.py
@@ -90,6 +90,7 @@ class PLCSSequencePredictor(BasePredictor):
         court_kp: Tensor,
         human_vis: Tensor | None = None,
         court_vis: Tensor | None = None,
+        seq_mask: Tensor | None = None,
         denormalize: bool = True,
     ) -> dict[str, Tensor]:
         """Predict player 3D position and orientation sequences.
@@ -99,6 +100,7 @@ class PLCSSequencePredictor(BasePredictor):
             court_kp: Court keypoints. Shape (B, T, 40) or (B, T, 20, 2).
             human_vis: Human keypoint visibility mask. Shape (B, T, 17).
             court_vis: Court keypoint visibility mask. Shape (B, T, 20).
+            seq_mask: Sequence padding mask. Shape (B, T), True = valid frame.
             denormalize: If True, convert positions to meters.
 
         Returns:
@@ -116,9 +118,11 @@ class PLCSSequencePredictor(BasePredictor):
             human_vis = human_vis.to(self.device)
         if court_vis is not None:
             court_vis = court_vis.to(self.device)
+        if seq_mask is not None:
+            seq_mask = seq_mask.to(self.device)
 
         # Forward pass
-        outputs = self.model(human_kp, court_kp, human_vis, court_vis)
+        outputs = self.model(human_kp, court_kp, human_vis, court_vis, seq_mask)
 
         position = outputs["position"].cpu()  # (B, T, 3)
         rotation = outputs["rotation"].cpu()  # (B, T, 2)

--- a/src/plcs/models/plcs_multiview_model.py
+++ b/src/plcs/models/plcs_multiview_model.py
@@ -255,7 +255,8 @@ class PLCSMultiViewModel(nn.Module):
         court_kp: Tensor,
         human_vis: Tensor | None = None,
         court_vis: Tensor | None = None,
-        num_views: Tensor | None = None,
+        view_mask: Tensor | None = None,
+        seq_mask: Tensor | None = None,
         camera_params: list[list[dict]] | None = None,
     ) -> dict[str, Tensor]:
         """Forward pass.
@@ -281,10 +282,12 @@ class PLCSMultiViewModel(nn.Module):
                 - Single frame: (B, N, 20)
                 Each element is interpreted as visible if > 0.
                 Optional; if None, all court keypoints are treated as visible.
-            num_views:
-                Number of valid camera views per sample. Shape: (B,).
-                Cameras with index >= num_views[b] are treated as padded/invalid.
+            view_mask:
+                Padding mask for camera views. Shape: (B, N), True = valid view.
                 Optional; if None, all N views are treated as valid.
+            seq_mask:
+                Padding mask for sequence frames. Shape: (B, T), True = valid frame.
+                Optional; if None, all T frames are treated as valid.
             camera_params:
                 Camera metadata per sample/view (currently unused by this model).
 
@@ -321,6 +324,28 @@ class PLCSMultiViewModel(nn.Module):
         if T > self.max_seq_len:
             raise ValueError(f"Sequence length T={T} exceeds max_seq_len={self.max_seq_len}.")
 
+        if view_mask is not None:
+            if view_mask.dim() == 1:
+                view_mask = view_mask.unsqueeze(0)
+            if view_mask.shape != (B, N):
+                raise ValueError(
+                    f"view_mask must have shape {(B, N)}, got {tuple(view_mask.shape)}"
+                )
+            view_valid = view_mask > 0
+        else:
+            view_valid = torch.ones(B, N, dtype=torch.bool, device=device)
+
+        if seq_mask is not None:
+            if seq_mask.dim() == 1:
+                seq_mask = seq_mask.unsqueeze(0)
+            if seq_mask.shape != (B, T):
+                raise ValueError(
+                    f"seq_mask must have shape {(B, T)}, got {tuple(seq_mask.shape)}"
+                )
+            seq_valid = seq_mask > 0
+        else:
+            seq_valid = torch.ones(B, T, dtype=torch.bool, device=device)
+
         # court is camera-level (use first frame per camera)
         court_scene = court_kp[:, :, 0, :, :]  # (B,N,20,2)
         court_scene_flat = court_scene.reshape(B * N, NUM_COURT_KP, 2)
@@ -351,31 +376,19 @@ class PLCSMultiViewModel(nn.Module):
         tokens_per_camera = torch.cat([court_tok, frame_tok], dim=2)  # (B,N,L_cam,D)
         x = tokens_per_camera.reshape(B, N * camera_block_tokens, self.hidden_dim)
 
-        # Build token validity mask for padded views/empty frames.
-        if num_views is None:
-            view_valid = torch.ones(B, N, dtype=torch.bool, device=device)
-        else:
-            view_idx = torch.arange(N, device=device).view(1, N)
-            view_valid = view_idx < num_views.view(B, 1)
-
-        if human_vis is None:
-            frame_valid = torch.ones(B, N, T, dtype=torch.bool, device=device)
-        else:
-            frame_valid = human_vis.sum(dim=-1) > 0
-
-        if court_vis is None:
-            court_valid = torch.ones(B, N, dtype=torch.bool, device=device)
-        else:
-            court_valid = court_vis[:, :, 0, :].sum(dim=-1) > 0
-
-        court_token_valid = view_valid & court_valid
-        frame_token_valid = frame_valid & view_valid.unsqueeze(-1)
+        # Build token validity mask from padding masks only.
+        frame_token_valid = view_valid.unsqueeze(-1) & seq_valid.unsqueeze(1)
+        court_token_valid = view_valid
 
         court_rep = court_token_valid.unsqueeze(-1).expand(B, N, NUM_COURT_KP)
-        frame_rep = frame_token_valid.unsqueeze(-1).expand(B, N, T, self.frame_block_tokens)
+        frame_rep = frame_token_valid.unsqueeze(-1).expand(
+            B, N, T, self.frame_block_tokens
+        )
         frame_rep = frame_rep.reshape(B, N, T * self.frame_block_tokens)
 
-        token_valid = torch.cat([court_rep, frame_rep], dim=-1).reshape(B, N * camera_block_tokens)
+        token_valid = torch.cat([court_rep, frame_rep], dim=-1).reshape(
+            B, N * camera_block_tokens
+        )
 
         x = x * token_valid.unsqueeze(-1).to(dtype=x.dtype)
 

--- a/src/plcs/models/plcs_sequence_model.py
+++ b/src/plcs/models/plcs_sequence_model.py
@@ -198,6 +198,7 @@ class PLCSSequenceModel(nn.Module):
         court_kp: Tensor,
         human_vis: Tensor | None = None,
         court_vis: Tensor | None = None,
+        seq_mask: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Forward pass.
 
@@ -221,6 +222,9 @@ class PLCSSequenceModel(nn.Module):
                 Shape: (B, 20) or (B, T, 20). Each element is interpreted as
                 visible if > 0. For per-frame input, frame 0 is used.
                 Optional; if None, all court keypoints are treated as visible.
+            seq_mask:
+                Sequence padding mask. Shape: (B, T), True = valid frame.
+                Optional; if None, all frames are treated as valid.
 
         Returns:
             dict with:
@@ -269,6 +273,21 @@ class PLCSSequenceModel(nn.Module):
         if freqs_cis.device != x.device:
             freqs_cis = freqs_cis.to(x.device)
 
+        attn_mask: Tensor | None = None
+        if seq_mask is not None:
+            if seq_mask.dim() == 1:
+                seq_mask = seq_mask.unsqueeze(0)
+            if seq_mask.shape != (B, T):
+                raise ValueError(
+                    f"seq_mask must have shape {(B, T)}, got {tuple(seq_mask.shape)}"
+                )
+            seq_valid = seq_mask > 0
+            court_valid = torch.ones(B, NUM_COURT_KP, device=x.device, dtype=torch.bool)
+            frame_valid = seq_valid.unsqueeze(-1).expand(B, T, self.frame_block_tokens)
+            frame_valid = frame_valid.reshape(B, T * self.frame_block_tokens)
+            token_valid = torch.cat([court_valid, frame_valid], dim=1)
+            attn_mask = token_valid[:, None, :] & token_valid[:, :, None]
+
         residual = None
         for blk in self.blocks:
             x, residual = blk(
@@ -276,7 +295,7 @@ class PLCSSequenceModel(nn.Module):
                 residual,
                 start_pos=0,
                 freqs_cis=freqs_cis,
-                attn_mask=None,
+                attn_mask=attn_mask,
                 is_causal=False,
             )
 

--- a/src/plcs/scripts/visualize_multiview.py
+++ b/src/plcs/scripts/visualize_multiview.py
@@ -361,13 +361,17 @@ def main_predict_multiview(cfg: RuntimeConfig) -> int:
                 court_vis_chunk, (0, 0, 0, pad_len, 0, 0)
             )
 
+        seq_mask = torch.zeros(seq_len, dtype=torch.bool)
+        seq_mask[:chunk_len] = True
+
         # Run prediction on chunk: input (N, T, K, 2), output (1, T, 3)
         pred = predictor.predict(
             human_kp=human_kp_chunk,
             court_kp=court_kp_chunk,
-            human_kp_mask=human_vis_chunk,
-            court_kp_mask=court_vis_chunk,
+            human_vis=human_vis_chunk,
+            court_vis=court_vis_chunk,
             view_mask=None,
+            seq_mask=seq_mask,
             denormalize=False,
         )
 

--- a/src/plcs/training/multiview_lightning_module.py
+++ b/src/plcs/training/multiview_lightning_module.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from torch import Tensor
 
 from src.base.training.lightning_module import BaseLightningModule
@@ -62,7 +62,8 @@ class PLCSMultiViewLightningModule(BaseLightningModule):
         court_kp: Tensor,
         human_vis: Tensor | None = None,
         court_vis: Tensor | None = None,
-        num_views: Tensor | None = None,
+        view_mask: Tensor | None = None,
+        seq_mask: Tensor | None = None,
         camera_params: list[list[dict]] | None = None,
     ) -> dict[str, Any]:
         """Forward pass.
@@ -80,7 +81,8 @@ class PLCSMultiViewLightningModule(BaseLightningModule):
             court_vis: Court visibility mask.
                 - Frame-based: shape (B, N, 20)
                 - Sequence-based: shape (B, N, T, 20)
-            num_views: Number of valid views per sample, shape (B,).
+            view_mask: Valid view mask, shape (B, N), True = non-padding.
+            seq_mask: Valid frame mask, shape (B, T), True = non-padding.
             camera_params: Camera parameters per view.
 
         Returns:
@@ -88,7 +90,7 @@ class PLCSMultiViewLightningModule(BaseLightningModule):
 
         """
         outputs: dict[str, Any] = self.model(
-            human_kp, court_kp, human_vis, court_vis, num_views, camera_params
+            human_kp, court_kp, human_vis, court_vis, view_mask, seq_mask, camera_params
         )
         return outputs
 
@@ -113,7 +115,8 @@ class PLCSMultiViewLightningModule(BaseLightningModule):
             court_kp=batch["court_kp"],
             human_vis=batch.get("human_vis"),
             court_vis=batch.get("court_vis"),
-            num_views=batch.get("num_views"),
+            view_mask=batch.get("view_mask"),
+            seq_mask=batch.get("seq_mask"),
             camera_params=batch.get("camera_params"),
         )
 

--- a/src/plcs/training/sequence_lightning_module.py
+++ b/src/plcs/training/sequence_lightning_module.py
@@ -79,6 +79,7 @@ class PLCSSequenceLightningModule(BaseLightningModule):
         court_kp: Tensor,
         human_vis: Tensor | None = None,
         court_vis: Tensor | None = None,
+        seq_mask: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Forward pass.
 
@@ -87,12 +88,16 @@ class PLCSSequenceLightningModule(BaseLightningModule):
             court_kp: Court keypoint sequences.
             human_vis: Human visibility mask sequences.
             court_vis: Court visibility mask sequences.
+            seq_mask: Sequence padding mask.
 
         Returns:
             dict: Model outputs.
 
         """
-        return cast(dict[str, Tensor], self.model(human_kp, court_kp, human_vis, court_vis))
+        return cast(
+            dict[str, Tensor],
+            self.model(human_kp, court_kp, human_vis, court_vis, seq_mask),
+        )
 
     def _shared_step(
         self, batch: dict[str, Tensor], stage: str
@@ -113,6 +118,7 @@ class PLCSSequenceLightningModule(BaseLightningModule):
             court_kp=batch["court_kp"],
             human_vis=batch.get("human_vis"),
             court_vis=batch.get("court_vis"),
+            seq_mask=batch.get("seq_mask"),
         )
 
         # Compute loss (supports (B, T, 3/2) shapes)


### PR DESCRIPTION
## Summary
This PR implements the PLCS `vis` / `mask` responsibility split discussed in #246.

- `vis` is used for invisible-token substitution in embeddings.
- padding masks are used for attention blocking.

### What changed
1. `PLCSMultiViewModel`
- Replaced `num_views`-driven/visibility-mixed token validity with explicit padding masks:
  - `view_mask` (B, N)
  - `seq_mask` (B, T)
- Attention mask now derives from padding-only token validity.
- `human_vis` / `court_vis` remain embedding inputs only.

2. `PLCSSequenceModel`
- Added `seq_mask` input.
- Built padding-only attention mask from `seq_mask` over frame blocks.

3. Training/inference wiring
- Multi-view lightning module now passes `view_mask` / `seq_mask` from batch.
- Sequence lightning module now passes `seq_mask`.
- Multi-view predictor now passes `human_vis` / `court_vis` and forwards `view_mask` / `seq_mask` to model.
- Sequence predictor now accepts and forwards `seq_mask`.

4. Data/script alignment
- `collate_multiview` now emits `view_mask` for frame-based multi-view batches.
- `visualize_multiview.py` now builds and passes `seq_mask` for padded tail chunks.
- Updated multi-view collated type schema to include `view_mask`.

## Validation
- Ran `python -m compileall` on all modified PLCS files.
- Runtime smoke script hit an unrelated pre-existing import issue in `src/plcs/__init__.py` (`PerTokenKeypoint3DHead`).

Closes #246
