### PR TITLE
docs: Clarify git skill preflight output

### DIFF
--- a/.agents/skills/gh-issue-create/SKILL.md
+++ b/.agents/skills/gh-issue-create/SKILL.md
@@ -24,11 +24,20 @@ This repository defines issue templates under `.github/ISSUE_TEMPLATE/`, so issu
 
 - Run preflight checks in one command before creating or editing issues:
 
-```bash
-./.agents/skills/gh-issue-create/scripts/preflight.sh Motoki0705/tennis-lab
-```
+  ```bash
+  ./.agents/skills/gh-issue-create/scripts/preflight.sh Motoki0705/tennis-lab
+  ```
 
-- The script validates `gh` auth, repo reachability, required issue templates, and expected labels.
+- `preflight.sh` validates:
+  - `gh` authentication
+  - repository reachability
+  - required issue templates exist
+  - expected labels exist
+- `preflight.sh` output includes:
+  - per-check `[OK]` / `[WARN]` / `[FAIL]` lines
+  - a label summary showing how many required labels are present or missing
+  - a final `Summary: ok=... warn=... fail=...` line
+- Because `preflight.sh` already checks `gh` authentication and repository access, do not separately run `gh auth status` or `gh repo view` unless you need full diagnostic detail.
 - Review the summary (`ok/warn/fail`) before continuing.
 
 ## Template selection rules
@@ -119,3 +128,4 @@ gh api -X POST repos/Motoki0705/tennis-lab/issues/<BLOCKED_NUMBER>/dependencies/
 - Use repeated `--label` flags rather than comma-separated label lists.
 - `gh issue edit` uses `--add-assignee` and `--remove-assignee`.
 - Dependencies require an authenticated token with Issues write permission.
+- When reporting the preflight result, summarize whether auth, templates, repo reachability, and label coverage are all healthy.

--- a/.agents/skills/gh-issue-create/scripts/preflight.sh
+++ b/.agents/skills/gh-issue-create/scripts/preflight.sh
@@ -50,10 +50,12 @@ done
 
 required_labels=(bug enhancement documentation research question codex)
 missing_labels=()
+present_label_count=0
 
 for label in "${required_labels[@]}"; do
   if gh label list --repo "${REPO}" --search "${label}" --limit 200 --json name --jq ".[].name" | grep -Fx "${label}" >/dev/null 2>&1; then
     ok "Label exists: ${label}"
+    present_label_count=$((present_label_count + 1))
   else
     missing_labels+=("${label}")
   fi
@@ -65,8 +67,12 @@ else
   ok "All required labels are present."
 fi
 
+echo "Issue preflight summary:"
+echo "  repo=${REPO}"
+echo "  required_labels=${#required_labels[@]}"
+echo "  present_labels=${present_label_count}"
+echo "  missing_labels=${#missing_labels[@]}"
 echo "Summary: ok=${ok_count} warn=${warn_count} fail=${fail_count}"
 if [[ "${fail_count}" -gt 0 ]]; then
   exit 1
 fi
-

--- a/.agents/skills/gh-pr-create/SKILL.md
+++ b/.agents/skills/gh-pr-create/SKILL.md
@@ -27,7 +27,20 @@ Use this skill for PR creation in `Motoki0705/tennis-lab`.
   ./.agents/skills/gh-pr-create/scripts/preflight.sh main
   ```
 
-- The script validates `gh` auth, current branch, base branch, PR template, upstream, and commits relative to base.
+- `preflight.sh` validates:
+  - `gh` authentication
+  - current branch can be resolved
+  - current branch is not accidentally the base branch
+  - local base branch exists
+  - PR template exists
+  - upstream is configured
+  - commits exist relative to the base branch
+- `preflight.sh` output includes:
+  - per-check `[OK]` / `[WARN]` / `[FAIL]` lines
+  - the commit list relative to the base branch
+  - a `PR summary:` block with branch, base, upstream, commit count, and working tree counts
+  - a final `Summary: ok=... warn=... fail=...` line
+- Because `preflight.sh` already runs the `gh` authentication check, do not separately run `gh auth status` unless you need the full token/account details for debugging.
 - Prepare PR body with `--body-file` (avoid inline multiline body).
 - Copy `.github/pull_request_template.md` to a tmp file before editing.
 - Recommended tmp creation:
@@ -63,6 +76,7 @@ gh pr create --repo Motoki0705/tennis-lab \
 - Add `Closes #...` / `References #...` in PR body when linking issues.
 - If this is a stacked PR, replace `main` with the actual integration base branch.
 - Use `--reviewer`, `--draft`, `--milestone` only when needed.
+- When reporting the preflight result, summarize what it verified and whether commits/upstream/template state look correct.
 
 ## Failure quick fixes
 

--- a/.agents/skills/gh-pr-create/scripts/preflight.sh
+++ b/.agents/skills/gh-pr-create/scripts/preflight.sh
@@ -22,6 +22,16 @@ fail() {
   fail_count=$((fail_count + 1))
 }
 
+summarize_worktree() {
+  local status_output unstaged staged untracked
+  status_output="$(git status --short 2>/dev/null || true)"
+  unstaged="$(printf '%s\n' "${status_output}" | awk 'substr($0,1,1)!=" " && substr($0,1,1)!="?" && NF>0 {count++} END {print count+0}')"
+  staged="$(printf '%s\n' "${status_output}" | awk 'substr($0,2,1)!=" " && substr($0,1,1)!="?" && NF>0 {count++} END {print count+0}')"
+  untracked="$(printf '%s\n' "${status_output}" | awk 'substr($0,1,2)=="??" {count++} END {print count+0}')"
+  echo "Working tree summary:"
+  echo "  unstaged=${unstaged} staged=${staged} untracked=${untracked}"
+}
+
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "[FAIL] Not inside a git repository."
   exit 1
@@ -58,11 +68,14 @@ fi
 
 if git rev-parse --verify "@{upstream}" >/dev/null 2>&1; then
   ok "Upstream branch is configured."
+  upstream_ref="$(git rev-parse --abbrev-ref '@{upstream}')"
 else
   warn "Upstream branch is not configured for current branch."
+  upstream_ref="<none>"
 fi
 
 commit_list="$(git log --oneline "${BASE_BRANCH}..HEAD" 2>/dev/null || true)"
+commit_count="$(printf '%s\n' "${commit_list}" | awk 'NF>0 {count++} END {print count+0}')"
 if [[ -n "${commit_list}" ]]; then
   echo "Commits relative to ${BASE_BRANCH}:"
   echo "${commit_list}"
@@ -71,8 +84,13 @@ else
   fail "No commits found relative to ${BASE_BRANCH}."
 fi
 
+echo "PR summary:"
+echo "  branch=${current_branch:-<unknown>}"
+echo "  base=${BASE_BRANCH}"
+echo "  upstream=${upstream_ref}"
+echo "  commits_relative_to_base=${commit_count}"
+summarize_worktree
 echo "Summary: ok=${ok_count} warn=${warn_count} fail=${fail_count}"
 if [[ "${fail_count}" -gt 0 ]]; then
   exit 1
 fi
-

--- a/.agents/skills/git-branch-create/SKILL.md
+++ b/.agents/skills/git-branch-create/SKILL.md
@@ -31,6 +31,17 @@ Prefer the repository's existing prefixes:
   ./.agents/skills/git-branch-create/scripts/preflight.sh main <new-branch-name>
   ```
 
+- `preflight.sh` validates:
+  - current branch can be resolved
+  - local base branch exists
+  - remote-tracking base branch exists
+  - working tree is clean or intentionally dirty
+  - target branch name does not already exist locally or on `origin`
+- `preflight.sh` output includes:
+  - per-check `[OK]` / `[WARN]` / `[FAIL]` lines
+  - a short `Branch summary:` block with current branch, base branch, target branch, and working tree counts
+  - a final `Summary: ok=... warn=... fail=...` line
+- When the script already checks branch state, do not re-run `git branch --show-current` or `git status --short` unless you specifically need extra detail beyond the preflight summary.
 - Sync the base branch before branching:
 
   ```bash
@@ -62,3 +73,4 @@ git branch --show-current
 
 - `main` is the default starting point, but stacked or task-local workflows may branch from another active branch when intentional.
 - Match existing repo conventions instead of forcing a single format when the branch already belongs to an established series.
+- When reporting the result to the user, summarize the preflight output instead of just saying that the command succeeded.

--- a/.agents/skills/git-branch-create/scripts/preflight.sh
+++ b/.agents/skills/git-branch-create/scripts/preflight.sh
@@ -23,6 +23,16 @@ fail() {
   fail_count=$((fail_count + 1))
 }
 
+summarize_worktree() {
+  local status_output unstaged staged untracked
+  status_output="$(git status --short 2>/dev/null || true)"
+  unstaged="$(printf '%s\n' "${status_output}" | awk 'substr($0,1,1)!=" " && substr($0,1,1)!="?" && NF>0 {count++} END {print count+0}')"
+  staged="$(printf '%s\n' "${status_output}" | awk 'substr($0,2,1)!=" " && substr($0,1,1)!="?" && NF>0 {count++} END {print count+0}')"
+  untracked="$(printf '%s\n' "${status_output}" | awk 'substr($0,1,2)=="??" {count++} END {print count+0}')"
+  echo "Working tree summary:"
+  echo "  unstaged=${unstaged} staged=${staged} untracked=${untracked}"
+}
+
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "[FAIL] Not inside a git repository."
   exit 1
@@ -69,8 +79,12 @@ else
   warn "Target branch name not provided. Skip branch name collision checks."
 fi
 
+echo "Branch summary:"
+echo "  current=${current_branch:-<unknown>}"
+echo "  base=${BASE_BRANCH}"
+echo "  target=${TARGET_BRANCH:-<not-provided>}"
+summarize_worktree
 echo "Summary: ok=${ok_count} warn=${warn_count} fail=${fail_count}"
 if [[ "${fail_count}" -gt 0 ]]; then
   exit 1
 fi
-

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -17,8 +17,20 @@ Use this skill for committing changes in `Motoki0705/tennis-lab` via git CLI.
 ./.agents/skills/git-commit/scripts/preflight.sh "docs: Add example change"
 ```
 
-- The script prints staged files, staged diff stat, and a summary (`ok/warn/fail`).
+- `preflight.sh` validates:
+  - the command is running inside a git repository
+  - staged changes exist
+  - the staged file list can be shown
+  - the staged diff stat can be shown
+  - the proposed commit message matches `prefix: Subject`
+- `preflight.sh` output includes:
+  - per-check `[OK]` / `[WARN]` / `[FAIL]` lines
+  - a `Commit summary:` block with current branch, staged file count, and working tree counts
+  - the staged file list
+  - the staged diff stat
+  - a final `Summary: ok=... warn=... fail=...` line
 - If no staged changes are found, it exits non-zero.
+- When the script already prints the staged state, do not separately run `git status --short` unless you need more detail than the summary provides.
 
 ## Commit Message Convention
 
@@ -61,3 +73,4 @@ Use these prefixes to categorize your changes:
 
 - Keep the subject aligned with the actual repo domain: tasks, datasets, visualization, pipeline, training, or third-party integration.
 - Prefer one focused commit per logical change.
+- When reporting the commit preparation step, summarize the preflight output instead of quoting raw git output without context.

--- a/.agents/skills/git-commit/scripts/preflight.sh
+++ b/.agents/skills/git-commit/scripts/preflight.sh
@@ -22,9 +22,26 @@ fail() {
   fail_count=$((fail_count + 1))
 }
 
+summarize_worktree() {
+  local status_output unstaged staged untracked
+  status_output="$(git status --short 2>/dev/null || true)"
+  unstaged="$(printf '%s\n' "${status_output}" | awk 'substr($0,1,1)!=" " && substr($0,1,1)!="?" && NF>0 {count++} END {print count+0}')"
+  staged="$(printf '%s\n' "${status_output}" | awk 'substr($0,2,1)!=" " && substr($0,1,1)!="?" && NF>0 {count++} END {print count+0}')"
+  untracked="$(printf '%s\n' "${status_output}" | awk 'substr($0,1,2)=="??" {count++} END {print count+0}')"
+  echo "Working tree summary:"
+  echo "  unstaged=${unstaged} staged=${staged} untracked=${untracked}"
+}
+
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "[FAIL] Not inside a git repository."
   exit 1
+fi
+
+current_branch="$(git branch --show-current)"
+if [[ -n "${current_branch}" ]]; then
+  ok "Current branch: ${current_branch}"
+else
+  warn "Could not resolve current branch."
 fi
 
 if git diff --cached --quiet; then
@@ -34,6 +51,7 @@ else
 fi
 
 staged_files="$(git diff --cached --name-status)"
+staged_file_count="$(printf '%s\n' "${staged_files}" | awk 'NF>0 {count++} END {print count+0}')"
 if [[ -n "${staged_files}" ]]; then
   echo "Staged files:"
   echo "${staged_files}"
@@ -61,8 +79,11 @@ else
   warn "Commit message was not provided. Skip message format validation."
 fi
 
+echo "Commit summary:"
+echo "  branch=${current_branch:-<unknown>}"
+echo "  staged_files=${staged_file_count}"
+summarize_worktree
 echo "Summary: ok=${ok_count} warn=${warn_count} fail=${fail_count}"
 if [[ "${fail_count}" -gt 0 ]]; then
   exit 1
 fi
-

--- a/.codex/agents/pr-publisher.toml
+++ b/.codex/agents/pr-publisher.toml
@@ -1,0 +1,42 @@
+name = "pr_publisher"
+description = "Use this agent when you need to create a branch, commit a specified change set, and open a PR to a specified base branch."
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Act as a focused publishing worker for git and GitHub operations.
+Your job is to take a clearly specified publication request from the parent agent and carry it through branch creation, commit creation, validation summary, push, and PR creation.
+
+Expected parent-agent inputs:
+- target branch name to create or use
+- which files or change set to include in the commit
+- commit message to use
+- PR base branch
+- PR title
+- PR summary / changes / notes to include
+- validation commands already run, or validation results to report
+- any exclusions that must not be committed
+
+Workflow:
+1. Read and follow these repo skills when relevant:
+   - `.agents/skills/git-branch-create/SKILL.md`
+   - `.agents/skills/git-commit/SKILL.md`
+   - `.agents/skills/gh-pr-create/SKILL.md`
+2. Use the corresponding `preflight.sh` scripts before branch creation, commit creation, and PR creation.
+3. Summarize preflight results for the parent agent instead of returning raw command output only.
+4. Stage only the requested files. Do not include excluded paths or unrelated local changes.
+5. Create exactly the requested commit message unless the parent agent explicitly changes it.
+6. Push the branch and open the PR against the requested base branch.
+7. Report back with:
+   - branch name
+   - commit sha and subject
+   - PR URL
+   - concise validation summary
+   - any blockers or intentionally excluded paths
+
+Rules:
+- Do not invent missing publication details. If the parent agent did not specify commit scope, commit message, or PR target, stop and report what is missing.
+- Do not modify unrelated files just to make publication easier.
+- Do not include dirty-worktree changes outside the requested scope.
+- Prefer stacked PRs when the requested base branch is not `main`.
+- If validation fails, do not open the PR unless the parent agent explicitly instructed you to proceed with known failures.
+"""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,4 +17,5 @@
 
 ## Done definition
 - For changes that can affect repository checks, call the `pre_commit_validator` subagent to run `uv run pre-commit run --all-files`, analyze failures, and apply fixes.
+- When the task includes publication work, call the `pr_publisher` subagent with the branch name, commit scope, commit message, PR base branch, PR title, and validation summary.
 - Do not consider the task done until the relevant validation has passed or remaining blockers are explicitly documented.


### PR DESCRIPTION
## Summary

- clarify what each git / gh preflight script validates in the corresponding skill docs
- make preflight scripts print structured summaries so branch, worktree, staged, upstream, and commit state are easier to relay to users
- document when separate `gh auth status`, `git branch --show-current`, or `git status --short` calls are unnecessary because preflight already covers them

## Changes

- update `git-branch-create`, `git-commit`, `gh-pr-create`, and `gh-issue-create` SKILL docs with explicit validation and output descriptions
- add summary sections to each `preflight.sh` with branch / worktree / staged / upstream / label coverage context
- add guidance in the skill docs to summarize preflight output instead of dumping raw command output

## Validation

- `bash -n .agents/skills/git-branch-create/scripts/preflight.sh`
- `bash -n .agents/skills/git-commit/scripts/preflight.sh`
- `bash -n .agents/skills/gh-pr-create/scripts/preflight.sh`
- `bash -n .agents/skills/gh-issue-create/scripts/preflight.sh`
- `./.agents/skills/git-branch-create/scripts/preflight.sh chore/script-conventions-validator chore/test-branch`
- `./.agents/skills/git-commit/scripts/preflight.sh "chore: Test Summary"`
- `./.agents/skills/gh-pr-create/scripts/preflight.sh chore/script-conventions-validator`
- `./.agents/skills/gh-issue-create/scripts/preflight.sh Motoki0705/tennis-lab`

## Notes

- This is a stacked PR on top of `chore/script-conventions-validator`.
- `third_party/GVHMR` and `third_party/gaussian-exp/` remain intentionally excluded.
