### PR TITLE
feat: add ball detection inference utilities

### DIFF
--- a/src/tasks/ball_detection/configs/infer_video.yaml
+++ b/src/tasks/ball_detection/configs/infer_video.yaml
@@ -1,0 +1,26 @@
+defaults:
+  - model: stunet
+  - data: rgb_sequence
+  - _self_
+
+checkpoint_path: checkpoints/ball_detection/best.pt
+video_path: data/samples/clip.mp4
+output_video_path: outputs/ball_detection/inference/sample_clip_overlay.mp4
+output_json_path: outputs/ball_detection/inference/sample_clip_predictions.json
+
+inference:
+  device: auto
+  batch_size: 8
+  confidence_threshold: 0.5
+  video_codec: mp4v
+  draw:
+    radius: 8
+    thickness: 2
+    font_scale: 0.8
+
+hydra:
+  run:
+    dir: outputs/ball_detection/infer_video/${now:%Y-%m-%d_%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/tasks/ball_detection/configs/inspect_checkpoint.yaml
+++ b/src/tasks/ball_detection/configs/inspect_checkpoint.yaml
@@ -1,0 +1,12 @@
+defaults:
+  - _self_
+
+checkpoint_path: checkpoints/ball_detection/best.pt
+output_path: null
+
+hydra:
+  run:
+    dir: outputs/ball_detection/inspect_checkpoint/${now:%Y-%m-%d_%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/tasks/ball_detection/scripts/infer_video.py
+++ b/src/tasks/ball_detection/scripts/infer_video.py
@@ -1,0 +1,314 @@
+"""Run ball-detection inference on one video and save an annotated video.
+
+Example commands:
+    `uv run python -m src.tasks.ball_detection.scripts.infer_video`
+    `uv run python -m src.tasks.ball_detection.scripts.infer_video video_path=path/to/video.mp4`
+    `uv run python -m src.tasks.ball_detection.scripts.infer_video checkpoint_path=checkpoints/ball_detection/best.pt`
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import cv2
+import hydra
+import numpy as np
+import torch
+from hydra.utils import to_absolute_path
+from omegaconf import DictConfig
+from torch import nn
+from tqdm.auto import tqdm
+
+from src.tasks.ball_detection.models import build_ball_detection_model
+
+
+@dataclass(slots=True, frozen=True)
+class FramePrediction:
+    """One video-frame prediction produced by sliding-window inference."""
+
+    frame_index: int
+    frame_name: str
+    confidence: float
+    visible: bool
+    x_original: float
+    y_original: float
+    support_count: int
+
+
+def _resolve_path(value: str | None) -> Path | None:
+    if value in (None, ""):
+        return None
+    return Path(to_absolute_path(str(value))).resolve()
+
+
+def _resolve_checkpoint_payload(checkpoint_path: Path) -> dict[str, Any]:
+    payload = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    if not isinstance(payload, dict):
+        raise TypeError(
+            "Expected checkpoint payload to be a dict, "
+            f"got {type(payload).__name__}."
+        )
+    return payload
+
+
+def _load_model(cfg: DictConfig, *, checkpoint_path: Path, device: torch.device) -> nn.Module:
+    model = build_ball_detection_model(cfg).to(device)
+    payload = _resolve_checkpoint_payload(checkpoint_path)
+    state_dict = payload.get("model_state_dict", payload)
+    if not isinstance(state_dict, dict):
+        raise TypeError("Checkpoint does not contain a valid model_state_dict.")
+    model.load_state_dict(state_dict)
+    model.eval()
+    return model
+
+
+def _read_video_frames(video_path: Path) -> tuple[list[np.ndarray], float]:
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        raise RuntimeError(f"Failed to open video: {video_path}")
+
+    fps = float(cap.get(cv2.CAP_PROP_FPS) or 0.0)
+    frames_bgr: list[np.ndarray] = []
+    try:
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            frames_bgr.append(frame)
+    finally:
+        cap.release()
+
+    if not frames_bgr:
+        raise RuntimeError(f"Video contains no frames: {video_path}")
+    if fps <= 0.0:
+        fps = 30.0
+    return frames_bgr, fps
+
+
+def _preprocess_frame(frame_bgr: np.ndarray, *, image_size: tuple[int, int]) -> np.ndarray:
+    image_h, image_w = image_size
+    frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+    frame_rgb = cv2.resize(frame_rgb, (image_w, image_h))
+    return frame_rgb.astype(np.float32) / 255.0
+
+
+def _to_model_input(images: torch.Tensor) -> torch.Tensor:
+    if images.ndim != 5:
+        raise ValueError(
+            f"Expected input with shape (B, T, C, H, W), got {tuple(images.shape)}."
+        )
+    return images.permute(0, 2, 1, 3, 4).contiguous()
+
+
+def _predict_frames(
+    *,
+    model: nn.Module,
+    device: torch.device,
+    frames_bgr: list[np.ndarray],
+    cfg: DictConfig,
+) -> list[FramePrediction]:
+    num_frames = int(cfg.model.num_frames)
+    image_h = int(cfg.data.image_size[0])
+    image_w = int(cfg.data.image_size[1])
+    heatmap_h = int(cfg.data.heatmap_size[0])
+    heatmap_w = int(cfg.data.heatmap_size[1])
+    threshold = float(cfg.inference.confidence_threshold)
+    batch_size = int(cfg.inference.batch_size)
+
+    if len(frames_bgr) < num_frames:
+        raise ValueError(
+            f"Video has {len(frames_bgr)} frames but model.num_frames={num_frames}."
+        )
+    if batch_size <= 0:
+        raise ValueError("inference.batch_size must be positive.")
+
+    original_height, original_width = frames_bgr[0].shape[:2]
+    preprocessed = [
+        _preprocess_frame(frame, image_size=(image_h, image_w))
+        for frame in frames_bgr
+    ]
+
+    frame_count = len(preprocessed)
+    starts = list(range(0, frame_count - num_frames + 1))
+    heatmap_sums = np.zeros((frame_count, heatmap_h, heatmap_w), dtype=np.float32)
+    heatmap_counts = np.zeros(frame_count, dtype=np.int32)
+
+    progress = tqdm(
+        range(0, len(starts), batch_size),
+        desc="Infer video",
+        leave=False,
+        dynamic_ncols=True,
+    )
+    for batch_start_index in progress:
+        batch_starts = starts[batch_start_index : batch_start_index + batch_size]
+        batch = []
+        for start in batch_starts:
+            window = np.stack(
+                [preprocessed[start + offset].transpose(2, 0, 1) for offset in range(num_frames)]
+            )
+            batch.append(window)
+        inputs = torch.from_numpy(np.stack(batch)).to(device=device, dtype=torch.float32)
+        with torch.inference_mode():
+            probs = torch.sigmoid(model(_to_model_input(inputs))).squeeze(1).cpu().numpy()
+
+        for sample_index, start in enumerate(batch_starts):
+            for offset in range(num_frames):
+                frame_index = start + offset
+                heatmap_sums[frame_index] += probs[sample_index, offset]
+                heatmap_counts[frame_index] += 1
+    progress.close()
+
+    predictions: list[FramePrediction] = []
+    for frame_index in range(frame_count):
+        support_count = int(heatmap_counts[frame_index])
+        if support_count <= 0:
+            predictions.append(
+                FramePrediction(
+                    frame_index=frame_index,
+                    frame_name=f"{frame_index:06d}.jpg",
+                    confidence=0.0,
+                    visible=False,
+                    x_original=0.0,
+                    y_original=0.0,
+                    support_count=0,
+                )
+            )
+            continue
+        avg_heatmap = heatmap_sums[frame_index] / float(support_count)
+        avg_heatmap = np.nan_to_num(avg_heatmap, nan=0.0, posinf=0.0, neginf=0.0)
+        confidence = float(avg_heatmap.max())
+        peak_y, peak_x = np.unravel_index(int(avg_heatmap.argmax()), avg_heatmap.shape)
+        visible = confidence >= threshold
+        x_original = float(peak_x * original_width / max(heatmap_w, 1)) if visible else 0.0
+        y_original = float(peak_y * original_height / max(heatmap_h, 1)) if visible else 0.0
+        predictions.append(
+            FramePrediction(
+                frame_index=frame_index,
+                frame_name=f"{frame_index:06d}.jpg",
+                confidence=confidence,
+                visible=visible,
+                x_original=x_original,
+                y_original=y_original,
+                support_count=support_count,
+            )
+        )
+    return predictions
+
+
+def _annotate_and_write_video(
+    *,
+    frames_bgr: list[np.ndarray],
+    predictions: list[FramePrediction],
+    output_video_path: Path,
+    fps: float,
+    cfg: DictConfig,
+) -> None:
+    output_video_path.parent.mkdir(parents=True, exist_ok=True)
+    height, width = frames_bgr[0].shape[:2]
+    fourcc = cv2.VideoWriter_fourcc(*str(cfg.inference.video_codec))
+    writer = cv2.VideoWriter(str(output_video_path), fourcc, fps, (width, height))
+    if not writer.isOpened():
+        raise RuntimeError(f"Failed to open output video for writing: {output_video_path}")
+
+    radius = int(cfg.inference.draw.radius)
+    thickness = int(cfg.inference.draw.thickness)
+    font_scale = float(cfg.inference.draw.font_scale)
+    try:
+        for frame_bgr, prediction in zip(frames_bgr, predictions, strict=True):
+            annotated = frame_bgr.copy()
+            if prediction.visible:
+                cv2.circle(
+                    annotated,
+                    center=(int(round(prediction.x_original)), int(round(prediction.y_original))),
+                    radius=radius,
+                    color=(0, 0, 255),
+                    thickness=thickness,
+                    lineType=cv2.LINE_AA,
+                )
+            label = (
+                f"frame={prediction.frame_index:04d} "
+                f"conf={prediction.confidence:.3f} "
+                f"support={prediction.support_count}"
+            )
+            cv2.putText(
+                annotated,
+                label,
+                (16, 32),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                font_scale,
+                (255, 255, 255),
+                2,
+                cv2.LINE_AA,
+            )
+            writer.write(annotated)
+    finally:
+        writer.release()
+
+
+def _write_predictions_json(
+    *,
+    checkpoint_path: Path,
+    video_path: Path,
+    output_json_path: Path,
+    predictions: list[FramePrediction],
+    fps: float,
+) -> None:
+    output_json_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "checkpoint_path": str(checkpoint_path),
+        "video_path": str(video_path),
+        "fps": fps,
+        "frame_count": len(predictions),
+        "predictions": [asdict(prediction) for prediction in predictions],
+    }
+    output_json_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+@hydra.main(
+    version_base=None,
+    config_path="../configs",
+    config_name="infer_video",
+)
+def main(cfg: DictConfig) -> None:
+    """Load a checkpoint, infer one video, and save the overlay video."""
+    checkpoint_path = _resolve_path(str(cfg.checkpoint_path))
+    video_path = _resolve_path(str(cfg.video_path))
+    output_video_path = _resolve_path(str(cfg.output_video_path))
+    output_json_path = _resolve_path(str(cfg.output_json_path))
+    if checkpoint_path is None or video_path is None or output_video_path is None:
+        raise ValueError("checkpoint_path, video_path, and output_video_path are required.")
+
+    device_name = str(cfg.inference.device).lower()
+    if device_name == "auto":
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    else:
+        device = torch.device(device_name)
+
+    model = _load_model(cfg, checkpoint_path=checkpoint_path, device=device)
+    frames_bgr, fps = _read_video_frames(video_path)
+    predictions = _predict_frames(model=model, device=device, frames_bgr=frames_bgr, cfg=cfg)
+    _annotate_and_write_video(
+        frames_bgr=frames_bgr,
+        predictions=predictions,
+        output_video_path=output_video_path,
+        fps=fps,
+        cfg=cfg,
+    )
+    if output_json_path is not None:
+        _write_predictions_json(
+            checkpoint_path=checkpoint_path,
+            video_path=video_path,
+            output_json_path=output_json_path,
+            predictions=predictions,
+            fps=fps,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tasks/ball_detection/scripts/inspect_checkpoint.py
+++ b/src/tasks/ball_detection/scripts/inspect_checkpoint.py
@@ -1,0 +1,100 @@
+"""Inspect a ball-detection checkpoint and print a minimal summary.
+
+Example commands:
+    `uv run python -m src.tasks.ball_detection.scripts.inspect_checkpoint`
+    `uv run python -m src.tasks.ball_detection.scripts.inspect_checkpoint checkpoint_path=checkpoints/ball_detection/best.pt`
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import hydra
+import torch
+from hydra.utils import to_absolute_path
+from omegaconf import DictConfig
+
+
+def _resolve_checkpoint_path(cfg: DictConfig) -> Path:
+    path = Path(to_absolute_path(str(cfg.checkpoint_path))).resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"Checkpoint not found: {path}")
+    return path
+
+
+def _extract_optimizer_step(payload: dict[str, Any]) -> float | None:
+    optimizer_state = payload.get("optimizer_state_dict")
+    if not isinstance(optimizer_state, dict):
+        return None
+    states = optimizer_state.get("state")
+    if not isinstance(states, dict):
+        return None
+    for state in states.values():
+        if not isinstance(state, dict) or "step" not in state:
+            continue
+        step = state["step"]
+        if isinstance(step, torch.Tensor):
+            return float(step.detach().cpu().item())
+        if isinstance(step, (int, float)):
+            return float(step)
+    return None
+
+
+def _extract_history_tail(payload: dict[str, Any]) -> dict[str, Any] | None:
+    history = payload.get("history")
+    if not isinstance(history, list) or not history:
+        return None
+    tail = history[-1]
+    if not isinstance(tail, dict):
+        return None
+    return tail
+
+
+def _build_summary(payload: dict[str, Any], checkpoint_path: Path) -> dict[str, Any]:
+    history_tail = _extract_history_tail(payload)
+    summary = {
+        "checkpoint_path": str(checkpoint_path),
+        "top_level_keys": sorted(payload.keys()),
+        "epoch": payload.get("epoch"),
+        "phase": payload.get("phase"),
+        "phase_epoch": payload.get("phase_epoch"),
+        "best_monitor": payload.get("best_monitor"),
+        "monitor_value": payload.get("monitor_value"),
+        "optimizer_step": _extract_optimizer_step(payload),
+        "best_metrics": payload.get("best_metrics"),
+        "history_length": len(payload["history"]) if isinstance(payload.get("history"), list) else 0,
+        "last_history_entry": history_tail,
+    }
+    return summary
+
+
+@hydra.main(
+    version_base=None,
+    config_path="../configs",
+    config_name="inspect_checkpoint",
+)
+def main(cfg: DictConfig) -> None:
+    """Load the configured checkpoint and emit a compact JSON summary."""
+    checkpoint_path = _resolve_checkpoint_path(cfg)
+    payload = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    if not isinstance(payload, dict):
+        raise TypeError(
+            "Expected the checkpoint payload to be a dict, "
+            f"got {type(payload).__name__}."
+        )
+
+    summary = _build_summary(payload, checkpoint_path)
+    summary_text = json.dumps(summary, indent=2, ensure_ascii=False, default=str)
+    print(summary_text)
+
+    output_path = str(cfg.get("output_path", "") or "").strip()
+    if output_path:
+        resolved_output_path = Path(to_absolute_path(output_path)).resolve()
+        resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
+        resolved_output_path.write_text(summary_text + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add a checkpoint inspection script and Hydra config for ball-detection checkpoints.
- Add a single-video inference script and Hydra config that save an overlay video and per-frame JSON predictions.
- Stack this PR on `fix/ball-detection-lr-pseudo-label-output` to keep the new utilities isolated.

## Changes

- Add `src/tasks/ball_detection/scripts/inspect_checkpoint.py` and `src/tasks/ball_detection/configs/inspect_checkpoint.yaml`.
- Add `src/tasks/ball_detection/scripts/infer_video.py` and `src/tasks/ball_detection/configs/infer_video.yaml`.
- Load `checkpoints/ball_detection/best.pt` by default and write outputs under `outputs/ball_detection/`.

## Validation

| Script | Default command implied by config | Command used for validation | Difference |
| --- | --- | --- | --- |
| `inspect_checkpoint` | `uv run python -m src.tasks.ball_detection.scripts.inspect_checkpoint` | `uv run python -m src.tasks.ball_detection.scripts.inspect_checkpoint output_path=outputs/ball_detection/inspect_checkpoint/manual_summary.json` | Added `output_path` override to write a deterministic validation artifact. |
| `infer_video` | `uv run python -m src.tasks.ball_detection.scripts.infer_video` | `uv run python -m src.tasks.ball_detection.scripts.infer_video output_video_path=outputs/ball_detection/inference/manual_overlay.mp4 output_json_path=outputs/ball_detection/inference/manual_predictions.json` | Added output path overrides to avoid relying on the sample default filenames and to preserve explicit validation artifacts. |

- Confirmed the checkpoint summary JSON was written.
- Confirmed the inference run produced an overlay MP4 and a 325-frame prediction JSON.

## Notes

- This is a stacked PR with base branch `fix/ball-detection-lr-pseudo-label-output`.
