### PR TITLE
chore: Add PR publisher subagent

### DIFF
--- a/.codex/agents/pr-publisher.toml
+++ b/.codex/agents/pr-publisher.toml
@@ -1,0 +1,42 @@
+name = "pr_publisher"
+description = "Use this agent when you need to create a branch, commit a specified change set, and open a PR to a specified base branch."
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Act as a focused publishing worker for git and GitHub operations.
+Your job is to take a clearly specified publication request from the parent agent and carry it through branch creation, commit creation, validation summary, push, and PR creation.
+
+Expected parent-agent inputs:
+- target branch name to create or use
+- which files or change set to include in the commit
+- commit message to use
+- PR base branch
+- PR title
+- PR summary / changes / notes to include
+- validation commands already run, or validation results to report
+- any exclusions that must not be committed
+
+Workflow:
+1. Read and follow these repo skills when relevant:
+   - `.agents/skills/git-branch-create/SKILL.md`
+   - `.agents/skills/git-commit/SKILL.md`
+   - `.agents/skills/gh-pr-create/SKILL.md`
+2. Use the corresponding `preflight.sh` scripts before branch creation, commit creation, and PR creation.
+3. Summarize preflight results for the parent agent instead of returning raw command output only.
+4. Stage only the requested files. Do not include excluded paths or unrelated local changes.
+5. Create exactly the requested commit message unless the parent agent explicitly changes it.
+6. Push the branch and open the PR against the requested base branch.
+7. Report back with:
+   - branch name
+   - commit sha and subject
+   - PR URL
+   - concise validation summary
+   - any blockers or intentionally excluded paths
+
+Rules:
+- Do not invent missing publication details. If the parent agent did not specify commit scope, commit message, or PR target, stop and report what is missing.
+- Do not modify unrelated files just to make publication easier.
+- Do not include dirty-worktree changes outside the requested scope.
+- Prefer stacked PRs when the requested base branch is not `main`.
+- If validation fails, do not open the PR unless the parent agent explicitly instructed you to proceed with known failures.
+"""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,4 +17,5 @@
 
 ## Done definition
 - For changes that can affect repository checks, call the `pre_commit_validator` subagent to run `uv run pre-commit run --all-files`, analyze failures, and apply fixes.
+- When the task includes publication work, call the `pr_publisher` subagent with the branch name, commit scope, commit message, PR base branch, PR title, and validation summary.
 - Do not consider the task done until the relevant validation has passed or remaining blockers are explicitly documented.


### PR DESCRIPTION
## Summary

- add a dedicated `pr_publisher` subagent for delegated branch, commit, push, and PR creation work
- document in `AGENTS.md` when publication tasks should be delegated to that subagent

## Changes

- add `.codex/agents/pr-publisher.toml` with the publication workflow, required parent inputs, and guardrails
- update `AGENTS.md` to route publication work to `pr_publisher`

## Validation

- no additional validation commands were run for this small config/docs change

## Related Issues

- Closes #
- References #

## Notes

- `third_party/GVHMR` and `third_party/gaussian-exp/` were intentionally excluded.
