### PR TITLE
Refactor PLCS training to use structured Hydra config and remove implicit config fallbacks

### DIFF
--- a/src/tasks/plcs/configs/data/frame.yaml
+++ b/src/tasks/plcs/configs/data/frame.yaml
@@ -14,6 +14,8 @@ num_views_range: [1, 1]
 scene_sampler: true
 scenes_per_batch: 32
 chunk_max_scenes: 64
+cache_max_scenes: 128
+adapter_camera_index: 0
 
 augmentation:
   keypoint_noise_std: 0.0001

--- a/src/tasks/plcs/configs/data/multiview.yaml
+++ b/src/tasks/plcs/configs/data/multiview.yaml
@@ -4,11 +4,14 @@ num_workers: 4
 pin_memory: true
 
 mode: multiview_sequence
+camera_mode: random
 
 # Scene sampler: none | scene | mixed | chunked
 scene_sampler: true
 scenes_per_batch: 8
 chunk_max_scenes: 64
+cache_max_scenes: 128
+adapter_camera_index: 0
 
 # Multi-view sampling
 min_cameras: 2

--- a/src/tasks/plcs/configs/data/sequence.yaml
+++ b/src/tasks/plcs/configs/data/sequence.yaml
@@ -13,6 +13,8 @@ num_views_range: [1, 1]
 scene_sampler: true
 scenes_per_batch: 8
 chunk_max_scenes: 64
+cache_max_scenes: 128
+adapter_camera_index: 0
 
 # Sequence sampling
 seq_stride: 128

--- a/src/tasks/plcs/configs/model/frame.yaml
+++ b/src/tasks/plcs/configs/model/frame.yaml
@@ -41,3 +41,9 @@ moe_config:
   n_limited_groups: 1
   score_func: softmax
   route_scale: 1.0
+max_views: null
+max_seq_len: 120
+num_player_layers: null
+num_query_layers: null
+query_init_std: null
+architecture: frame

--- a/src/tasks/plcs/configs/model/multiview.yaml
+++ b/src/tasks/plcs/configs/model/multiview.yaml
@@ -38,3 +38,9 @@ moe_config:
 
 # Model type
 architecture: multiview
+num_register_tokens: null
+use_kp_id_embedding: null
+use_rope: null
+num_player_layers: null
+num_query_layers: null
+query_init_std: null

--- a/src/tasks/plcs/configs/model/sequence_query.yaml
+++ b/src/tasks/plcs/configs/model/sequence_query.yaml
@@ -9,6 +9,7 @@ io:
 
 # Architecture
 hidden_dim: 256
+num_layers: null
 num_heads: 8
 ffn_dim: null
 dropout: 0.1
@@ -29,3 +30,9 @@ yarn: null
 
 # Model type
 architecture: sequence
+num_register_tokens: null
+use_kp_id_embedding: null
+use_rope: null
+use_moe: false
+moe_config: null
+max_views: null

--- a/src/tasks/plcs/configs/training/default.yaml
+++ b/src/tasks/plcs/configs/training/default.yaml
@@ -6,13 +6,22 @@ trainer:
   precision: "16-mixed"
   log_every_n_steps: 50
   check_val_every_n_epoch: 1
+  benchmark: null
 
 # ---- Optimizer / schedule (LightningModule references) ----
 learning_rate: 1.0e-5
 weight_decay: 1.0e-5
 warmup_steps: 1000
+warmup_epochs: null
 scheduler: cosine
 min_lr: 1.0e-6
+matmul_precision: high
+allow_tf32: true
+steps_per_epoch: null
+num_samples_per_epoch: null
+max_epochs: ${training.trainer.max_epochs}
+optimizer:
+  betas: null
 
 # ---- Callbacks (BaseTrainingRunner references) ----
 checkpoint:

--- a/src/tasks/plcs/data/datamodule.py
+++ b/src/tasks/plcs/data/datamodule.py
@@ -19,29 +19,24 @@ if TYPE_CHECKING:
 class PLCSDataModule(pl.LightningDataModule):
     """Lightning DataModule for unified PLCS frame/sequence/multiview training."""
 
-    def __init__(self, config: DictConfig | None = None) -> None:
+    def __init__(self, config: DictConfig) -> None:
         super().__init__()
-        self.config = config or {}
+        self.config = config
 
-        data_cfg = self.config.get("data", {})
-        self.batch_size = int(data_cfg.get("batch_size", 64))
-        self.num_workers = int(data_cfg.get("num_workers", 4))
-        self.pin_memory = bool(data_cfg.get("pin_memory", True))
-        self.scene_dir = Path(data_cfg.get("scene_dir", "data/plcs"))
+        data_cfg = self.config.data
+        self.batch_size = int(data_cfg.batch_size)
+        self.num_workers = int(data_cfg.num_workers)
+        self.pin_memory = bool(data_cfg.pin_memory)
+        self.scene_dir = Path(data_cfg.scene_dir)
 
-        self.scene_sampler = bool(data_cfg.get("scene_sampler", True))
-        self.scenes_per_batch = int(data_cfg.get("scenes_per_batch", 1))
-        self.chunk_max_scenes = int(data_cfg.get("chunk_max_scenes", 64))
-        self.adapter_camera_index = int(data_cfg.get("adapter_camera_index", 0))
+        self.scene_sampler = bool(data_cfg.scene_sampler)
+        self.scenes_per_batch = int(data_cfg.scenes_per_batch)
+        self.chunk_max_scenes = int(data_cfg.chunk_max_scenes)
+        self.adapter_camera_index = int(data_cfg.adapter_camera_index)
 
-        model_cfg = self.config.get("model", {})
-        io_cfg = model_cfg.get("io", {})
-        self.input_profile = str(
-            io_cfg.get(
-                "input_profile",
-                self._infer_input_profile_from_model_name(str(model_cfg.get("name", "plcs"))),
-            )
-        )
+        model_cfg = self.config.model
+        io_cfg = model_cfg.io
+        self.input_profile = str(io_cfg.input_profile)
         self.collate_fn = partial(
             collate_and_adapt_plcs_batch,
             input_profile=self.input_profile,

--- a/src/tasks/plcs/data/dataset.py
+++ b/src/tasks/plcs/data/dataset.py
@@ -35,10 +35,10 @@ class SceneDataset(NPZSceneDatasetBase[dict[str, Tensor]]):
         *,
         scene_dir: str | Path,
         split_file: str | Path,
-        config: DictConfig | None = None,
+        config: DictConfig,
         augment: bool = True,
     ) -> None:
-        self.hydra_cfg = config or {}
+        self.hydra_cfg = config
         self.augment = augment
         data_cfg = self._resolve_data_cfg(self.hydra_cfg)
         self._configure_task(data_cfg)
@@ -53,24 +53,18 @@ class SceneDataset(NPZSceneDatasetBase[dict[str, Tensor]]):
     def _configure_task(self, data_cfg: dict) -> None:  # type: ignore[override]
         from omegaconf import DictConfig
 
-        self.camera_mode_plcs = str(data_cfg.get("camera_mode", "random"))
-        self.is_multiview = str(data_cfg.get("mode", "frame")) in {
+        self.camera_mode_plcs = str(data_cfg["camera_mode"])
+        self.is_multiview = str(data_cfg["mode"]) in {
             "multiview", "multiview_sequence",
         }
 
-        if "num_views_range" in data_cfg:
-            r = data_cfg["num_views_range"]
-            self._plcs_num_views_range: tuple[int, int] = (int(r[0]), int(r[1]))
-        else:
-            self._plcs_num_views_range = (1, 2)
+        views_range = data_cfg["num_views_range"]
+        self._plcs_num_views_range = (int(views_range[0]), int(views_range[1]))
 
-        if "seq_len_range" in data_cfg:
-            r = data_cfg["seq_len_range"]
-            self._plcs_seq_len_range: tuple[int, int] = (int(r[0]), int(r[1]))
-        else:
-            self._plcs_seq_len_range = (64, 512)
+        seq_len_range = data_cfg["seq_len_range"]
+        self._plcs_seq_len_range = (int(seq_len_range[0]), int(seq_len_range[1]))
 
-        augmentation_cfg = data_cfg.get("augmentation")
+        augmentation_cfg = data_cfg["augmentation"]
         if not isinstance(augmentation_cfg, (dict, DictConfig)):
             raise ValueError(
                 "data.augmentation must be provided with keys "
@@ -91,7 +85,7 @@ class SceneDataset(NPZSceneDatasetBase[dict[str, Tensor]]):
             split_file=Path(split_file),
             seq_len_range=self._plcs_seq_len_range,
             num_views_range=self._plcs_num_views_range,
-            cache_max_scenes=int(data_cfg.get("cache_max_scenes", 128)),
+            cache_max_scenes=int(data_cfg["cache_max_scenes"]),
             camera_mode=self.camera_mode_plcs,
             crop_mode=("random" if self.augment else "center"),
         )

--- a/src/tasks/plcs/models/__init__.py
+++ b/src/tasks/plcs/models/__init__.py
@@ -17,8 +17,7 @@ if TYPE_CHECKING:
 
 def build_plcs_model(config: DictConfig) -> nn.Module:
     """Build a PLCS model from ``config.model.name``."""
-    model_cfg = config.get("model", {})
-    model_name = str(model_cfg.get("name", "plcs"))
+    model_name = str(config.model.name)
     if model_name == "plcs":
         return PLCSModel.from_config(config)
     if model_name == "plcs_query_sequence":

--- a/src/tasks/plcs/models/plcs_model.py
+++ b/src/tasks/plcs/models/plcs_model.py
@@ -226,36 +226,35 @@ class PLCSModel(nn.Module):
             PLCSModel: Initialized model.
 
         """
-        model_cfg = config.get("model", {})
+        model_cfg = config.model
 
-        yarn_cfg = model_cfg.get("yarn", None)
+        yarn_cfg = model_cfg.yarn
         yarn: YaRNConfig | None = None
         if yarn_cfg is not None:
             yarn_cfg = dict(yarn_cfg)
-            if yarn_cfg.get("original_seq_len") is not None:
-                yarn = YaRNConfig(**yarn_cfg)
+            yarn = YaRNConfig(**yarn_cfg)
 
-        use_moe = bool(model_cfg.get("use_moe", False))
-        moe_cfg = model_cfg.get("moe_config", None)
+        use_moe = bool(model_cfg.use_moe)
+        moe_cfg = model_cfg.moe_config
         moe_config: MoEConfig | None = None
         if use_moe and moe_cfg is not None:
-            moe_config = MoEConfig(dim=int(model_cfg.get("hidden_dim", 256)), **dict(moe_cfg))
+            moe_config = MoEConfig(dim=int(model_cfg.hidden_dim), **dict(moe_cfg))
 
         return cls(
-            hidden_dim=model_cfg.get("hidden_dim", 256),
-            num_layers=model_cfg.get("num_layers", 4),
-            num_heads=model_cfg.get("num_heads", 8),
-            ffn_dim=model_cfg.get("ffn_dim", None),
-            dropout=model_cfg.get("dropout", 0.1),
-            rope_dim=model_cfg.get("rope_dim", None),
-            rope_theta=model_cfg.get("rope_theta", 10000.0),
+            hidden_dim=model_cfg.hidden_dim,
+            num_layers=model_cfg.num_layers,
+            num_heads=model_cfg.num_heads,
+            ffn_dim=model_cfg.ffn_dim,
+            dropout=model_cfg.dropout,
+            rope_dim=model_cfg.rope_dim,
+            rope_theta=model_cfg.rope_theta,
             yarn=yarn,
-            num_register_tokens=int(model_cfg.get("num_register_tokens", 4)),
-            use_kp_id_embedding=bool(model_cfg.get("use_kp_id_embedding", True)),
-            use_rope=bool(model_cfg.get("use_rope", False)),
+            num_register_tokens=int(model_cfg.num_register_tokens),
+            use_kp_id_embedding=bool(model_cfg.use_kp_id_embedding),
+            use_rope=bool(model_cfg.use_rope),
             use_moe=use_moe,
             moe_config=moe_config,
-            invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
+            invisible_init_std=float(model_cfg.invisible_init_std),
         )
 
     def _build_body_tokens(

--- a/src/tasks/plcs/models/plcs_multiview_model.py
+++ b/src/tasks/plcs/models/plcs_multiview_model.py
@@ -197,27 +197,27 @@ class PLCSMultiViewModel(nn.Module):
     @classmethod
     def from_config(cls, config: DictConfig) -> PLCSMultiViewModel:
         """Create model from hydra config."""
-        model_cfg = config.get("model", {})
+        model_cfg = config.model
 
-        use_moe = bool(model_cfg.get("use_moe", False))
-        moe_cfg = model_cfg.get("moe_config", None)
+        use_moe = bool(model_cfg.use_moe)
+        moe_cfg = model_cfg.moe_config
         moe_config: MoEConfig | None = None
         if use_moe and moe_cfg is not None:
-            moe_config = MoEConfig(dim=int(model_cfg.get("hidden_dim", 256)), **dict(moe_cfg))
+            moe_config = MoEConfig(dim=int(model_cfg.hidden_dim), **dict(moe_cfg))
 
         return cls(
-            hidden_dim=model_cfg.get("hidden_dim", 256),
-            num_layers=model_cfg.get("num_layers", 6),
-            num_heads=model_cfg.get("num_heads", 8),
-            ffn_dim=model_cfg.get("ffn_dim", None),
-            dropout=model_cfg.get("dropout", 0.1),
-            rope_dim=model_cfg.get("rope_dim", None),
-            rope_theta=model_cfg.get("rope_theta", 10000.0),
+            hidden_dim=model_cfg.hidden_dim,
+            num_layers=model_cfg.num_layers,
+            num_heads=model_cfg.num_heads,
+            ffn_dim=model_cfg.ffn_dim,
+            dropout=model_cfg.dropout,
+            rope_dim=model_cfg.rope_dim,
+            rope_theta=model_cfg.rope_theta,
             use_moe=use_moe,
             moe_config=moe_config,
-            max_views=model_cfg.get("max_views", 8),
-            max_seq_len=model_cfg.get("max_seq_len", 120),
-            invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
+            max_views=model_cfg.max_views,
+            max_seq_len=model_cfg.max_seq_len,
+            invisible_init_std=float(model_cfg.invisible_init_std),
         )
 
     def _build_positions_2d(

--- a/src/tasks/plcs/models/plcs_query_sequence_model.py
+++ b/src/tasks/plcs/models/plcs_query_sequence_model.py
@@ -195,28 +195,27 @@ class PLCSQuerySequenceModel(nn.Module):
     @classmethod
     def from_config(cls, config: DictConfig) -> PLCSQuerySequenceModel:
         """Create query-based sequence model from hydra config."""
-        model_cfg = config.get("model", {})
+        model_cfg = config.model
 
-        yarn_cfg = model_cfg.get("yarn", None)
+        yarn_cfg = model_cfg.yarn
         yarn: YaRNConfig | None = None
         if yarn_cfg is not None:
             yarn_cfg = dict(yarn_cfg)
-            if yarn_cfg.get("original_seq_len", None) is not None:
-                yarn = YaRNConfig(**yarn_cfg)
+            yarn = YaRNConfig(**yarn_cfg)
 
         return cls(
-            hidden_dim=int(model_cfg.get("hidden_dim", 256)),
-            num_heads=int(model_cfg.get("num_heads", 8)),
-            ffn_dim=model_cfg.get("ffn_dim", None),
-            dropout=float(model_cfg.get("dropout", 0.1)),
-            rope_dim=model_cfg.get("rope_dim", None),
-            rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            hidden_dim=int(model_cfg.hidden_dim),
+            num_heads=int(model_cfg.num_heads),
+            ffn_dim=model_cfg.ffn_dim,
+            dropout=float(model_cfg.dropout),
+            rope_dim=model_cfg.rope_dim,
+            rope_theta=float(model_cfg.rope_theta),
             yarn=yarn,
-            num_player_layers=int(model_cfg.get("num_player_layers", 4)),
-            num_query_layers=int(model_cfg.get("num_query_layers", 2)),
-            max_seq_len=int(model_cfg.get("max_seq_len", 120)),
-            invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
-            query_init_std=float(model_cfg.get("query_init_std", 0.02)),
+            num_player_layers=int(model_cfg.num_player_layers),
+            num_query_layers=int(model_cfg.num_query_layers),
+            max_seq_len=int(model_cfg.max_seq_len),
+            invisible_init_std=float(model_cfg.invisible_init_std),
+            query_init_std=float(model_cfg.query_init_std),
         )
 
     def _normalize_court_inputs(

--- a/src/tasks/plcs/scripts/train.py
+++ b/src/tasks/plcs/scripts/train.py
@@ -12,11 +12,13 @@ Config entry point: `src/tasks/plcs/configs/train.yaml`
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 from collections.abc import Callable
 from typing import TypeVar, cast
 
 import hydra
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from src.tasks.plcs.training.runner import PLCSTrainingRunner
 
@@ -24,16 +26,208 @@ F = TypeVar("F", bound=Callable[..., object])
 hydra.main = cast(Callable[..., Callable[[F], F]], hydra.main)
 
 
-def run_training(config: DictConfig) -> None:
+@dataclass
+class ModelIOConfig:
+    input_profile: str
+    strict_input: bool
+
+
+@dataclass
+class MoEConfigSchema:
+    moe_inter_dim: int
+    n_routed_experts: int
+    n_shared_experts: int
+    n_activated_experts: int
+    n_expert_groups: int
+    n_limited_groups: int
+    score_func: str
+    route_scale: float
+
+
+@dataclass
+class ModelConfig:
+    name: str
+    io: ModelIOConfig
+    hidden_dim: int
+    num_layers: int | None
+    num_heads: int
+    ffn_dim: int | None
+    dropout: float
+    invisible_init_std: float
+    num_register_tokens: int | None
+    use_kp_id_embedding: bool | None
+    use_rope: bool | None
+    rope_dim: int | None
+    rope_theta: float
+    yarn: dict[str, int | float] | None
+    use_moe: bool
+    moe_config: MoEConfigSchema | None
+    max_views: int | None
+    max_seq_len: int
+    num_player_layers: int | None
+    num_query_layers: int | None
+    query_init_std: float | None
+    architecture: str | None
+
+
+@dataclass
+class AugmentationConfig:
+    keypoint_noise_std: float
+    visibility_drop_prob: float
+
+
+@dataclass
+class DataConfig:
+    scene_dir: str
+    batch_size: int
+    num_workers: int
+    pin_memory: bool
+    mode: str
+    camera_mode: str
+    seq_len_range: list[int]
+    num_views_range: list[int]
+    scene_sampler: bool
+    scenes_per_batch: int
+    chunk_max_scenes: int
+    adapter_camera_index: int
+    augmentation: AugmentationConfig
+
+
+@dataclass
+class TemporalLossTermConfig:
+    weight: float
+    order: int
+    robust: bool
+
+
+@dataclass
+class TemporalLossConfig:
+    position_gt: TemporalLossTermConfig
+    position_inertia: TemporalLossTermConfig
+    rotation_gt: TemporalLossTermConfig
+    rotation_inertia: TemporalLossTermConfig
+
+
+@dataclass
+class LossConfig:
+    position_weight: float
+    rotation_weight: float
+    temporal: TemporalLossConfig
+
+
+@dataclass
+class MetricsConfig:
+    position_threshold_m: float
+    angle_threshold_deg: float
+    velocity_threshold_m: float
+
+
+@dataclass
+class TrainerConfig:
+    max_epochs: int
+    gradient_clip_val: float | None
+    deterministic: bool
+    precision: str | None
+    log_every_n_steps: int
+    check_val_every_n_epoch: int
+    benchmark: bool | None
+
+
+@dataclass
+class CheckpointConfig:
+    enabled: bool
+    filename: str
+    monitor: str
+    mode: str
+    save_top_k: int
+    save_last: bool
+
+
+@dataclass
+class EarlyStoppingConfig:
+    enabled: bool
+    monitor: str
+    mode: str
+    patience: int
+    min_delta: float | None
+    check_on_train_epoch_end: bool
+
+
+@dataclass
+class LRMonitorConfig:
+    enabled: bool
+    interval: str
+
+
+@dataclass
+class OptimizerConfig:
+    betas: list[float] | None
+
+
+@dataclass
+class TrainingConfig:
+    trainer: TrainerConfig
+    learning_rate: float
+    weight_decay: float
+    warmup_steps: int | None
+    warmup_epochs: int | None
+    scheduler: str
+    min_lr: float
+    matmul_precision: str
+    allow_tf32: bool
+    optimizer: OptimizerConfig
+    checkpoint: CheckpointConfig
+    early_stopping: EarlyStoppingConfig
+    lr_monitor: LRMonitorConfig
+    steps_per_epoch: int | None
+    num_samples_per_epoch: int | None
+    max_epochs: int
+
+
+@dataclass
+class RunConfig:
+    output_dir: str
+    seed: int | None
+    gpus: int
+    resume: str | None
+    fast_dev_run: bool
+    dry_run: bool
+
+
+@dataclass
+class TrainConfig:
+    model: ModelConfig
+    data: DataConfig
+    training: TrainingConfig
+    loss: LossConfig
+    metrics: MetricsConfig
+    run: RunConfig
+
+
+if TYPE_CHECKING:
+    StructuredTrainConfig = TrainConfig
+    RuntimeTrainConfig = TrainConfig
+else:
+    StructuredTrainConfig = DictConfig
+    RuntimeTrainConfig = DictConfig
+
+
+def _validate_structured_config(config: DictConfig) -> DictConfig:
+    schema = OmegaConf.structured(TrainConfig)
+    return cast(DictConfig, OmegaConf.merge(schema, config))
+
+
+def run_training(config: RuntimeTrainConfig) -> None:
     """Execute PLCS training with the provided configuration."""
     runner = PLCSTrainingRunner()
-    runner.run(config)
+    runner.run(cast(DictConfig, config))
 
 
 @hydra.main(config_path="../configs", config_name="train", version_base="1.3")
-def main(config: DictConfig) -> None:  # pragma: no cover - CLI entry point
+def main(config: StructuredTrainConfig) -> None:  # pragma: no cover - CLI entry point
     """Hydra entry point for PLCS training."""
-    run_training(config)
+    validated = _validate_structured_config(cast(DictConfig, config))
+    run_training(validated)
 
 
 if __name__ == "__main__":

--- a/src/tasks/plcs/training/lightning_module.py
+++ b/src/tasks/plcs/training/lightning_module.py
@@ -18,34 +18,35 @@ if TYPE_CHECKING:
 class PLCSLightningModule(BaseLightningModule):
     """Lightning module for unified PLCS I/O training."""
 
-    def __init__(self, config: DictConfig | None = None) -> None:
+    def __init__(self, config: DictConfig) -> None:
         super().__init__(config)
+        training_cfg = self.config.training
+        self.learning_rate = float(training_cfg.learning_rate)
+        self.weight_decay = float(training_cfg.weight_decay)
+        self.warmup_steps = training_cfg.warmup_steps
+        self.warmup_epochs = training_cfg.warmup_epochs
+        self.max_epochs = int(training_cfg.trainer.max_epochs)
+        self.min_lr = float(training_cfg.min_lr)
+        betas = training_cfg.optimizer.betas
+        self.optimizer_betas = tuple(betas) if betas is not None else None
 
         self.model: nn.Module = build_plcs_model(self.config)
 
-        loss_cfg_dict = self.config.get("loss", {})
-        if loss_cfg_dict:
-            loss_cfg = PLCSLossConfig.from_dict(dict(loss_cfg_dict))
-        else:
-            train_cfg = self.config.get("training", {})
-            loss_cfg = PLCSLossConfig(
-                position_weight=float(train_cfg.get("position_loss_weight", 1.0)),
-                rotation_weight=float(train_cfg.get("rotation_loss_weight", 1.0)),
-            )
+        loss_cfg = PLCSLossConfig.from_dict(dict(self.config.loss))
         self.loss_fn = PLCSLoss(config=loss_cfg)
 
-        metrics_cfg = self.config.get("metrics", {})
+        metrics_cfg = self.config.metrics
         self.train_metrics = PLCSMetrics(
-            position_threshold_m=float(metrics_cfg.get("position_threshold_m", 0.5)),
-            angle_threshold_deg=float(metrics_cfg.get("angle_threshold_deg", 15.0)),
+            position_threshold_m=float(metrics_cfg.position_threshold_m),
+            angle_threshold_deg=float(metrics_cfg.angle_threshold_deg),
         )
         self.val_metrics = PLCSMetrics(
-            position_threshold_m=float(metrics_cfg.get("position_threshold_m", 0.5)),
-            angle_threshold_deg=float(metrics_cfg.get("angle_threshold_deg", 15.0)),
+            position_threshold_m=float(metrics_cfg.position_threshold_m),
+            angle_threshold_deg=float(metrics_cfg.angle_threshold_deg),
         )
         self.test_metrics = PLCSMetrics(
-            position_threshold_m=float(metrics_cfg.get("position_threshold_m", 0.5)),
-            angle_threshold_deg=float(metrics_cfg.get("angle_threshold_deg", 15.0)),
+            position_threshold_m=float(metrics_cfg.position_threshold_m),
+            angle_threshold_deg=float(metrics_cfg.angle_threshold_deg),
         )
 
     def _forward_from_batch(self, batch: dict[str, Tensor]) -> dict[str, Tensor]:

--- a/src/tasks/plcs/training/runner.py
+++ b/src/tasks/plcs/training/runner.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytorch_lightning as pl
+from omegaconf import DictConfig
 
 from src.tasks.base.training.runner import BaseTrainingRunner
 from src.tasks.plcs.data.datamodule import PLCSDataModule
@@ -14,12 +13,12 @@ from src.tasks.plcs.training.lightning_module import PLCSLightningModule
 class PLCSTrainingRunner(BaseTrainingRunner):
     """Training runner for PLCS."""
 
-    def build_datamodule(self, config: Any) -> pl.LightningDataModule:
+    def build_datamodule(self, config: DictConfig) -> pl.LightningDataModule:
         return PLCSDataModule(config)
 
     def build_lightning_module(
         self,
-        config: Any,
+        config: DictConfig,
         datamodule: pl.LightningDataModule,
         *,
         steps_per_epoch: int | None = None,


### PR DESCRIPTION
### Motivation
- Enforce a strict Hydra / OmegaConf configuration policy where dataclasses define schema and YAML provides all default values to prevent implicit runtime fallbacks. 
- Ensure `run_training(config)` receives a validated, fully-resolved config whose non-`Optional` fields are present and typed. 
- Remove ad-hoc `cfg.get(..., default)` and other implicit fallbacks from runtime code so configuration responsibility is centralized in YAML and schema. 

### Description
- Add structured config dataclasses to `src/tasks/plcs/scripts/train.py` and validate the composed Hydra config with `OmegaConf.structured(...)` before invoking training. 
- Update PLCS runtime code to use direct attribute access on the structured config instead of `.get(...)` style fallbacks in `PLCSDataModule`, `SceneDataset`, `PLCSLightningModule`, `PLCSTrainingRunner`, and model `from_config` factories. 
- Update model factory to read `config.model.name` directly and propagate strongly-typed model fields into `PLCSModel`, `PLCSMultiViewModel`, and `PLCSQuerySequenceModel` initialization. 
- Add required keys to PLCS YAML defaults so runtime code has explicit values for fields that were previously implicitly defaulted (examples: `cache_max_scenes`, `adapter_camera_index`, training optimizer/trainer fields, and model fields used by strict access paths). 

### Testing
- `python -m compileall` on the modified PLCS Python files succeeded. 
- `uv run pre-commit run --all-files` could not complete in this environment due to external dependency fetch restrictions (git fetch of `pytorch3d` failed with HTTP 403) and a `pyproject.toml` parse warning. 
- `uv run pytest src/tasks/plcs -q` was blocked by the same external dependency fetch restriction and could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74f324c9083298c6a3039d83bc867)