### PR TITLE
fix: Update ball detection training configs

### DIFF
--- a/src/tasks/ball_detection/configs/data/rgb_sequence.yaml
+++ b/src/tasks/ball_detection/configs/data/rgb_sequence.yaml
@@ -17,7 +17,7 @@ gaussian_variance: 1.0
 
 augmentation:
   camera_rotation:
-    enabled: true
+    enabled: false
     prob: 0.35
     max_center_angle_deg: 1.2
     max_angular_velocity_deg_per_frame: 0.2
@@ -38,6 +38,6 @@ augmentation:
     enabled: true
     std: 0.012
   gaussian_blur:
-    enabled: true
+    enabled: false
     prob: 0.12
     kernel_size: 3

--- a/src/tasks/ball_detection/configs/training/default.yaml
+++ b/src/tasks/ball_detection/configs/training/default.yaml
@@ -8,7 +8,7 @@ trainer:
   check_val_every_n_epoch: 1
 
 # ---- Optimizer / scheduler ----
-learning_rate: 1.0e-3
+learning_rate: 1.0e-4
 weight_decay: 1.0e-4
 warmup_steps: 200
 min_lr: 1.0e-6
@@ -35,7 +35,7 @@ early_stopping:
   monitor: val/loss
   mode: min
   patience: 5
-  min_delta: 1.0e-3
+  min_delta: 2.0e-6
 
 lr_monitor:
   enabled: true


### PR DESCRIPTION
## Summary

- Tune ball detection training configs to reduce augmentation intensity and lower the base learning rate.

## Changes

- Disable camera rotation augmentation in `rgb_sequence.yaml`.
- Disable gaussian blur augmentation in `rgb_sequence.yaml`.
- Reduce `learning_rate` from `1.0e-3` to `1.0e-4` and relax early stopping `min_delta` to `2.0e-6` in `training/default.yaml`.

## Validation

- Parsed both updated YAML files with `python -c` and `yaml.safe_load`.
