### PR TITLE
chore: Add preflight scripts for skills

### DIFF
--- a/.agents/skills/gh-issue-create/SKILL.md
+++ b/.agents/skills/gh-issue-create/SKILL.md
@@ -20,6 +20,17 @@ This repository defines issue templates under `.github/ISSUE_TEMPLATE/`, so issu
   - Feature / enhancement: `.github/ISSUE_TEMPLATE/02_feature.md`
   - Research / investigation: `.github/ISSUE_TEMPLATE/03_research.md`
 
+## Preflight
+
+- Run preflight checks in one command before creating or editing issues:
+
+```bash
+./.agents/skills/gh-issue-create/scripts/preflight.sh Motoki0705/tennis-lab
+```
+
+- The script validates `gh` auth, repo reachability, required issue templates, and expected labels.
+- Review the summary (`ok/warn/fail`) before continuing.
+
 ## Template selection rules
 
 - Use `01_bug.md` for defects, regressions, crashes, incorrect outputs, and broken workflows.

--- a/.agents/skills/gh-issue-create/scripts/preflight.sh
+++ b/.agents/skills/gh-issue-create/scripts/preflight.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${1:-Motoki0705/tennis-lab}"
+
+ok_count=0
+warn_count=0
+fail_count=0
+
+ok() {
+  echo "[OK] $1"
+  ok_count=$((ok_count + 1))
+}
+
+warn() {
+  echo "[WARN] $1"
+  warn_count=$((warn_count + 1))
+}
+
+fail() {
+  echo "[FAIL] $1"
+  fail_count=$((fail_count + 1))
+}
+
+if gh auth status >/dev/null 2>&1; then
+  ok "gh authentication is valid."
+else
+  fail "gh auth status failed. Re-authenticate before creating or editing an issue."
+fi
+
+if gh repo view "${REPO}" >/dev/null 2>&1; then
+  ok "Repository is reachable: ${REPO}"
+else
+  fail "Repository is not reachable: ${REPO}"
+fi
+
+templates=(
+  ".github/ISSUE_TEMPLATE/01_bug.md"
+  ".github/ISSUE_TEMPLATE/02_feature.md"
+  ".github/ISSUE_TEMPLATE/03_research.md"
+)
+
+for template in "${templates[@]}"; do
+  if [[ -f "${template}" ]]; then
+    ok "Template exists: ${template}"
+  else
+    fail "Template is missing: ${template}"
+  fi
+done
+
+required_labels=(bug enhancement documentation research question codex)
+missing_labels=()
+
+for label in "${required_labels[@]}"; do
+  if gh label list --repo "${REPO}" --search "${label}" --limit 200 --json name --jq ".[].name" | grep -Fx "${label}" >/dev/null 2>&1; then
+    ok "Label exists: ${label}"
+  else
+    missing_labels+=("${label}")
+  fi
+done
+
+if [[ "${#missing_labels[@]}" -gt 0 ]]; then
+  warn "Missing labels: ${missing_labels[*]}"
+else
+  ok "All required labels are present."
+fi
+
+echo "Summary: ok=${ok_count} warn=${warn_count} fail=${fail_count}"
+if [[ "${fail_count}" -gt 0 ]]; then
+  exit 1
+fi
+

--- a/.agents/skills/gh-pr-create/SKILL.md
+++ b/.agents/skills/gh-pr-create/SKILL.md
@@ -19,10 +19,15 @@ Use this skill for PR creation in `Motoki0705/tennis-lab`.
 
 ### 1) Preflight
 
-- Run `gh auth status` and confirm no timeout.
 - Confirm the target base branch before creating the PR.
 - If the user did not specify a base branch, use `main`.
-- Ensure the current branch has commits relative to the chosen base branch.
+- Run preflight checks in one command and review the summary:
+
+  ```bash
+  ./.agents/skills/gh-pr-create/scripts/preflight.sh main
+  ```
+
+- The script validates `gh` auth, current branch, base branch, PR template, upstream, and commits relative to base.
 - Prepare PR body with `--body-file` (avoid inline multiline body).
 - Copy `.github/pull_request_template.md` to a tmp file before editing.
 - Recommended tmp creation:

--- a/.agents/skills/gh-pr-create/scripts/preflight.sh
+++ b/.agents/skills/gh-pr-create/scripts/preflight.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_BRANCH="${1:-main}"
+
+ok_count=0
+warn_count=0
+fail_count=0
+
+ok() {
+  echo "[OK] $1"
+  ok_count=$((ok_count + 1))
+}
+
+warn() {
+  echo "[WARN] $1"
+  warn_count=$((warn_count + 1))
+}
+
+fail() {
+  echo "[FAIL] $1"
+  fail_count=$((fail_count + 1))
+}
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "[FAIL] Not inside a git repository."
+  exit 1
+fi
+
+if gh auth status >/dev/null 2>&1; then
+  ok "gh authentication is valid."
+else
+  fail "gh auth status failed. Re-authenticate before creating a PR."
+fi
+
+current_branch="$(git branch --show-current)"
+if [[ -n "${current_branch}" ]]; then
+  ok "Current branch: ${current_branch}"
+else
+  fail "Could not resolve current branch."
+fi
+
+if [[ "${current_branch}" == "${BASE_BRANCH}" ]]; then
+  warn "Current branch equals base branch (${BASE_BRANCH}). Confirm this is intentional."
+fi
+
+if git rev-parse --verify "${BASE_BRANCH}" >/dev/null 2>&1; then
+  ok "Base branch exists locally: ${BASE_BRANCH}"
+else
+  fail "Base branch does not exist locally: ${BASE_BRANCH}"
+fi
+
+if [[ -f ".github/pull_request_template.md" ]]; then
+  ok "PR template exists: .github/pull_request_template.md"
+else
+  fail "PR template is missing: .github/pull_request_template.md"
+fi
+
+if git rev-parse --verify "@{upstream}" >/dev/null 2>&1; then
+  ok "Upstream branch is configured."
+else
+  warn "Upstream branch is not configured for current branch."
+fi
+
+commit_list="$(git log --oneline "${BASE_BRANCH}..HEAD" 2>/dev/null || true)"
+if [[ -n "${commit_list}" ]]; then
+  echo "Commits relative to ${BASE_BRANCH}:"
+  echo "${commit_list}"
+  ok "Found commits to include in PR."
+else
+  fail "No commits found relative to ${BASE_BRANCH}."
+fi
+
+echo "Summary: ok=${ok_count} warn=${warn_count} fail=${fail_count}"
+if [[ "${fail_count}" -gt 0 ]]; then
+  exit 1
+fi
+

--- a/.agents/skills/git-branch-create/SKILL.md
+++ b/.agents/skills/git-branch-create/SKILL.md
@@ -25,6 +25,12 @@ Prefer the repository's existing prefixes:
 
 - Confirm which branch to branch from.
 - If the user did not specify a base, use `main`.
+- Run preflight checks in one command and review the summary:
+
+  ```bash
+  ./.agents/skills/git-branch-create/scripts/preflight.sh main <new-branch-name>
+  ```
+
 - Sync the base branch before branching:
 
   ```bash

--- a/.agents/skills/git-branch-create/scripts/preflight.sh
+++ b/.agents/skills/git-branch-create/scripts/preflight.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_BRANCH="${1:-main}"
+TARGET_BRANCH="${2:-}"
+
+ok_count=0
+warn_count=0
+fail_count=0
+
+ok() {
+  echo "[OK] $1"
+  ok_count=$((ok_count + 1))
+}
+
+warn() {
+  echo "[WARN] $1"
+  warn_count=$((warn_count + 1))
+}
+
+fail() {
+  echo "[FAIL] $1"
+  fail_count=$((fail_count + 1))
+}
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "[FAIL] Not inside a git repository."
+  exit 1
+fi
+
+current_branch="$(git branch --show-current)"
+if [[ -n "${current_branch}" ]]; then
+  ok "Current branch: ${current_branch}"
+else
+  fail "Could not resolve current branch."
+fi
+
+if git show-ref --verify --quiet "refs/heads/${BASE_BRANCH}"; then
+  ok "Local base branch exists: ${BASE_BRANCH}"
+else
+  fail "Local base branch is missing: ${BASE_BRANCH}"
+fi
+
+if git show-ref --verify --quiet "refs/remotes/origin/${BASE_BRANCH}"; then
+  ok "Remote-tracking base branch exists: origin/${BASE_BRANCH}"
+else
+  warn "Remote-tracking branch origin/${BASE_BRANCH} is missing. Run git fetch origin."
+fi
+
+if git diff --quiet && git diff --cached --quiet; then
+  ok "Working tree is clean."
+else
+  warn "Working tree has changes. Confirm branching from this state is intentional."
+fi
+
+if [[ -n "${TARGET_BRANCH}" ]]; then
+  if git show-ref --verify --quiet "refs/heads/${TARGET_BRANCH}"; then
+    fail "Target branch already exists locally: ${TARGET_BRANCH}"
+  else
+    ok "Target branch does not exist locally: ${TARGET_BRANCH}"
+  fi
+
+  if git ls-remote --exit-code --heads origin "${TARGET_BRANCH}" >/dev/null 2>&1; then
+    fail "Target branch already exists on origin: ${TARGET_BRANCH}"
+  else
+    ok "Target branch does not exist on origin: ${TARGET_BRANCH}"
+  fi
+else
+  warn "Target branch name not provided. Skip branch name collision checks."
+fi
+
+echo "Summary: ok=${ok_count} warn=${warn_count} fail=${fail_count}"
+if [[ "${fail_count}" -gt 0 ]]; then
+  exit 1
+fi
+

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -9,6 +9,17 @@ description: Use this skill when committing changes in Motoki0705/tennis-lab. Th
 
 Use this skill for committing changes in `Motoki0705/tennis-lab` via git CLI.
 
+## Preflight
+
+- Run preflight checks in one command before commit:
+
+```bash
+./.agents/skills/git-commit/scripts/preflight.sh "docs: Add example change"
+```
+
+- The script prints staged files, staged diff stat, and a summary (`ok/warn/fail`).
+- If no staged changes are found, it exits non-zero.
+
 ## Commit Message Convention
 
 Follow the `prefix: Subject` format for all commit messages.

--- a/.agents/skills/git-commit/scripts/preflight.sh
+++ b/.agents/skills/git-commit/scripts/preflight.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MESSAGE="${1:-}"
+
+ok_count=0
+warn_count=0
+fail_count=0
+
+ok() {
+  echo "[OK] $1"
+  ok_count=$((ok_count + 1))
+}
+
+warn() {
+  echo "[WARN] $1"
+  warn_count=$((warn_count + 1))
+}
+
+fail() {
+  echo "[FAIL] $1"
+  fail_count=$((fail_count + 1))
+}
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "[FAIL] Not inside a git repository."
+  exit 1
+fi
+
+if git diff --cached --quiet; then
+  fail "No staged changes found."
+else
+  ok "Staged changes are present."
+fi
+
+staged_files="$(git diff --cached --name-status)"
+if [[ -n "${staged_files}" ]]; then
+  echo "Staged files:"
+  echo "${staged_files}"
+  ok "Printed staged file list."
+else
+  warn "Could not print staged file list."
+fi
+
+staged_stat="$(git diff --cached --stat)"
+if [[ -n "${staged_stat}" ]]; then
+  echo "Staged diff stat:"
+  echo "${staged_stat}"
+  ok "Printed staged diff stat."
+else
+  warn "Staged diff stat is empty."
+fi
+
+if [[ -n "${MESSAGE}" ]]; then
+  if [[ "${MESSAGE}" =~ ^(feat|fix|docs|chore|refactor|style|test|ci|perf):\ [A-Z][^[:cntrl:]]+$ ]]; then
+    ok "Commit message format looks valid: prefix: Subject"
+  else
+    warn "Commit message does not match expected format: prefix: Subject"
+  fi
+else
+  warn "Commit message was not provided. Skip message format validation."
+fi
+
+echo "Summary: ok=${ok_count} warn=${warn_count} fail=${fail_count}"
+if [[ "${fail_count}" -gt 0 ]]; then
+  exit 1
+fi
+


### PR DESCRIPTION
## Summary

- Add preflight shell scripts for four existing skills under `.agents/skills`.
- Standardize one-command pre-check flows and summary output (`OK/WARN/FAIL`) to reduce prompt-side command noise.

## Changes

- Add `scripts/preflight.sh` for:
  - `gh-issue-create`
  - `gh-pr-create`
  - `git-branch-create`
  - `git-commit`
- Update each `SKILL.md` to call its preflight script in the workflow.
- Keep failure signaling consistent via non-zero exit on critical failures.

## Validation

- Ran `bash -n` on all four new preflight scripts.
- Confirmed only eight intended files were included in commit `312da4e`.

## Related Issues

- References #

## Notes

- Existing unrelated working tree changes were intentionally excluded from this PR.
