### PR TITLE
Remove uv runner assumptions for Docker + pip execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,8 +117,6 @@ web/**/dist/
 web/**/.vite/
 
 # Package management
-uv.lock
-.uv-cache/
 Pipfile.lock
 
 # OS generated files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@ repos:
     hooks:
       - id: ruff
         name: ruff (fix)
-        entry: uv run --no-sync ruff check --fix --exit-non-zero-on-fix
+        entry: ruff check --fix --exit-non-zero-on-fix
         language: system
         types: [python]
         files: ^(src|tests)/
       - id: mypy
         name: mypy
-        entry: uv run --no-sync mypy --follow-imports=skip
+        entry: mypy --follow-imports=skip
         language: system
         types: [python]
         files: ^(src|tests)/
       - id: task-script-reviewer
         name: task script reviewer
-        entry: uv run --no-sync python ./.agents/skills/script-conventions/scripts/review_task_scripts.py
+        entry: python ./.agents/skills/script-conventions/scripts/review_task_scripts.py
         language: system
         files: ^(src|experiments)/.+/scripts/.+\.py$
         exclude: ^(src|experiments)/.+/scripts/__init__\.py$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 - Generated outputs belong in `outputs/`.
 
 ## Build / test / lint
-- Use `uv run` for project commands.
-- Test: `uv run pytest`
-- Lint/checks: `uv run pre-commit run --all-files`
-- Type check: `uv run mypy src`
+- Use container-internal commands for project work.
+- Test: `python -m pytest`
+- Lint/checks: `pre-commit run --all-files`
+- Type check: `python -m mypy src`
 - Prefer tool configuration in `pyproject.toml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
 
 # Optional group for the BLCS WebUI API server (FastAPI + Uvicorn).
 # Usage:
-#   uv run --group webui -m src.tasks.blcs.generate_dataset.api_server --reload --port 8001
+#   python -m src.tasks.blcs.generate_dataset.api_server --reload --port 8001
 webui = [
     "fastapi>=0.110.0",
     "uvicorn>=0.30.0",

--- a/src/developing/ball_multitask/scripts/train.py
+++ b/src/developing/ball_multitask/scripts/train.py
@@ -1,8 +1,12 @@
 """Train the ball multi-task model with Hydra configuration.
 
-Example commands:
-    `uv run python -m src.developing.ball_multitask.scripts.train`
-    `uv run python -m src.developing.ball_multitask.scripts.train run.dry_run=true`
+Usage:
+    python -m src.developing.ball_multitask.scripts.train
+    python -m src.developing.ball_multitask.scripts.train run.dry_run=true
+
+Notes:
+    - Configuration is loaded from `src/developing/ball_multitask/configs/train.yaml`.
+    - Hydra handles runtime overrides.
 """
 
 from __future__ import annotations

--- a/src/developing/ball_multitask/scripts/visualize.py
+++ b/src/developing/ball_multitask/scripts/visualize.py
@@ -1,4 +1,13 @@
-"""Entry point for ball multitask visualization orchestration."""
+"""Run ball multi-task visualization orchestration with Hydra configuration.
+
+Usage:
+    python -m src.developing.ball_multitask.scripts.visualize
+    python -m src.developing.ball_multitask.scripts.visualize run.dry_run=true
+
+Notes:
+    - Configuration is loaded from `src/developing/ball_multitask/configs/visualize.yaml`.
+    - Hydra handles runtime overrides.
+"""
 
 from __future__ import annotations
 

--- a/src/developing/mae/README.md
+++ b/src/developing/mae/README.md
@@ -31,16 +31,16 @@ Token structure: `[CLS, Register_1, ..., Register_R, Patch_1, ..., Patch_N]`
 
 ```bash
 # Basic training
-uv run python -m src.developing.mae.scripts.train
+python -m src.developing.mae.scripts.train
 
 # With custom settings
-uv run python -m src.developing.mae.scripts.train \
+python -m src.developing.mae.scripts.train \
     model=small \
     data=cached_batches data.bucket_alpha=2.5 \
     training=fast
 
 # Cached-batch training (no padding; preprocessing in background)
-uv run python -m src.developing.mae.scripts.train \
+python -m src.developing.mae.scripts.train \
     data=cached_batches
 ```
 
@@ -101,7 +101,7 @@ Download tennis videos using the WASB download script:
 ```bash
 # Create urls.yaml with video URLs
 # Then download:
-uv run python -m src.tasks.wasb.scripts.generate_dataset.download_videos \
+python -m src.tasks.wasb.scripts.generate_dataset.download_videos \
     urls_path=data/tennis/raw/urls.yaml
 ```
 

--- a/src/developing/mae/configs/train.yaml
+++ b/src/developing/mae/configs/train.yaml
@@ -3,9 +3,9 @@
 # Train Masked Autoencoder on tennis domain videos.
 #
 # Usage:
-#   uv run python -m src.developing.mae.scripts.train
-#   uv run python -m src.developing.mae.scripts.train model.hidden_dim=512
-#   uv run python -m src.developing.mae.scripts.train data=cached_batches data.bucket_alpha=2.5
+#   python -m src.developing.mae.scripts.train
+#   python -m src.developing.mae.scripts.train model.hidden_dim=512
+#   python -m src.developing.mae.scripts.train data=cached_batches data.bucket_alpha=2.5
 
 defaults:
   - _self_

--- a/src/developing/mae/scripts/produce_epoch_cache.py
+++ b/src/developing/mae/scripts/produce_epoch_cache.py
@@ -1,11 +1,13 @@
 """Generate cached MAE batches for a single epoch using Hydra-managed configuration.
 
-Example commands:
-    `uv run python -m src.developing.mae.scripts.produce_epoch_cache`
-    `uv run python -m src.developing.mae.scripts.produce_epoch_cache task.epoch=5`
-    `uv run python -m src.developing.mae.scripts.produce_epoch_cache task.split=val`
+Usage:
+    python -m src.developing.mae.scripts.produce_epoch_cache
+    python -m src.developing.mae.scripts.produce_epoch_cache task.epoch=5
+    python -m src.developing.mae.scripts.produce_epoch_cache task.split=val
 
-Config entry point: `src/developing/mae/configs/produce_epoch_cache.yaml`
+Notes:
+    - Configuration is loaded from `src/developing/mae/configs/produce_epoch_cache.yaml`.
+    - Hydra handles runtime overrides.
 """
 
 from __future__ import annotations

--- a/src/developing/mae/scripts/train.py
+++ b/src/developing/mae/scripts/train.py
@@ -1,11 +1,13 @@
 """Train MAE on tennis domain videos using Hydra-managed configuration.
 
-Example commands:
-    `uv run python -m src.developing.mae.scripts.train`
-    `uv run python -m src.developing.mae.scripts.train model.hidden_dim=512 training.max_epochs=200`
-    `uv run python -m src.developing.mae.scripts.train data=cached_batches data.bucket_alpha=2.5`
+Usage:
+    python -m src.developing.mae.scripts.train
+    python -m src.developing.mae.scripts.train model.hidden_dim=512 training.max_epochs=200
+    python -m src.developing.mae.scripts.train data=cached_batches data.bucket_alpha=2.5
 
-Config entry point: `src/developing/mae/configs/train.yaml`
+Notes:
+    - Configuration is loaded from `src/developing/mae/configs/train.yaml`.
+    - Hydra handles runtime overrides.
 """
 
 from __future__ import annotations

--- a/src/tasks/ball_detection/README.md
+++ b/src/tasks/ball_detection/README.md
@@ -40,14 +40,14 @@ Ball Detection は、テニス動画からボール位置ヒートマップを�
 
 ```bash
 # 既定設定で学習
-uv run python -m src.tasks.ball_detection.scripts.train
+python -m src.tasks.ball_detection.scripts.train
 
 # 出力先を指定
-uv run python -m src.tasks.ball_detection.scripts.train \
+python -m src.tasks.ball_detection.scripts.train \
     run.output_dir=outputs/ball_detection/stunet_custom
 
 # バッチサイズを変更
-uv run python -m src.tasks.ball_detection.scripts.train \
+python -m src.tasks.ball_detection.scripts.train \
     data.batch_size=8
 ```
 
@@ -55,13 +55,13 @@ uv run python -m src.tasks.ball_detection.scripts.train \
 
 ```bash
 # phase-based semi-supervised training
-uv run python -m src.tasks.ball_detection.scripts.train \
+python -m src.tasks.ball_detection.scripts.train \
     training.semi_supervised.num_semi_phases=4 \
     training.semi_supervised.phase0_epochs=15 \
     training.semi_supervised.phase_epochs=15
 
 # pseudo-label generation settings を上書き
-uv run python -m src.tasks.ball_detection.scripts.train \
+python -m src.tasks.ball_detection.scripts.train \
     training.semi_supervised.num_semi_phases=4 \
     training.semi_supervised.pseudo_windows_per_video=128 \
     training.semi_supervised.pseudo_inference_batch_size=16
@@ -70,7 +70,7 @@ uv run python -m src.tasks.ball_detection.scripts.train \
 ### 生動画ダウンロード
 
 ```bash
-uv run python -m src.tasks.ball_detection.scripts.download_videos
+python -m src.tasks.ball_detection.scripts.download_videos
 ```
 
 設定は `src/tasks/ball_detection/configs/downlaod.yaml` を使います。  
@@ -81,11 +81,11 @@ uv run python -m src.tasks.ball_detection.scripts.download_videos
 
 ```bash
 # train split の sample 0 を可視化
-uv run python -m src.tasks.ball_detection.scripts.visualize_augmentation \
+python -m src.tasks.ball_detection.scripts.visualize_augmentation \
     preview.sample_indices=[0]
 
 # val split を複数サンプル出力
-uv run python -m src.tasks.ball_detection.scripts.visualize_augmentation \
+python -m src.tasks.ball_detection.scripts.visualize_augmentation \
     preview.split=val \
     preview.sample_indices=[0,1,2]
 ```
@@ -97,13 +97,13 @@ uv run python -m src.tasks.ball_detection.scripts.visualize_augmentation \
 
 ```bash
 # code + data
-uv run python -m src.tasks.ball_detection.scripts.package
+python -m src.tasks.ball_detection.scripts.package
 
 # code のみ
-uv run python -m src.tasks.ball_detection.scripts.package package_target=code
+python -m src.tasks.ball_detection.scripts.package package_target=code
 
 # data のみ
-uv run python -m src.tasks.ball_detection.scripts.package package_target=data
+python -m src.tasks.ball_detection.scripts.package package_target=data
 ```
 
 ## 半教師あり pseudo-label フロー

--- a/src/tasks/ball_detection/scripts/download_videos.py
+++ b/src/tasks/ball_detection/scripts/download_videos.py
@@ -1,10 +1,12 @@
-"""Download raw tennis videos from configured URLs using yt-dlp.
+"""Download raw tennis videos from configured URLs using ``yt-dlp``.
 
-Example commands:
-    `uv run python -m src.tasks.ball_detection.scripts.download_videos`
-    `uv run python -m src.tasks.ball_detection.scripts.download_videos urls=[https://example.com/video]`
+Usage:
+    python -m src.tasks.ball_detection.scripts.download_videos
+    python -m src.tasks.ball_detection.scripts.download_videos urls=[https://example.com/video]
 
-Config entry point: `src/tasks/ball_detection/configs/downlaod.yaml`
+Notes:
+    - Hydra loads configuration from `src/tasks/ball_detection/configs/downlaod.yaml`.
+    - Downloads are renamed into `video_<n>.mp4` files and summarized in JSON.
 """
 
 from __future__ import annotations

--- a/src/tasks/ball_detection/scripts/package.py
+++ b/src/tasks/ball_detection/scripts/package.py
@@ -1,11 +1,13 @@
 """Package ball detection code and dataset into 7z archives.
 
-Example commands:
-    `uv run python -m src.tasks.ball_detection.scripts.package`
-    `uv run python -m src.tasks.ball_detection.scripts.package package_target=code`
-    `uv run python -m src.tasks.ball_detection.scripts.package package_target=data overwrite=true`
+Usage:
+    python -m src.tasks.ball_detection.scripts.package
+    python -m src.tasks.ball_detection.scripts.package package_target=code
+    python -m src.tasks.ball_detection.scripts.package package_target=data overwrite=true
 
-Config entry point: `src/tasks/ball_detection/configs/package.yaml`
+Notes:
+    - Hydra loads configuration from `src/tasks/ball_detection/configs/package.yaml`.
+    - The script shells out to `7z` and writes a JSON summary beside the archive output.
 """
 
 from __future__ import annotations

--- a/src/tasks/ball_detection/scripts/train.py
+++ b/src/tasks/ball_detection/scripts/train.py
@@ -1,12 +1,14 @@
 """Train a supervised ball detection model with a manual PyTorch loop.
 
-Example commands:
-    `uv run python -m src.tasks.ball_detection.scripts.train`
-    `uv run python -m src.tasks.ball_detection.scripts.train run.dry_run=true`
-    `uv run python -m src.tasks.ball_detection.scripts.train training.trainer.max_epochs=1`
-    `uv run python -m src.tasks.ball_detection.scripts.train training.semi_supervised.num_semi_phases=1`
+Usage:
+    python -m src.tasks.ball_detection.scripts.train
+    python -m src.tasks.ball_detection.scripts.train run.dry_run=true
+    python -m src.tasks.ball_detection.scripts.train training.trainer.max_epochs=1
+    python -m src.tasks.ball_detection.scripts.train training.semi_supervised.num_semi_phases=1
 
-Config entry point: `src/tasks/ball_detection/configs/train.yaml`
+Notes:
+    - Hydra loads configuration from `src/tasks/ball_detection/configs/train.yaml`.
+    - The script supports both supervised training and phase-based semi-supervised scheduling.
 """
 
 from __future__ import annotations

--- a/src/tasks/ball_detection/scripts/visualize_augmentation.py
+++ b/src/tasks/ball_detection/scripts/visualize_augmentation.py
@@ -1,9 +1,13 @@
 """Generate contact sheets for ball-detection sequence augmentations.
 
-Example commands:
-    `uv run python -m src.tasks.ball_detection.scripts.visualize_augmentation`
-    `uv run python -m src.tasks.ball_detection.scripts.visualize_augmentation preview.sample_indices=[0,1,2]`
-    `uv run python -m src.tasks.ball_detection.scripts.visualize_augmentation preview.split=val`
+Usage:
+    python -m src.tasks.ball_detection.scripts.visualize_augmentation
+    python -m src.tasks.ball_detection.scripts.visualize_augmentation preview.sample_indices=[0,1,2]
+    python -m src.tasks.ball_detection.scripts.visualize_augmentation preview.split=val
+
+Notes:
+    - Hydra loads configuration from `src/tasks/ball_detection/configs/visualize_augmentation.yaml`.
+    - The script renders paired original and fully augmented contact sheets for selected clips.
 """
 
 from __future__ import annotations

--- a/src/tasks/blcs/README.md
+++ b/src/tasks/blcs/README.md
@@ -40,14 +40,14 @@ BLCS は、テニスコート座標系におけるボールの 3D 軌道を、2D
 ### データ生成
 
 ```bash
-uv run python -m src.tasks.blcs.scripts.generate_dataset
+python -m src.tasks.blcs.scripts.generate_dataset
 
 # 固定8カメラ（四隅+中点）で生成
 # - 四隅は z_min
 # - 中点は z_max
 # - すべてコート中央 (0,0,0) を注視
 # - Y軸方向バッファは fixed_baseline_clear_extra で増やす
-uv run python -m src.tasks.blcs.scripts.generate_dataset \
+python -m src.tasks.blcs.scripts.generate_dataset \
     camera.placement_mode=fixed_8 \
     camera.fixed_baseline_clear_extra=2.0
 ```
@@ -56,15 +56,15 @@ uv run python -m src.tasks.blcs.scripts.generate_dataset \
 
 ```bash
 # 単一カメラモデル
-uv run python -m src.tasks.blcs.scripts.train
+python -m src.tasks.blcs.scripts.train
 
 # マルチビューモデル（複数カメラ統合）
-uv run python -m src.tasks.blcs.scripts.train \
+python -m src.tasks.blcs.scripts.train \
     model=multiview \
     data=multiview
 
 # マルチビュー学習のカスタム設定例
-uv run python -m src.tasks.blcs.scripts.train \
+python -m src.tasks.blcs.scripts.train \
     model=multiview \
     data=multiview \
     data.num_views_range=[2,4] \
@@ -75,7 +75,6 @@ uv run python -m src.tasks.blcs.scripts.train \
 ### ハイパーパラメータ探索
 
 ```bash
-UV_CACHE_DIR=outputs/tmp_cache/uv_cache \
 RUN_ROOT=outputs/blcs/sweep_$(date +%Y-%m-%d_%H-%M-%S) \
 bash src/tasks/blcs/scripts/run_hparam_sweep.sh
 ```
@@ -90,14 +89,14 @@ bash src/tasks/blcs/scripts/run_hparam_sweep.sh
 
 ```bash
 # 単一カメラ（GT vs Prediction 比較アニメーション）
-uv run python -m src.tasks.blcs.scripts.visualize
+python -m src.tasks.blcs.scripts.visualize
 
 # 単一カメラ（view指定）
-uv run python -m src.tasks.blcs.scripts.visualize \
+python -m src.tasks.blcs.scripts.visualize \
     visualization.animation_view=3d
 
 # マルチビュー（GT vs Prediction 比較アニメーション）
-uv run python -m src.tasks.blcs.scripts.visualize \
+python -m src.tasks.blcs.scripts.visualize \
     visualization=multiview \
     visualization.scene_path=data/blcs/scenes/scene_000003.npz \
     visualization.mode=predict \
@@ -105,7 +104,7 @@ uv run python -m src.tasks.blcs.scripts.visualize \
     visualization.cameras=all
 
 # 保存する場合
-uv run python -m src.tasks.blcs.scripts.visualize \
+python -m src.tasks.blcs.scripts.visualize \
     visualization=multiview \
     visualization.mode=predict \
     visualization.checkpoint=outputs/blcs/multiview/logs/version_0/checkpoints/last.ckpt \

--- a/src/tasks/blcs/generate_dataset/api_server/README.md
+++ b/src/tasks/blcs/generate_dataset/api_server/README.md
@@ -51,7 +51,7 @@ src/tasks/blcs/generate_dataset/api_server/
 From the repo root:
 
 ```bash
-UV_CACHE_DIR=/tmp/uv_cache uv run --group webui -m src.tasks.blcs.generate_dataset.api_server --reload --port 8001
+python -m src.tasks.blcs.generate_dataset.api_server --reload --port 8001
 ```
 
 Quick smoke test:

--- a/src/tasks/blcs/generate_dataset/api_server/__main__.py
+++ b/src/tasks/blcs/generate_dataset/api_server/__main__.py
@@ -1,7 +1,7 @@
 """Module entrypoint for local dev.
 
 Run:
-  uv run python -m src.tasks.blcs.generate_dataset.api_server --port 8001
+  python -m src.tasks.blcs.generate_dataset.api_server --port 8001
 """
 
 from __future__ import annotations
@@ -30,4 +30,3 @@ def main() -> int:
 
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())
-

--- a/src/tasks/blcs/generate_dataset/webui/README.md
+++ b/src/tasks/blcs/generate_dataset/webui/README.md
@@ -54,7 +54,7 @@ src/tasks/blcs/generate_dataset/webui/
 1) Start Python API server (repo root):
 
 ```bash
-UV_CACHE_DIR=/tmp/uv_cache uv run --group webui -m src.tasks.blcs.generate_dataset.api_server --reload --port 8001
+python -m src.tasks.blcs.generate_dataset.api_server --reload --port 8001
 ```
 
 2) Start Next.js dev server (separate terminal):

--- a/src/tasks/blcs/scripts/generate_dataset.py
+++ b/src/tasks/blcs/scripts/generate_dataset.py
@@ -1,11 +1,13 @@
 """Generate a BLCS dataset with Hydra-managed configuration.
 
-Example commands:
-    `uv run python -m src.tasks.blcs.scripts.generate_dataset`
-    `uv run python -m src.tasks.blcs.scripts.generate_dataset generator.num_scenes=100`
-    `uv run python -m src.tasks.blcs.scripts.generate_dataset run.output_dir=data/blcs generator.num_scenes=500`
+Usage:
+    python -m src.tasks.blcs.scripts.generate_dataset
+    python -m src.tasks.blcs.scripts.generate_dataset generator.num_scenes=100
+    python -m src.tasks.blcs.scripts.generate_dataset run.output_dir=data/blcs generator.num_scenes=500
 
-Config entry point: `src/tasks/blcs/configs/generate_dataset.yaml`
+Notes:
+    - Hydra loads configuration from `src/tasks/blcs/configs/generate_dataset.yaml`.
+    - The script generates scenes, writes splits, and persists dataset metadata.
 """
 
 from __future__ import annotations

--- a/src/tasks/blcs/scripts/train.py
+++ b/src/tasks/blcs/scripts/train.py
@@ -1,12 +1,14 @@
 """Train a BLCS model with Hydra-managed configuration.
 
-Example commands:
-    `uv run python -m src.tasks.blcs.scripts.train`
-    `uv run python -m src.tasks.blcs.scripts.train training.max_epochs=5 run.gpus=0`
-    `uv run python -m src.tasks.blcs.scripts.train model=multiview data=multiview`
-    `uv run python -m src.tasks.blcs.scripts.train run.dry_run=true`
+Usage:
+    python -m src.tasks.blcs.scripts.train
+    python -m src.tasks.blcs.scripts.train training.max_epochs=5 run.gpus=0
+    python -m src.tasks.blcs.scripts.train model=multiview data=multiview
+    python -m src.tasks.blcs.scripts.train run.dry_run=true
 
-Config entry point: `src/tasks/blcs/configs/train.yaml`
+Notes:
+    - Hydra loads configuration from `src/tasks/blcs/configs/train.yaml`.
+    - The runner handles the full BLCS training loop from the resolved config.
 """
 
 from __future__ import annotations

--- a/src/tasks/blcs/scripts/visualize.py
+++ b/src/tasks/blcs/scripts/visualize.py
@@ -1,4 +1,13 @@
-"""Entry point for BLCS visualization orchestration."""
+"""Visualize BLCS reconstruction or inference outputs.
+
+Usage:
+    python -m src.tasks.blcs.scripts.visualize
+    python -m src.tasks.blcs.scripts.visualize output_dir=outputs/blcs/preview
+
+Notes:
+    - Hydra loads configuration from `src/tasks/blcs/configs/visualize.yaml`.
+    - The script builds a runtime visualization config and forwards it to the orchestrator.
+"""
 
 from __future__ import annotations
 

--- a/src/tasks/court_detection/README.md
+++ b/src/tasks/court_detection/README.md
@@ -120,13 +120,13 @@ src/tasks/court_detection/
 ### 学習
 
 ```bash
-uv run python -m src.tasks.court_detection.scripts.train
+python -m src.tasks.court_detection.scripts.train
 ```
 
 ### 可視化
 
 ```bash
-uv run python -m src.tasks.court_detection.scripts.visualize
+python -m src.tasks.court_detection.scripts.visualize
 ```
 
 ## 手動アノテーション
@@ -134,7 +134,7 @@ uv run python -m src.tasks.court_detection.scripts.visualize
 実映像からアノテーションを作成する場合は `src.tools.annotate_court_keypoints` を使用：
 
 ```bash
-uv run python -m src.tools.annotate_court_keypoints \
+python -m src.tools.annotate_court_keypoints \
     input_path=data/raw/court_image.jpg \
     output.output_dir=data/court_keypoints
 ```

--- a/src/tasks/court_detection/scripts/train.py
+++ b/src/tasks/court_detection/scripts/train.py
@@ -1,12 +1,12 @@
 """Train court keypoint detection model.
 
-Example:
-    uv run python -m src.tasks.court_detection.scripts.train
+Usage:
+    python -m src.tasks.court_detection.scripts.train
+    python -m src.tasks.court_detection.scripts.train model=hrnet_heatmap training.max_epochs=200
 
-    # With custom config
-    uv run python -m src.tasks.court_detection.scripts.train model=hrnet_heatmap training.max_epochs=200
-
-Config entry point: `src/tasks/court_detection/configs/train.yaml`
+Notes:
+    - Hydra loads configuration from `src/tasks/court_detection/configs/train.yaml`.
+    - The script forwards the resolved config to the training runner.
 """
 
 from __future__ import annotations

--- a/src/tasks/court_detection/scripts/visualize.py
+++ b/src/tasks/court_detection/scripts/visualize.py
@@ -1,4 +1,13 @@
-"""Entry point for court detection visualization orchestration."""
+"""Visualize court detection reconstruction or inference outputs.
+
+Usage:
+    python -m src.tasks.court_detection.scripts.visualize
+    python -m src.tasks.court_detection.scripts.visualize output_dir=outputs/court_detection/preview
+
+Notes:
+    - Hydra loads configuration from `src/tasks/court_detection/configs/visualize.yaml`.
+    - The script builds a runtime visualization config and forwards it to the orchestrator.
+"""
 
 from __future__ import annotations
 

--- a/src/tasks/event_detection/README.md
+++ b/src/tasks/event_detection/README.md
@@ -7,8 +7,8 @@ Models:
 - **3D model**: predicts shot/bounce timings from `ball_pos_world` only (for within-scene event timing).
 
 Entry points:
-- `uv run python -m src.tasks.event_detection.scripts.train_uv`
-- `uv run python -m src.tasks.event_detection.scripts.train_3d`
+- `python -m src.tasks.event_detection.scripts.train_uv`
+- `python -m src.tasks.event_detection.scripts.train_3d`
 
 Inference:
 - `src/tasks/event_detection/inference/uv_predictor.py` for UV-based event detection
@@ -35,11 +35,11 @@ event_peaks = outputs["event_peaks"]  # list[B][E][N]
 軌道はGT系列を使用し、イベント表現は推論結果（predicted peaks）のみを使用します。
 
 - UV:
-    - `uv run python -m src.tasks.event_detection.scripts.visualize visualization.scene_path=data/blcs/scenes/rally_000000.npz`
-    - 推論: `uv run python -m src.tasks.event_detection.scripts.visualize visualization.mode=predict visualization.checkpoint=...`
+    - `python -m src.tasks.event_detection.scripts.visualize visualization.scene_path=data/blcs/scenes/rally_000000.npz`
+    - 推論: `python -m src.tasks.event_detection.scripts.visualize visualization.mode=predict visualization.checkpoint=...`
 - 3D:
-    - `uv run python -m src.tasks.event_detection.scripts.visualize visualization=traj3d data=blcs_rally_3d visualization.scene_path=data/blcs/scenes/rally_000000.npz`
-    - 推論: `uv run python -m src.tasks.event_detection.scripts.visualize visualization=traj3d data=blcs_rally_3d visualization.mode=predict visualization.checkpoint=...`
+    - `python -m src.tasks.event_detection.scripts.visualize visualization=traj3d data=blcs_rally_3d visualization.scene_path=data/blcs/scenes/rally_000000.npz`
+    - 推論: `python -m src.tasks.event_detection.scripts.visualize visualization=traj3d data=blcs_rally_3d visualization.mode=predict visualization.checkpoint=...`
 
 Animationでは、推論イベント周辺フレームでもボール色が連続的に変化します。
 

--- a/src/tasks/event_detection/scripts/train_3d.py
+++ b/src/tasks/event_detection/scripts/train_3d.py
@@ -1,11 +1,13 @@
-"""Train a 3D-trajectory event detection model using Hydra-managed configuration.
+"""Train the 3D event detection model with Hydra-managed configuration.
 
-Example commands:
-    `uv run python -m src.tasks.event_detection.scripts.train_3d`
-    `uv run python -m src.tasks.event_detection.scripts.train_3d run.dry_run=true`
-    `uv run python -m src.tasks.event_detection.scripts.train_3d data.scene_dir=data/blcs run.dry_run=false`
+Usage:
+    python -m src.tasks.event_detection.scripts.train_3d
+    python -m src.tasks.event_detection.scripts.train_3d run.dry_run=true
+    python -m src.tasks.event_detection.scripts.train_3d data.scene_dir=data/blcs run.dry_run=false
 
-Config entry point: `src/tasks/event_detection/configs/train_3d.yaml`
+Notes:
+    - Configuration is loaded from `src/tasks/event_detection/configs/train_3d.yaml`.
+    - The script uses Hydra for configuration loading.
 """
 
 from __future__ import annotations

--- a/src/tasks/event_detection/scripts/train_uv.py
+++ b/src/tasks/event_detection/scripts/train_uv.py
@@ -1,11 +1,13 @@
-"""Train a UV-based event detection model using Hydra-managed configuration.
+"""Train the UV-based event detection model with Hydra-managed configuration.
 
-Example commands:
-    `uv run python -m src.tasks.event_detection.scripts.train_uv`
-    `uv run python -m src.tasks.event_detection.scripts.train_uv run.dry_run=true`
-    `uv run python -m src.tasks.event_detection.scripts.train_uv data.scene_dir=data/blcs run.dry_run=false`
+Usage:
+    python -m src.tasks.event_detection.scripts.train_uv
+    python -m src.tasks.event_detection.scripts.train_uv run.dry_run=true
+    python -m src.tasks.event_detection.scripts.train_uv data.scene_dir=data/blcs run.dry_run=false
 
-Config entry point: `src/tasks/event_detection/configs/train_uv.yaml`
+Notes:
+    - Configuration is loaded from `src/tasks/event_detection/configs/train_uv.yaml`.
+    - The script uses Hydra for configuration loading.
 """
 
 from __future__ import annotations

--- a/src/tasks/event_detection/scripts/visualize.py
+++ b/src/tasks/event_detection/scripts/visualize.py
@@ -1,4 +1,13 @@
-"""Entry point for event detection visualization orchestration."""
+"""Visualize event detection outputs with Hydra-managed configuration.
+
+Usage:
+    python -m src.tasks.event_detection.scripts.visualize
+    python -m src.tasks.event_detection.scripts.visualize run.output_dir=outputs/event_detection
+
+Notes:
+    - Configuration is loaded from `src/tasks/event_detection/configs/visualize.yaml`.
+    - The script uses Hydra for configuration loading.
+"""
 
 from __future__ import annotations
 

--- a/src/tasks/plcs/README.md
+++ b/src/tasks/plcs/README.md
@@ -151,7 +151,7 @@ src/tasks/plcs/
 ### データ生成
 
 ```bash
-uv run python -m src.tasks.plcs.scripts.generate_dataset
+python -m src.tasks.plcs.scripts.generate_dataset
 ```
 
 ### データ分布の調査（位置・向き・カメラ数）
@@ -160,10 +160,10 @@ uv run python -m src.tasks.plcs.scripts.generate_dataset
 原点近傍への偏り（半径しきい値内の割合）などを集計します。
 
 ```bash
-uv run python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution
+python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution
 
 # 出力先やサンプル数の変更例
-uv run python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution \
+python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution \
     run.output_dir=outputs/plcs/analysis/dataset_distribution \
     analysis.max_scenes=200 \
     analysis.max_frames_per_scene=256
@@ -173,16 +173,16 @@ uv run python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution \
 
 ```bash
 # フレーム単位モデル（単一カメラ）
-uv run python -m src.tasks.plcs.scripts.train
+python -m src.tasks.plcs.scripts.train
 
 # シーケンスモデル（単一カメラ・時系列）
-uv run python -m src.tasks.plcs.scripts.train_sequence
+python -m src.tasks.plcs.scripts.train_sequence
 
 # マルチビューモデル（複数カメラ統合）
-uv run python -m src.tasks.plcs.scripts.train_multiview
+python -m src.tasks.plcs.scripts.train_multiview
 
 # マルチビュー学習のカスタム設定例
-uv run python -m src.tasks.plcs.scripts.train_multiview \
+python -m src.tasks.plcs.scripts.train_multiview \
     data.num_views=4 \
     data.min_cameras=2 \
     training.max_epochs=100
@@ -192,20 +192,20 @@ uv run python -m src.tasks.plcs.scripts.train_multiview \
 
 ```bash
 # 単一カメラ
-uv run python -m src.tasks.plcs.scripts.visualize
+python -m src.tasks.plcs.scripts.visualize
 
 # マルチビュー（Ground Truth）
-uv run python -m src.tasks.plcs.scripts.visualize_multiview \
+python -m src.tasks.plcs.scripts.visualize_multiview \
     visualization.scene_path=data/plcs/scenes/scene_000003.npz
 
 # マルチビュー（チェックポイントからの予測）
-uv run python -m src.tasks.plcs.scripts.visualize_multiview \
+python -m src.tasks.plcs.scripts.visualize_multiview \
     visualization.mode=predict \
     visualization.checkpoint=outputs/plcs/multiview/logs/version_0/checkpoints/last.ckpt \
     visualization.cameras=all
 
 # 比較アニメーション出力
-uv run python -m src.tasks.plcs.scripts.visualize_multiview \
+python -m src.tasks.plcs.scripts.visualize_multiview \
     visualization.mode=predict \
     visualization.view=animation \
     visualization.save=comparison.mp4

--- a/src/tasks/plcs/scripts/analysis/analyze_dataset_distribution.py
+++ b/src/tasks/plcs/scripts/analysis/analyze_dataset_distribution.py
@@ -1,16 +1,13 @@
-"""Analyze PLCS dataset distributions (position, yaw, cameras) using Hydra.
+"""Analyze PLCS dataset distributions with Hydra-managed configuration.
 
-This script inspects pre-generated PLCS scene NPZ files and summarizes:
-- Player position distribution (per-frame and initial conditions)
-- Player yaw distribution
-- Camera count distribution (after filtering)
-- Fractions near the court origin (useful for detecting dataset bias)
+Usage:
+    python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution
+    python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution run.output_dir=outputs/plcs/analysis/dataset_distribution analysis.max_scenes=200
 
-Example commands:
-    `uv run python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution`
-    `uv run python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution run.output_dir=outputs/plcs/analysis/dataset_distribution analysis.max_scenes=200`
-
-Config entry point: `src/tasks/plcs/configs/analyze_dataset_distribution.yaml`
+Notes:
+    - Configuration is loaded from `src/tasks/plcs/configs/analyze_dataset_distribution.yaml`.
+    - The script summarizes position, yaw, and camera statistics from PLCS scene NPZ files.
+    - The script uses Hydra for configuration loading.
 """
 
 from __future__ import annotations

--- a/src/tasks/plcs/scripts/generate_dataset.py
+++ b/src/tasks/plcs/scripts/generate_dataset.py
@@ -1,10 +1,12 @@
-"""Generate PLCS scenes for training using Hydra-managed configuration.
+"""Generate PLCS scenes for training with Hydra-managed configuration.
 
-Example commands:
-    `uv run python -m src.tasks.plcs.scripts.generate_dataset`
-    `uv run python -m src.tasks.plcs.scripts.generate_dataset run.output_dir=data/plcs simulation.num_scenes=10`
+Usage:
+    python -m src.tasks.plcs.scripts.generate_dataset
+    python -m src.tasks.plcs.scripts.generate_dataset run.output_dir=data/plcs simulation.num_scenes=10
 
-Config entry point: `src/tasks/plcs/configs/generate_dataset.yaml`
+Notes:
+    - Configuration is loaded from `src/tasks/plcs/configs/generate_dataset.yaml`.
+    - The script uses Hydra for configuration loading.
 """
 
 from __future__ import annotations

--- a/src/tasks/plcs/scripts/train.py
+++ b/src/tasks/plcs/scripts/train.py
@@ -1,11 +1,13 @@
-"""Train a PLCS model with Hydra-managed configuration.
+"""Train the PLCS model with Hydra-managed configuration.
 
-Example commands:
-    `uv run python -m src.tasks.plcs.scripts.train`
-    `uv run python -m src.tasks.plcs.scripts.train run.gpus=0 training.max_epochs=1`
-    `uv run python -m src.tasks.plcs.scripts.train run.dry_run=true`
+Usage:
+    python -m src.tasks.plcs.scripts.train
+    python -m src.tasks.plcs.scripts.train run.gpus=0 training.max_epochs=1
+    python -m src.tasks.plcs.scripts.train run.dry_run=true
 
-Config entry point: `src/tasks/plcs/configs/train.yaml`
+Notes:
+    - Configuration is loaded from `src/tasks/plcs/configs/train.yaml`.
+    - The script uses Hydra for configuration loading.
 """
 
 # mypy: disable-error-code=misc

--- a/src/tasks/plcs/scripts/visualize.py
+++ b/src/tasks/plcs/scripts/visualize.py
@@ -1,4 +1,13 @@
-"""Entry point for PLCS visualization orchestration."""
+"""Visualize PLCS outputs with Hydra-managed configuration.
+
+Usage:
+    python -m src.tasks.plcs.scripts.visualize
+    python -m src.tasks.plcs.scripts.visualize run.output_dir=outputs/plcs/visualization
+
+Notes:
+    - Configuration is loaded from `src/tasks/plcs/configs/visualize.yaml`.
+    - The script uses Hydra for configuration loading.
+"""
 
 from __future__ import annotations
 

--- a/src/tasks/trajectory_completion/README.md
+++ b/src/tasks/trajectory_completion/README.md
@@ -3,7 +3,7 @@
 Train and run inference for UV trajectory completion using court keypoints.
 
 Entry points:
-- `uv run python -m src.tasks.trajectory_completion.scripts.train`
+- `python -m src.tasks.trajectory_completion.scripts.train`
 
 Inference:
 - `src/tasks/trajectory_completion/inference/uv_predictor.py`
@@ -45,18 +45,18 @@ resolution. Provide only one of them per dataset instance.
 
 Animation-only visualization:
 
-- `uv run python -m src.tasks.trajectory_completion.scripts.visualize`
-- `uv run python -m src.tasks.trajectory_completion.scripts.visualize visualization.scene_path=data/blcs/scenes/rally_000000.npz`
+- `python -m src.tasks.trajectory_completion.scripts.visualize`
+- `python -m src.tasks.trajectory_completion.scripts.visualize visualization.scene_path=data/blcs/scenes/rally_000000.npz`
 - Inference animation (GT line + predicted point, color-coded by observed/completed frames):
-    - `uv run python -m src.tasks.trajectory_completion.scripts.visualize visualization.mode=predict visualization.checkpoint=outputs/trajectory_completion/.../last.ckpt`
+    - `python -m src.tasks.trajectory_completion.scripts.visualize visualization.mode=predict visualization.checkpoint=outputs/trajectory_completion/.../last.ckpt`
 - Keep observed frames in completed output:
-    - `uv run python -m src.tasks.trajectory_completion.scripts.visualize visualization.mode=predict visualization.merge_observed=true`
+    - `python -m src.tasks.trajectory_completion.scripts.visualize visualization.mode=predict visualization.merge_observed=true`
 - Disable observed-frame merge (show raw model output):
-    - `uv run python -m src.tasks.trajectory_completion.scripts.visualize visualization.mode=predict visualization.merge_observed=false`
+    - `python -m src.tasks.trajectory_completion.scripts.visualize visualization.mode=predict visualization.merge_observed=false`
 - Cut out-of-frame predictions using in-frame head:
-    - `uv run python -m src.tasks.trajectory_completion.scripts.visualize visualization.mode=predict visualization.cut_out_of_frame=true visualization.in_frame_threshold=0.5`
+    - `python -m src.tasks.trajectory_completion.scripts.visualize visualization.mode=predict visualization.cut_out_of_frame=true visualization.in_frame_threshold=0.5`
 - Save animation:
-    - `uv run python -m src.tasks.trajectory_completion.scripts.visualize visualization.save=outputs/tmp/vis.gif`
+    - `python -m src.tasks.trajectory_completion.scripts.visualize visualization.save=outputs/tmp/vis.gif`
 
 ## Training design: observed drift mitigation
 

--- a/src/tasks/trajectory_completion/scripts/train.py
+++ b/src/tasks/trajectory_completion/scripts/train.py
@@ -1,10 +1,12 @@
-"""Train a UV trajectory completion model using Hydra-managed configuration.
+"""Train the trajectory completion model with Hydra-managed configuration.
 
-Example commands:
-    `uv run python -m src.tasks.trajectory_completion.scripts.train`
-    `uv run python -m src.tasks.trajectory_completion.scripts.train run.dry_run=true run.gpus=0 data.batch_size=2`
+Usage:
+    python -m src.tasks.trajectory_completion.scripts.train
+    python -m src.tasks.trajectory_completion.scripts.train run.dry_run=true run.gpus=0 data.batch_size=2
 
-Config entry point: `src/tasks/trajectory_completion/configs/train.yaml`
+Notes:
+    - Configuration is loaded from `src/tasks/trajectory_completion/configs/train.yaml`.
+    - The script uses Hydra for configuration loading.
 """
 
 from __future__ import annotations

--- a/src/tasks/trajectory_completion/scripts/visualize.py
+++ b/src/tasks/trajectory_completion/scripts/visualize.py
@@ -1,4 +1,13 @@
-"""Entry point for trajectory completion visualization orchestration."""
+"""Visualize trajectory completion outputs with Hydra-managed configuration.
+
+Usage:
+    python -m src.tasks.trajectory_completion.scripts.visualize
+    python -m src.tasks.trajectory_completion.scripts.visualize run.output_dir=outputs/trajectory_completion/visualization
+
+Notes:
+    - Configuration is loaded from `src/tasks/trajectory_completion/configs/visualize.yaml`.
+    - The script uses Hydra for configuration loading.
+"""
 
 from __future__ import annotations
 

--- a/src/tennis_scene/README.md
+++ b/src/tennis_scene/README.md
@@ -53,14 +53,14 @@ TennisSceneOrchestrator (オーケストレーター)
 ### 基本実行
 
 ```bash
-uv run python -m src.tennis_scene.scripts.run_pipeline \
+python -m src.tennis_scene.scripts.run_pipeline \
     video_path=inputs/demo/match.mp4
 ```
 
 ### オプション指定
 
 ```bash
-uv run python -m src.tennis_scene.scripts.run_pipeline \
+python -m src.tennis_scene.scripts.run_pipeline \
     video_path=inputs/demo/match.mp4 \
     max_frames=100 \
     court_kp.frame_index=0 \
@@ -72,7 +72,7 @@ uv run python -m src.tennis_scene.scripts.run_pipeline \
 手動入力UIを使う場合は `manual_ui` を指定します。結果JSONは `court_kp.output_path` に保存されます。
 
 ```bash
-uv run python -m src.tennis_scene.scripts.run_pipeline \
+python -m src.tennis_scene.scripts.run_pipeline \
     video_path=inputs/demo/match.mp4 \
     court_kp.mode=manual_ui \
     court_kp.output_path=outputs/tennis_scene/court_kp_result.json
@@ -81,7 +81,7 @@ uv run python -m src.tennis_scene.scripts.run_pipeline \
 ### GVHMRスキップ（デバッグ用）
 
 ```bash
-uv run python -m src.tennis_scene.scripts.run_pipeline \
+python -m src.tennis_scene.scripts.run_pipeline \
     video_path=inputs/demo/match.mp4 \
     gvhmr.skip=true
 ```
@@ -89,7 +89,7 @@ uv run python -m src.tennis_scene.scripts.run_pipeline \
 ### カスタムモデルパス指定
 
 ```bash
-uv run python -m src.tennis_scene.scripts.run_pipeline \
+python -m src.tennis_scene.scripts.run_pipeline \
     video_path=inputs/demo/match.mp4 \
     gvhmr.yolo_checkpoint=/path/to/yolov8.pt \
     gvhmr.vitpose_checkpoint=/path/to/vitpose.pth

--- a/src/tennis_scene/scripts/run_pipeline.py
+++ b/src/tennis_scene/scripts/run_pipeline.py
@@ -1,20 +1,14 @@
-"""Run tennis scene 3D reconstruction pipeline.
+"""Run the tennis scene 3D reconstruction pipeline.
 
-This script runs the integrated pipeline combining:
-- Court KP Detection (single frame, fixed camera)
-- GVHMR (local SMPL, static_cam=True)
-- WASB (ball detection)
-- Trajectory Completion (optional)
-- UV Event Detection
-- PLCS (3D player position + yaw)
-- BLCS (3D ball trajectory)
-- 3D Event Detection
+Usage:
+    python -m src.tennis_scene.scripts.run_pipeline video_path=inputs/demo/match.mp4
+    python -m src.tennis_scene.scripts.run_pipeline video_path=... max_frames=100
 
-Example commands:
-    `uv run python -m src.tennis_scene.scripts.run_pipeline video_path=inputs/demo/match.mp4`
-    `uv run python -m src.tennis_scene.scripts.run_pipeline video_path=... max_frames=100`
-
-Config entry point: `src/tennis_scene/configs/pipeline.yaml`
+Notes:
+    - The pipeline combines court keypoint detection, GVHMR, ball detection, trajectory completion,
+      UV event detection, PLCS, BLCS, and 3D event detection.
+    - Configuration is loaded from `src/tennis_scene/configs/pipeline.yaml`.
+    - Hydra handles runtime overrides.
 """
 
 from __future__ import annotations

--- a/src/tennis_scene/scripts/visualization.py
+++ b/src/tennis_scene/scripts/visualization.py
@@ -1,15 +1,14 @@
 """Visualize tennis scene reconstruction results.
 
-This script renders the output of the tennis scene pipeline as:
-- Interactive matplotlib 3D animation (view in UI)
-- MP4 video file (saved to disk)
+Usage:
+    python -m src.tennis_scene.scripts.visualization input=outputs/tennis_scene/clip.npz
+    python -m src.tennis_scene.scripts.visualization input=... output=animation.mp4 style.player_representation=skeleton
+    python -m src.tennis_scene.scripts.visualization input=... display=true
 
-Example commands:
-    `third_party/GVHMR/.venv/bin/python -m src.tennis_scene.scripts.visualization input=outputs/tennis_scene/clip.npz`
-    `third_party/GVHMR/.venv/bin/python -m src.tennis_scene.scripts.visualization input=... output=animation.mp4 style.player_representation=skeleton`
-    `third_party/GVHMR/.venv/bin/python -m src.tennis_scene.scripts.visualization input=... display=true`
-
-Config entry point: `src/tennis_scene/configs/visualization.yaml`
+Notes:
+    - The visualizer can render an interactive matplotlib 3D animation or save an MP4 file.
+    - Configuration is loaded from `src/tennis_scene/configs/visualization.yaml`.
+    - Hydra handles runtime overrides.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Remove stale `uv` runner assumptions across repo docs and script examples.
- Update commands to assume execution inside the container with `python -m ...` and direct tool invocations.
- Align project guidance and developer workflow files with the Docker + pip setup.

## Changes

- Updated `AGENTS.md`, `.pre-commit-config.yaml`, `.gitignore`, and `pyproject.toml` to remove `uv`-based workflow references.
- Rewrote README command examples and script docstring usage blocks to use container-internal execution.
- Updated `src/developing/mae/configs/train.yaml` and the BLCS API server entrypoint docs to remove `uv run` examples.

## Validation

- `rg -n --hidden --glob '!.git' '\buv run\b|\buv lock\b|\.uv-cache|uv\.lock' /workspace/AGENTS.md /workspace/.pre-commit-config.yaml /workspace/.gitignore /workspace/pyproject.toml /workspace/README.md /workspace/src`
- `python -m pytest --no-cov`

## Related Issues

- None

## Notes

- This PR excludes changes under `.codex/agents`.
