### PR TITLE
docs: Add Codex best practice guides

### DIFF
--- a/.codex/docs/codex-agent-md-best-practice.md
+++ b/.codex/docs/codex-agent-md-best-practice.md
@@ -1,0 +1,146 @@
+# Codex AGENTS.md ベストプラクティス
+
+## 公式例
+
+OpenAI 公式の `AGENTS.md` ガイドは、まず **グローバルな個人ルールを `~/.codex/AGENTS.md` に置き、リポジトリ固有のルールを repo 直下の `AGENTS.md` に置き、さらに必要ならサブディレクトリに `AGENTS.override.md` を置く** という構成を示しています。Codex は起動時にそれらを **global → repo root → deeper directory** の順に読み込み、現在の作業ディレクトリに近いものほど後勝ちで効きます。空ファイルは無視され、合計サイズは既定で 32 KiB までです。 ([OpenAI Developers][1])
+
+```md
+# ~/.codex/AGENTS.md
+
+## Working agreements
+
+- Always run `npm test` after modifying JavaScript files.
+- Prefer `pnpm` when installing dependencies.
+- Ask for confirmation before adding new production dependencies.
+```
+
+```md
+# AGENTS.md
+
+## Repository expectations
+
+- Run `npm run lint` before opening a pull request.
+- Document public utilities in `docs/` when you change behavior.
+```
+
+```md
+# services/payments/AGENTS.override.md
+
+## Payments service rules
+
+- Use `make test-payments` instead of `npm test`.
+- Never rotate API keys without notifying the security channel.
+```
+
+この例がよいのは、**個人の恒常ルール**、**repo 全体の共有ルール**、**局所ディレクトリの例外ルール** がきれいに分かれているからです。Codex は `AGENTS.md` を作業前に自動で読み込むため、毎回同じ前提を prompt に書き直さなくて済みます。また、より深いディレクトリの指示が強く効くので、特定パッケージだけ厳しめのルールを持たせる設計に向いています。 ([OpenAI Developers][1])
+
+---
+
+## ベストプラクティス
+
+### 1. AGENTS.md は「毎回守ってほしい永続ルール」だけを書く
+
+OpenAI は `AGENTS.md` を、repo に持ち歩ける **durable project guidance** と位置づけています。向いているのは、ビルド・テスト・lint コマンド、レビュー期待値、repo 固有の慣習、禁止事項、done の定義のように、**毎回の作業で繰り返し必要になる規則** です。 ([OpenAI Developers][2])
+
+これがよい理由は、`AGENTS.md` が長期的な作業前提を担当し、毎回の prompt はその回だけの目標や背景に集中できるからです。OpenAI も、うまくいった prompting pattern は prompt に閉じ込めず `AGENTS.md` に移すことを勧めています。 ([OpenAI Developers][3])
+
+### 2. 短く、正確に、実務的に書く
+
+OpenAI は **“Keep it small”**、**“A short, accurate AGENTS.md is more useful than a long file full of vague rules.”** という方針を示しています。長文化したら task-specific な別 markdown に逃がし、`AGENTS.md` 本体は簡潔に保つのが推奨です。 ([OpenAI Developers][2])
+
+これがよい理由は、Codex が `AGENTS.md` を会話の上流で読み込むため、曖昧で冗長な文書は routing と実行の両方を鈍らせるからです。さらに、読み込み上限は既定で 32 KiB なので、肥大化は実際に不利です。 ([OpenAI Developers][1])
+
+### 3. グローバル・repo・サブディレクトリで責務を分ける
+
+OpenAI の discovery 仕様では、`~/.codex/AGENTS.md` が個人ルール、repo root の `AGENTS.md` が共有ルール、深いディレクトリの `AGENTS.md` または `AGENTS.override.md` が局所ルールを担当します。深い階層ほど後に読み込まれ、実質的に優先されます。 ([OpenAI Developers][1])
+
+これがよい理由は、ルールの適用範囲を自然に分けられるからです。たとえば「全体では `pytest`、ただし `services/payments` だけは `make test-payments`」のような構造を、無理なく表現できます。GitHub integration でも、Codex は変更ファイルに最も近い `AGENTS.md` を重視すると説明されています。 ([OpenAI Developers][1])
+
+### 4. `AGENTS.override.md` は「その階層で上書きしたいときだけ」使う
+
+同じディレクトリに `AGENTS.override.md` がある場合、その階層では `AGENTS.md` より override が優先されます。OpenAI の例でも、`services/payments/AGENTS.md` は override があるため無視されます。 ([OpenAI Developers][1])
+
+これがよい理由は、例外ルールを明示的に扱えるからです。通常の追加ルールなら `AGENTS.md` を使い、**そのディレクトリでは通常ルールを差し替えたい** ときだけ override を使う、という使い分けが分かりやすいです。 ([OpenAI Developers][1])
+
+### 5. 内容は「どう動くべきか」が一目で分かる項目にする
+
+OpenAI の best practices では、良い `AGENTS.md` は次を含むとされています。**repo layout、実行方法、build/test/lint、engineering conventions と PR expectations、constraints / do-not rules、done の定義と検証方法** です。 ([OpenAI Developers][3])
+
+これがよい理由は、Codex が「何を変えるか」だけでなく「どこを見て」「どう検証して」「どこまでやれば完了か」を理解しやすくなるからです。結果として、余計な推測や無関係な探索が減ります。 ([OpenAI Developers][3])
+
+### 6. 同じミスが繰り返されたら AGENTS.md を更新する
+
+OpenAI は、agent が同じ誤りを繰り返す、毎回同じレビュー指摘が出る、読むファイルが多すぎる、といった摩擦が出たら **AGENTS.md にルールを追加して永続化する** ことを勧めています。これは feedback loop と明示されています。 ([OpenAI Developers][2])
+
+これがよい理由は、修正をその場限りの会話に閉じ込めず、次回以降の実行品質に変えられるからです。OpenAI は、GitHub 上でも `@codex add this to AGENTS.md` のように更新を依頼できると案内しています。 ([OpenAI Developers][2])
+
+### 7. 反復ワークフローは AGENTS.md ではなく Skills に寄せる
+
+OpenAI の customization 概念では、**AGENTS.md は行動の方針**、**Skills は再利用可能な workflow**、**MCP は外部システム接続**、**Subagents は役割分担** です。これらは競合ではなく補完関係です。 ([OpenAI Developers][2])
+
+これがよい理由は、役割を混ぜない方が保守しやすいからです。たとえば「必ず lint を走らせる」は `AGENTS.md`、`gh` で issue を作る定型手順は Skill、という分け方が自然です。 ([OpenAI Developers][2])
+
+### 8. まず `/init` を使い、その後で実態に合わせて編集する
+
+OpenAI は CLI の `/init` を、現在のディレクトリに starter `AGENTS.md` を作る quick-start としています。ただし、そのまま使うのではなく、実際の build / test / review / ship の流れに合わせて編集することを勧めています。 ([OpenAI Developers][3])
+
+これがよい理由は、白紙から始めるより速く、しかも運用に合わせて現実的に育てやすいからです。初期化は入口、運用で磨くのが本筋です。 ([OpenAI Developers][3])
+
+### 9. 読み込み確認とトラブルシュートの手順を持つ
+
+OpenAI は、`codex --ask-for-approval never "Summarize the current instructions."` や `codex --cd subdir --ask-for-approval never "Show which instruction files are active."` のように、実際にどの instruction file が効いているか確認する方法を示しています。空ファイルは無視され、想定外の guidance が出るときは上位の `AGENTS.override.md` や `CODEX_HOME` を疑うのが基本です。 ([OpenAI Developers][1])
+
+これがよい理由は、`AGENTS.md` は自動読込なので、効いていない原因が「ファイル名」「配置」「override」「別 home directory」に分かれやすいからです。確認コマンドを持っておくと、設定ミスとモデルの問題を切り分けやすくなります。 ([OpenAI Developers][1])
+
+---
+
+## 推奨テンプレート
+
+```md
+# AGENTS.md
+
+## Repository layout
+- `src/` が本体コード
+- `tests/` が自動テスト
+- `docs/` が公開ドキュメント
+
+## Working rules
+- 変更前に関連ファイルを読み、既存パターンに合わせる
+- 新規依存追加は確認を取る
+- 破壊的変更は避ける。必要なら明示する
+
+## Build / test / lint
+- Build: `make build`
+- Test: `pytest -q`
+- Lint: `ruff check .`
+
+## Review expectations
+- 変更理由を短く説明する
+- 影響範囲を明示する
+- 必要ならテストを追加する
+
+## Done when
+- 関連テストが通る
+- lint が通る
+- 動作変更があれば docs を更新する
+```
+
+この形がよいのは、OpenAI が推奨する主要項目を短くカバーできるからです。特に **repo layout / commands / conventions / done** がそろうと、Codex の探索、実装、検証、報告が安定しやすくなります。 ([OpenAI Developers][3])
+
+---
+
+## 避けるべき書き方
+
+* 長すぎて task-specific detail まで全部書く
+* 抽象的で検証不能な指示を書く
+* repo 全体のルールと局所例外を 1 ファイルに混ぜる
+* workflow そのものまで全部 `AGENTS.md` に書く
+* 同じ失敗が出ても更新しない
+
+これらは、OpenAI が勧める **短く実務的な永続ガイダンス** という設計から外れます。大きくなりすぎたら別 markdown や Skills に分けるのがよいです。 ([OpenAI Developers][3])
+
+---
+
+[1]: https://developers.openai.com/codex/guides/agents-md/ "Custom instructions with AGENTS.md – Codex | OpenAI Developers"
+[2]: https://developers.openai.com/codex/concepts/customization/ "Customization – Codex | OpenAI Developers"
+[3]: https://developers.openai.com/codex/learn/best-practices/ "Best practices – Codex | OpenAI Developers"

--- a/.codex/docs/codex-skill-best-practices.md
+++ b/.codex/docs/codex-skill-best-practices.md
@@ -1,0 +1,141 @@
+# Codex SKILL.md ベストプラクティス
+
+## 公式例
+
+OpenAI 公式は、**「小さな React デモアプリを毎回同じ形で作る skill」** を例として示しています。内容は、`SKILL.md` の front matter に `name` と `description` を置き、その後に **いつ使うか**、**何を作るか**、**手順**、**definition of done** を書く構成です。さらに公式は、この例を **意図的に狭く・具体的にしている** と説明しています。評価可能な条件がないと、skill の良し悪しを判定しにくいからです。 ([OpenAI デベロッパー][1])
+
+```md
+---
+name: setup-demo-app
+description: React のデモアプリを決まった最小構成で作るときに使う。
+---
+
+## いつ使うか
+UI の試作や再現用に、すぐ動く最小アプリが欲しいとき。
+
+## 何を作るか
+- Vite + React + TypeScript
+- Tailwind を設定
+- 最小の components 構成
+- 余計な UI ライブラリは入れない
+
+## 手順
+1. テンプレートから作成
+2. 依存を入れる
+3. Tailwind を設定
+4. 最小 UI を作る
+
+## 完了条件
+- 開発サーバが起動する
+- 必須ファイルがそろう
+- 指定した構成になっている
+```
+
+この例がよいのは、**skill が 1 つの仕事に絞られており、発火条件と完成条件が明確だから**です。Codex の skills は、最初に `name` と `description` だけを見て発見・選択し、必要になったときだけ `SKILL.md` 本文や `scripts/` などを読みます。つまり、skill の成否は本文の長さよりも、最初のメタデータと「何をいつどう終えるか」の明確さに強く依存します。 ([OpenAI デベロッパー][2])
+
+## ベストプラクティス
+
+### 1. skill は 1 つの仕事に絞る
+
+1 つの skill に複数の役割を詰め込まず、**1 workflow = 1 skill** に寄せます。OpenAI も「Keep each skill scoped to one job」と案内しています。まず 2〜3 個の具体的なユースケースを定め、入力と出力をはっきりさせるのが推奨です。 ([OpenAI デベロッパー][3])
+
+これがよい理由は、Codex が skill を選びやすくなり、使ったあとも「期待どおりに動いたか」を判定しやすいからです。広すぎる skill は説明文も曖昧になり、暗黙発火が不安定になります。 ([OpenAI デベロッパー][2])
+
+### 2. `description` は説明文ではなく「発火条件」として書く
+
+公式は、`description` を **routing contract** と位置づけています。Codex は skill の存在を把握するとき、まず `name`・`description`・path を見て、使うべきかどうかを判断します。したがって `description` には、**何をする skill か** だけでなく、**いつ使うか / いつ使わないか** を入れるのが重要です。 ([OpenAI デベロッパー][2])
+
+よい `description` は、たとえば「PR 文を書く」ではなく、**“大きめの変更が終わったあとに、PR-ready な要約ブロックを作るときに使う”** のように、タイミングと対象を含みます。これにより implicit invocation の精度が上がります。 ([OpenAI デベロッパー][4])
+
+### 3. 本文には「いつ使うか」「何を作るか」「手順」「完了条件」を書く
+
+公式例は、単なる作業メモではなく、**使用条件・成果物・実施順・definition of done** を含んでいます。 ([OpenAI デベロッパー][1])
+
+これがよい理由は、Codex にとっても人間にとっても、skill の目的と終了判定が同じになるからです。特に `definition of done` を入れると、無駄な試行錯誤を減らしやすくなります。 ([OpenAI デベロッパー][1])
+
+### 4. 最初は instruction-only で始める
+
+公式の skill 作成フローでは、`$skill-creator` が **instruction-only をデフォルト推奨** にしています。Codex の best practices でも、最初から全 edge case を詰め込まず、代表的な 1 タスクで skill 化し、必要に応じて育てる方針が勧められています。 ([OpenAI デベロッパー][2])
+
+これがよい理由は、早い段階で script や資産を増やしすぎると、保守対象が増えるわりに routing の問題が見えにくくなるからです。まずは説明と流れを固め、そのあと deterministic な処理だけを script に逃がすのが安定します。 ([OpenAI デベロッパー][3])
+
+### 5. 繰り返しの機械処理だけを `scripts/` に置く
+
+OpenAI の blog では、良い分担として **解釈・比較・報告は model 側、決定的で反復的な shell 作業は `scripts/` 側** と整理しています。さらに API docs 系の guidance では、skill scripts を **小さな CLI のように設計する** ことが勧められています。標準出力は決定的にし、失敗時は明確な usage / error を返し、必要なら既知のファイルパスに成果物を書きます。 ([OpenAI デベロッパー][4])
+
+これがよい理由は、model が得意な判断と script が得意な反復を分離できるからです。たとえば lint, test, log collect, fixed-order verification のような処理は script 化の相性が良いです。 ([OpenAI デベロッパー][4])
+
+### 6. `references/` と `assets/` は「信頼性を上げるときだけ」足す
+
+Codex skills は `SKILL.md` に加え、`scripts/`、`references/`、`assets/`、`agents/openai.yaml` を持てます。ですが公式は、script や追加資産は **信頼性を上げるときだけ** 入れることを勧めています。 ([OpenAI デベロッパー][2])
+
+これがよい理由は、skill の本体は workflow の定義であって、添付物を増やすこと自体ではないからです。まずは本文だけで十分かを見て、曖昧さや再現性の問題が出た部分だけを補強するのがよいです。 ([OpenAI デベロッパー][3])
+
+### 7. 現在の保存先は `.agents/skills` を優先する
+
+現在の Codex skills ドキュメントは、repo・user・admin・system の各レベルで skill を読み込み、repo と user の代表的な場所として **`.agents/skills`** と **`$HOME/.agents/skills`** を案内しています。best practices も同じ保存先を案内しています。 ([OpenAI デベロッパー][2])
+
+一方で、2026-01 の公式 blog には `.codex/skills/...` や `~/.codex/skills/...` の例も残っています。したがって、**新しく運用を始めるなら現行 docs に合わせて `.agents/skills` を優先する** のが自然です。これは docs の現在の記述を優先した実務上の判断です。 ([OpenAI デベロッパー][2])
+
+### 8. implicit invocation を使うなら、境界を狭くする
+
+Codex は skill を **明示的に呼ぶ** ことも、`description` に一致して **暗黙的に選ぶ** こともできます。さらに `agents/openai.yaml` で `allow_implicit_invocation: false` を設定すれば、暗黙発火を止めて明示呼び出し専用にもできます。 ([OpenAI デベロッパー][2])
+
+これがよい理由は、skill によっては勝手に走ってほしくないものがあるからです。たとえば危険な変更や重い検証、外部依存の強い skill は、明示呼び出しだけにした方が扱いやすいです。 ([OpenAI デベロッパー][2])
+
+### 9. 何度も同じ prompt を使うなら skill 化する
+
+OpenAI は、同じ prompt を何度も使ったり、同じ workflow を何度も修正しているなら **それは skill にすべきサイン** だと述べています。典型例として、log triage、release note drafting、PR review、migration planning、incident summary、debugging flow が挙げられています。 ([OpenAI デベロッパー][3])
+
+これがよい理由は、手順を skill に閉じ込めることで、毎回の prompt の長文化を防ぎ、再現性を上げられるからです。安定した後は automation に乗せる、という流れも公式が推奨しています。 ([OpenAI デベロッパー][3])
+
+## 推奨テンプレート
+
+```md
+---
+name: task-name
+description: 何をする skill かに加えて、いつ使うか / いつ使わないかを明記する。
+---
+
+## When to use
+この skill を使う条件を書く。
+
+## Inputs
+必要な入力、前提、対象範囲を書く。
+
+## Outputs
+期待する成果物や返答形式を書く。
+
+## Steps
+1. 実施順を短く固定する
+2. 判断が必要な点を書く
+3. 必要なら確認手順を書く
+
+## Definition of done
+- 完了条件を列挙
+- 検証方法を列挙
+```
+
+この形がよいのは、**routing 用の front matter** と **実行用の本文** がはっきり分かれ、しかも skill の終了判定まで含められるからです。Codex はまず metadata を見て skill を選び、選ばれた後に本文を読むので、この二段構えに合わせた構成にするのが合理的です。 ([OpenAI デベロッパー][2])
+
+## 避けるべき書き方
+
+* `description` が広すぎる
+  例: 「開発を助ける skill」
+
+* 1 skill に複数 workflow を入れる
+  例: 調査、実装、レビュー、PR 作成を全部まとめる
+
+* 完了条件がない
+  例: 「いい感じに整える」
+
+* script 化すべき反復処理を本文に長く書く
+
+* 逆に、まだ安定していない手順を最初から script に押し込む
+
+これらは、routing の不安定化、保守コストの増加、評価不能を招きやすいです。公式の guidance は一貫して、**狭い skill、明確な description、必要最小限の補助資産** を勧めています。 ([OpenAI デベロッパー][2])
+
+[1]: https://developers.openai.com/blog/eval-skills/ "Testing Agent Skills Systematically with Evals | OpenAI Developers"
+[2]: https://developers.openai.com/codex/skills/ "Agent Skills – Codex | OpenAI Developers"
+[3]: https://developers.openai.com/codex/learn/best-practices/ "Best practices – Codex | OpenAI Developers"
+[4]: https://developers.openai.com/blog/skills-agents-sdk/ "Using skills to accelerate OSS maintenance | OpenAI Developers"

--- a/.codex/docs/codex-skill-scripts-and-references.md
+++ b/.codex/docs/codex-skill-scripts-and-references.md
@@ -1,0 +1,165 @@
+# Codex Skills における `references/` と `scripts/` の書き方・作り方
+
+## 公式例
+
+OpenAI 公式の curated skill では、`SKILL.md` から **script は「実行するもの」** として、**reference は「必要時に読むもの」** として明示しています。たとえば `speech` skill は description と workflow の両方で `scripts/text_to_speech.py` を指し、詳細は `references/cli.md` を見るように分けています。`render-deploy` skill でも、本文は短く保ちつつ、詳細手順を `references/direct-creation.md` や `references/codebase-analysis.md` に逃がしています。これは OpenAI が説明する「progressive disclosure」の実例です。 ([OpenAI デベロッパー][1])
+
+---
+
+## 基本原則
+
+Codex の skill は、`SKILL.md` を必須とし、必要に応じて `scripts/` と `references/` を持てます。公式の位置づけは明確で、`scripts/` は **決定的で繰り返し発生する処理**、`references/` は **作業中に必要に応じて読む資料** です。`SKILL.md` は workflow の中核だけを書き、重い詳細は `references/` に分離するのが基本です。 ([OpenAI デベロッパー][1])
+
+---
+
+## `SKILL.md` でどう言及するか
+
+### 1. frontmatter には書きすぎない
+
+`SKILL.md` の frontmatter は `name` と `description` だけにします。OpenAI の skill-creator は、**発火条件は description に書き、本文の “When to use” に頼らない** ことを勧めています。つまり、`scripts/` や `references/` の細かな説明は frontmatter ではなく本文側に置きます。 ([OpenAI デベロッパー][1])
+
+### 2. script は本文で「いつ・どう実行するか」を書く
+
+script は `Workflow` や `How to run` の中で、**ファイル名を明示して** 書くのが公式例に近いです。`speech` skill は「bundled CLI を実行する」と書き、具体的に `scripts/text_to_speech.py` を示しています。API cookbook の runnable example でも、`SKILL.md` に `How to run` を置き、依存導入コマンドと `run.py` の実行例、期待する出力先を書いています。 ([GitHub][2])
+
+### 3. reference は本文で「どの場面で読むか」を書く
+
+reference は単に「参考資料がある」と書くのではなく、**どの判断でどの file を読むか** を `SKILL.md` に書きます。公式の `render-deploy` skill は、各 step ごとに `references/direct-creation.md` や `references/codebase-analysis.md` を指しています。OpenAI の skill-creator も、分離した資料を置くときは **SKILL.md から明示的に参照し、いつ使うかをはっきり書く** よう求めています。 ([GitHub][3])
+
+### 4. SKILL.md は短く、詳細は reference に逃がす
+
+OpenAI の guidance は、`SKILL.md` 本文は essentials に寄せ、長くなりすぎたら reference に分割する、というものです。特に **schemas、API docs、詳細手順、例、ポリシー類** は `references/` に置くのが推奨です。`SKILL.md` には core workflow と分岐判断だけを残します。 ([GitHub][4])
+
+### 5. 大きい reference は検索の入口も書く
+
+公式の skill-creator は、reference が大きい場合、`SKILL.md` に **grep 用の検索語や入口** を書くことを勧めています。要するに、reference を置くだけでは不十分で、「何を探すときにこの file を開くか」まで書くのがよい、ということです。 ([GitHub][4])
+
+---
+
+## 推奨パターン
+
+### script の言及パターン
+
+* description では、必要なら「bundled CLI を使う」程度まで触れる
+* 本文では `Workflow` または `How to run` に実行タイミングを書く
+* 実行コマンド、主要引数、出力先を書く
+* 期待する生成物を `Outputs` に書く
+
+この形がよいのは、Codex が **何を実行すべきか** と **どこに成果物が出るか** を迷いにくいからです。公式 cookbook でも `How to run` と `Outputs` を入れるよう勧めています。 ([OpenAI デベロッパー][5])
+
+### reference の言及パターン
+
+* `Workflow` の各段階で「この判断では `references/foo.md` を読む」と書く
+* `Advanced`, `Troubleshooting`, `Variants` などを reference に分離する
+* `SKILL.md` に詳細を重複させない
+
+この形がよいのは、`SKILL.md` を短く保ちながら、必要時だけ reference を読む progressive disclosure に合うからです。 ([OpenAI デベロッパー][1])
+
+---
+
+## script はどう作るべきか
+
+### 1. 作るべき場面
+
+OpenAI は、`scripts/` を **同じコードを何度も書き直しているとき**、または **決定的な信頼性が必要なとき** に入れるとしています。たとえば固定順での検証コマンド実行、ログ収集、前処理、ファイル変換のような処理です。 ([GitHub][4])
+
+### 2. 設計方針
+
+OpenAI の cookbook は、skill script を **tiny CLI** のように設計することを勧めています。つまり、コマンドラインから実行でき、stdout は決定的で、usage/error をはっきり出し、必要なら既知のパスに成果物を書きます。 ([OpenAI デベロッパー][5])
+
+### 3. SKILL.md との分担
+
+解釈、比較、報告、例外判断は model 側に残し、**機械的な反復処理だけ script に落とす** のが OpenAI の推奨です。つまり、script は「考える」ためではなく「確実に実行する」ために作ります。 ([OpenAI デベロッパー][6])
+
+### 4. 作成手順
+
+OpenAI の skill-creator は、`init_skill.py` で skill の雛形を作る方法を示しており、`--resources scripts,references` のように resource directory を生成できます。追加した script は、**実際に動かしてテストする** ことも明言されています。 ([GitHub][4])
+
+### 5. script に向いているもの
+
+* ファイル変換
+* 固定順の build / test / lint 実行
+* ログ収集や再実行ファイル生成
+* CSV / JSON / PDF の定型処理
+* 既知フォーマットのレポート生成
+
+これらは、公式が挙げる「deterministic, repeated shell work」に合います。 ([OpenAI デベロッパー][6])
+
+---
+
+## reference はどう作るべきか
+
+### 1. 作るべき場面
+
+OpenAI は、`references/` を **作業中に参照すべき資料** の置き場としています。具体例は、API 仕様、DB schema、社内ポリシー、詳細 workflow、domain knowledge です。 ([GitHub][4])
+
+### 2. 設計方針
+
+reference は **読ませるための file** です。したがって、実行可能 code ではなく、判断材料としての情報を置きます。OpenAI は、reference の役割を「Codex の process と thinking を支えるための documentation」と説明しています。 ([GitHub][4])
+
+### 3. SKILL.md との分担
+
+OpenAI の推奨は明快で、**情報は SKILL.md と reference に重複して置かない** ことです。SKILL.md には essential procedural guidance だけを置き、詳しい schema や例や派生ケースは reference に逃がします。 ([GitHub][4])
+
+### 4. reference に向いているもの
+
+* API endpoint の一覧
+* DB / table schema
+* リポジトリ固有の build / deploy ルール
+* 会社固有の style / policy / NDA
+* 長い troubleshooting guide
+* 分岐ごとの詳細手順
+
+これは公式の examples と一致しています。 ([GitHub][4])
+
+### 5. 避けるべきもの
+
+OpenAI の skill-creator は、skill には **README.md、INSTALLATION_GUIDE.md、QUICK_REFERENCE.md、CHANGELOG.md** のような余計な補助文書を増やさないよう勧めています。reference は汎用 docs 置き場ではなく、**その skill の実行に直接必要な資料** に絞るべきです。 ([GitHub][4])
+
+---
+
+## 推奨テンプレート
+
+````md
+---
+name: my-skill
+description: Use when Codex needs to run a repeatable workflow for X. Use this skill for A and B. Do not use it for C.
+---
+
+# My Skill
+
+## Workflow
+1. Confirm the target and inputs.
+2. If you need the exact command/flags, run `scripts/do_x.py`.
+3. If you need the detailed schema or edge cases, read `references/schema.md`.
+4. Write outputs to `output/...`.
+5. Validate the result.
+
+## How to run
+```bash
+python -m pip install -r requirements.txt
+python scripts/do_x.py --input <path> --outdir output
+````
+
+## Outputs
+
+* `output/result.json`
+* `output/report.md`
+
+## Reference guide
+
+* Read `references/schema.md` when mapping fields.
+* Read `references/troubleshooting.md` if validation fails.
+
+```
+
+この形がよいのは、script を **実行入口** として、reference を **判断資料** として分けて書けるからです。OpenAI の `speech`、`render-deploy`、`csv_insights_skill` の書き方と整合します。 :contentReference[oaicite:19]{index=19}
+
+---
+
+[1]: https://developers.openai.com/codex/skills/ "Agent Skills – Codex | OpenAI Developers"
+[2]: https://github.com/openai/skills/blob/main/skills/.curated/speech/SKILL.md "skills/skills/.curated/speech/SKILL.md at main · openai/skills · GitHub"
+[3]: https://github.com/openai/skills/blob/main/skills/.curated/render-deploy/SKILL.md "skills/skills/.curated/render-deploy/SKILL.md at main · openai/skills · GitHub"
+[4]: https://github.com/openai/skills/blob/main/skills/.system/skill-creator/SKILL.md "skills/skills/.system/skill-creator/SKILL.md at main · openai/skills · GitHub"
+[5]: https://developers.openai.com/cookbook/examples/skills_in_api/ "Skills in OpenAI API"
+[6]: https://developers.openai.com/blog/skills-agents-sdk/ "Using skills to accelerate OSS maintenance | OpenAI Developers"

--- a/.codex/docs/codex-subagent-best-practices.md
+++ b/.codex/docs/codex-subagent-best-practices.md
@@ -1,0 +1,168 @@
+# Codex Subagent ベストプラクティス
+
+## 公式例
+
+OpenAI 公式は、PR レビューを **3 つの責務に分けた custom agent 構成**を例として示しています。`pr_explorer` はコードパス調査、`reviewer` は correctness / security / tests の確認、`docs_researcher` はドキュメントや API 仕様の確認を担当します。また、`[agents]` では `max_threads = 6`、`max_depth = 1` を使い、各 agent の `sandbox_mode` は用途に応じて設定されています。 ([OpenAI デベロッパー][1])
+
+```toml
+# .codex/config.toml
+[agents]
+max_threads = 6
+max_depth = 1
+```
+
+```toml
+# .codex/agents/pr-explorer.toml
+name = "pr_explorer"
+description = "Read-only codebase explorer for gathering evidence before changes are proposed."
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Stay in exploration mode.
+Trace the real execution path, cite files and symbols, and avoid proposing fixes unless the parent agent asks for them.
+Prefer fast search and targeted file reads over broad scans.
+"""
+```
+
+```toml
+# .codex/agents/reviewer.toml
+name = "reviewer"
+description = "PR reviewer focused on correctness, security, and missing tests."
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Review code like an owner.
+Prioritize correctness, security, behavior regressions, and missing test coverage.
+Lead with concrete findings, include reproduction steps when possible, and avoid style-only comments unless they hide a real bug.
+"""
+```
+
+```toml
+# .codex/agents/docs-researcher.toml
+name = "docs_researcher"
+description = "Documentation specialist that uses the docs MCP server to verify APIs and framework behavior."
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Use the docs MCP server to confirm APIs, options, and version-specific behavior.
+Return concise answers with links or exact references when available.
+Do not make code changes.
+"""
+```
+
+## なぜこの例がよいのか
+
+この例がよいのは、**agent ごとの責務が狭く、出力の種類も明確だから**です。OpenAI は subagent を、探索メモ・ログ・テスト出力のようなノイズを親スレッドから切り離し、親 agent を要件整理と最終判断に集中させるための仕組みとして説明しています。これにより **context pollution** と **context rot** を避けやすくなります。 ([OpenAI デベロッパー][2])
+
+また、この構成は **権限を最小化している**点でも優れています。探索役・レビュー役・ドキュメント確認役はいずれも `read-only` で十分であり、Codex は sandbox mode と approval policy を組み合わせて安全に動かす設計です。さらに、ネットワークはデフォルトでオフです。つまり、必要な agent にだけ必要な権限を与えるのが基本です。 ([OpenAI デベロッパー][3])
+
+---
+
+## ベストプラクティス
+
+### 1. agent は狭い責務で作る
+
+1 agent = 1 役割に寄せます。
+例: `codebase_explorer`、`reviewer`、`docs_researcher`、`browser_debugger`。
+
+**理由**
+狭い責務の agent は、何を調べて何を返すべきかが明確になります。OpenAI の公式例も、探索・レビュー・仕様確認を分離しています。 ([OpenAI デベロッパー][1])
+
+### 2. explorer 系は read-only を基本にする
+
+調査用 subagent は、まず `sandbox_mode = "read-only"` を基本にします。
+
+**理由**
+explorer は証拠収集が役割であり、変更権限は不要です。OpenAI の公式例でも `pr_explorer` と `reviewer` と `docs_researcher` は read-only です。安全性の面でも、sandbox と approvals を強めに保つのが基本です。 ([OpenAI デベロッパー][1])
+
+### 3. developer_instructions は「行動境界」を明記する
+
+`developer_instructions` には、役割だけでなく **やってよいこと / だめなこと** を入れます。
+例: 「探索モードを維持する」「ファイルとシンボルを引用する」「親に求められない限り修正案を出さない」。
+
+**理由**
+subagent は specialized worker なので、境界が曖昧だと勝手に設計提案や編集に踏み込みやすくなります。公式の `pr_explorer` も、修正提案を抑えて証拠収集に集中するよう明示しています。 ([OpenAI デベロッパー][1])
+
+### 4. 親 agent には「要約」を返し、生ログを返しすぎない
+
+subagent の返答は、原則として **要点 + 根拠** にします。
+ログ全文、探索の試行錯誤、無関係な grep 結果を大量に返さないようにします。
+
+**理由**
+OpenAI は、subagent の価値を「ノイズを main thread から逃がすこと」に置いています。返すものまでノイズだと効果が薄れます。 ([OpenAI デベロッパー][2])
+
+### 5. `max_depth` は原則 1 のままにする
+
+再帰的 delegation が本当に必要でない限り、`max_depth = 1` を維持します。
+
+**理由**
+公式は、深い再帰は token 使用量、レイテンシ、ローカル資源消費、予測しづらさを増やすと説明しています。まずは親 → 子 までで十分です。 ([OpenAI デベロッパー][1])
+
+### 6. project 固有の agent は `.codex/agents/` に置く
+
+custom agent は `~/.codex/agents/` または `.codex/agents/` に置けます。
+チームで共有したい agent は repo 配下の `.codex/agents/` に置くのが基本です。
+
+**理由**
+project-scoped config は repo に閉じた運用ができ、trusted project では project config が user config より優先されます。チームの標準運用を repo に載せやすくなります。 ([OpenAI デベロッパー][1])
+
+### 7. 共通ルールは AGENTS.md、繰り返し手順は Skills に分ける
+
+* **AGENTS.md**: repo 全体の作法、レビュー方針、実行前後のルール
+* **Subagent**: 専門役の分担
+* **Skills**: 繰り返し使うワークフローや補助スクリプト
+
+**理由**
+OpenAI は、AGENTS.md を事前に読む project guidance、Skills を task-specific workflow bundle、Subagents を delegated specialized work として分けています。役割を混ぜない方が保守しやすいです。 ([OpenAI デベロッパー][4])
+
+### 8. `description` は「いつ使う agent か」が分かる文にする
+
+`description` は名前の言い換えではなく、**起動条件が伝わる説明**にします。
+例: `Read-only subagent for surveying src/tasks conventions before implementation starts.`
+
+**理由**
+OpenAI は `description` を「Codex がその agent をいつ使うべきかを示す人間向けガイダンス」と位置づけています。短くても、用途が見える文が有効です。 ([OpenAI デベロッパー][1])
+
+---
+
+## 推奨テンプレート
+
+```toml
+name = "tasks_codebase_explorer"
+description = "Read-only subagent for surveying src/tasks conventions before implementation starts."
+sandbox_mode = "read-only"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Stay in exploration mode.
+Trace the real execution path. Cite file paths and symbols.
+Prefer fast search and targeted reads over broad scans.
+Do not make code changes.
+Avoid proposing fixes unless the parent agent explicitly asks.
+"""
+```
+
+この形がよいのは、**役割、権限、出力スタイル、禁止事項** がすべて短く入っているからです。公式の `pr_explorer` の設計思想にもかなり近いです。 ([OpenAI デベロッパー][1])
+
+---
+
+## 避けるべき書き方
+
+* 責務が広すぎる agent
+  例: 「調査も実装もレビューも全部やる」
+
+* 権限が広すぎる agent
+  例: explorer なのに `workspace-write`
+
+* developer_instructions が抽象的すぎる agent
+  例: 「うまく調べてください」
+
+* 生ログをそのまま親に返す agent
+
+これらは、subagent を使う意味である **分離・要約・安全化** を弱めます。 ([OpenAI デベロッパー][2])
+
+---
+
+[1]: https://developers.openai.com/codex/subagents/ "Subagents – Codex | OpenAI Developers"
+[2]: https://developers.openai.com/codex/concepts/subagents/ "Subagents – Codex | OpenAI Developers"
+[3]: https://developers.openai.com/codex/agent-approvals-security/ "Agent approvals & security – Codex | OpenAI Developers"
+[4]: https://developers.openai.com/codex/guides/agents-md/ "Custom instructions with AGENTS.md – Codex | OpenAI Developers"


### PR DESCRIPTION
## Summary

- Add four Japanese documentation guides under `.codex/docs` for Codex best practices.
- Cover AGENTS.md design, SKILL.md design, skill `scripts/` and `references/` usage, and subagent design guidance.

## Changes

- Add `.codex/docs/codex-agent-md-best-practice.md`
- Add `.codex/docs/codex-skill-best-practices.md`
- Add `.codex/docs/codex-skill-scripts-and-references.md`
- Add `.codex/docs/codex-subagent-best-practices.md`

## Validation

- Confirmed only `.codex/docs` files are included in commit `1b79307`.
- Verified branch push to `origin/docs/codex-best-practices`.

## Notes

- This PR intentionally scopes to documentation only.
