### PR TITLE
feat: Add MDD input adapter for ball detection

### DIFF
--- a/src/tasks/ball_detection/configs/model/stunet.yaml
+++ b/src/tasks/ball_detection/configs/model/stunet.yaml
@@ -1,5 +1,8 @@
 name: stunet
-in_channels: 3
+input_mode: mdd
+in_channels: 2
 num_classes: 1
 num_frames: 8
 input_layout: bcthw
+mdd_a: 0.2
+mdd_b: 0.15

--- a/src/tasks/ball_detection/input_adapter.py
+++ b/src/tasks/ball_detection/input_adapter.py
@@ -1,0 +1,99 @@
+"""Input-mode specific adapters for ball detection models."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+from torch import Tensor
+
+_RGB_TO_LUMINANCE = (0.299, 0.587, 0.114)
+
+
+def resolve_input_mode(model_cfg: Mapping[str, Any] | Any) -> str:
+    """Resolve and validate the configured model input mode."""
+    input_mode = str(model_cfg.get("input_mode", "rgb")).strip().lower()
+    if input_mode not in {"rgb", "mdd"}:
+        raise ValueError(
+            "model.input_mode must be one of ['rgb', 'mdd'], "
+            f"got '{input_mode}'."
+        )
+    return input_mode
+
+
+def resolve_model_in_channels(model_cfg: Mapping[str, Any] | Any) -> int:
+    """Return the effective model input channel count for the configured mode."""
+    input_mode = resolve_input_mode(model_cfg)
+    configured_channels = model_cfg.get("in_channels")
+    if configured_channels is None:
+        return 3 if input_mode == "rgb" else 2
+
+    in_channels = int(configured_channels)
+    expected_channels = 3 if input_mode == "rgb" else 2
+    if in_channels != expected_channels:
+        raise ValueError(
+            f"model.in_channels must be {expected_channels} when "
+            f"model.input_mode='{input_mode}', got {in_channels}."
+        )
+    return in_channels
+
+
+def to_model_input(images: Tensor, model_cfg: Mapping[str, Any] | Any) -> Tensor:
+    """Convert ``(B, T, C, H, W)`` RGB frames into the configured model input."""
+    if images.ndim != 5:
+        raise ValueError(
+            "Expected images with shape (B, T, C, H, W), "
+            f"got {tuple(images.shape)}."
+        )
+
+    input_mode = resolve_input_mode(model_cfg)
+    if input_mode == "rgb":
+        return images.permute(0, 2, 1, 3, 4).contiguous()
+    return _rgb_frames_to_mdd(images, model_cfg)
+
+
+def _rgb_frames_to_mdd(images: Tensor, model_cfg: Mapping[str, Any] | Any) -> Tensor:
+    """Convert RGB frame sequences into ``(B, 2, T, H, W)`` MDD features."""
+    if images.shape[2] != 3:
+        raise ValueError(
+            "MDD conversion expects RGB images with shape (B, T, 3, H, W), "
+            f"got {tuple(images.shape)}."
+        )
+
+    weights = images.new_tensor(_RGB_TO_LUMINANCE).view(1, 1, 3, 1, 1)
+    luminance = (images * weights).sum(dim=2)
+    brighten = torch.zeros_like(luminance)
+    darken = torch.zeros_like(luminance)
+
+    if images.shape[1] > 1:
+        frame_diffs = luminance[:, 1:] - luminance[:, :-1]
+        gain, offset = _resolve_mdd_normalization(model_cfg)
+        brighten[:, 1:] = _power_normalize(torch.clamp(frame_diffs, min=0.0), gain, offset)
+        darken[:, 1:] = _power_normalize(torch.clamp(-frame_diffs, min=0.0), gain, offset)
+
+    return torch.stack([brighten, darken], dim=1)
+
+
+def _resolve_mdd_normalization(model_cfg: Mapping[str, Any] | Any) -> tuple[float, float]:
+    """Resolve the experiments-compatible MDD normalization constants."""
+    a_raw = float(model_cfg.get("mdd_a", 0.2))
+    b_raw = float(model_cfg.get("mdd_b", 0.15))
+    a_val = abs(float(torch.tanh(torch.tensor(a_raw)).item()))
+    b_val = float(torch.tanh(torch.tensor(b_raw)).item())
+    gain = 5.0 / (0.45 * a_val + 1.0e-6)
+    offset = 0.6 * b_val
+    return gain, offset
+
+
+def _power_normalize(values: Tensor, gain: float, offset: float) -> Tensor:
+    """Apply the same power normalization used by the experiments MDD path."""
+    logits = torch.clamp(gain * (values.abs() - offset), min=-80.0, max=80.0)
+    return torch.sigmoid(logits)
+
+
+__all__ = [
+    "resolve_input_mode",
+    "resolve_model_in_channels",
+    "to_model_input",
+]

--- a/src/tasks/ball_detection/models/spatiotemporal_unet.py
+++ b/src/tasks/ball_detection/models/spatiotemporal_unet.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 import torch
 import torch.nn as nn
 
+from src.tasks.ball_detection.input_adapter import resolve_model_in_channels
+
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
@@ -194,11 +196,11 @@ class SpatioTemporalUNet(nn.Module):
         self.final_conv = nn.Conv3d(64, self.num_classes, kernel_size=1)
 
     @classmethod
-    def from_config(cls, config: "DictConfig") -> "SpatioTemporalUNet":
+    def from_config(cls, config: DictConfig) -> SpatioTemporalUNet:
         """Create the model from a composed Hydra config."""
         model_cfg = config.get("model", {}) or {}
         return cls(
-            in_channels=int(model_cfg.get("in_channels", 3)),
+            in_channels=resolve_model_in_channels(model_cfg),
             num_classes=int(model_cfg.get("num_classes", 1)),
         )
 

--- a/src/tasks/ball_detection/scripts/train.py
+++ b/src/tasks/ball_detection/scripts/train.py
@@ -38,10 +38,13 @@ from tqdm.auto import tqdm
 from src.tasks.ball_detection.data.argumentation import BallDetectionArgumentation
 from src.tasks.ball_detection.data.dataset import BallDetectionDataset
 from src.tasks.ball_detection.data.types import BallDetectionBatch
+from src.tasks.ball_detection.input_adapter import to_model_input
 from src.tasks.ball_detection.models import build_ball_detection_model
 from src.tasks.ball_detection.training.losses import BallDetectionFocalLoss
 from src.tasks.ball_detection.training.metrics import BallDetectionMetrics
-from src.tasks.ball_detection.training.pseudo_labeling import generate_phase_pseudo_labels
+from src.tasks.ball_detection.training.pseudo_labeling import (
+    generate_phase_pseudo_labels,
+)
 
 if TYPE_CHECKING:
     from torch.amp.grad_scaler import GradScaler
@@ -514,7 +517,7 @@ def _train_epoch(
 
         optimizer.zero_grad(set_to_none=True)
         with _autocast_context(config, device=device):
-            logits = model(_to_model_input(images)).squeeze(1)
+            logits = model(_to_model_input(images, config)).squeeze(1)
             if logits.shape != targets.shape:
                 logits = F.interpolate(
                     logits,
@@ -593,7 +596,7 @@ def _evaluate(
         heatmap_size = batch["heatmap_size"].to(device=device, dtype=torch.float32, non_blocking=True)
 
         with _autocast_context(config, device=device):
-            logits = model(_to_model_input(images)).squeeze(1)
+            logits = model(_to_model_input(images, config)).squeeze(1)
             if logits.shape != targets.shape:
                 logits = F.interpolate(
                     logits,
@@ -632,7 +635,7 @@ def _run_dry_run(
     targets = batch["heatmaps"].to(device=device, dtype=torch.float32, non_blocking=True)
 
     with _autocast_context(config, device=device):
-        logits = model(_to_model_input(images)).squeeze(1)
+        logits = model(_to_model_input(images, config)).squeeze(1)
         if logits.shape != targets.shape:
             logits = F.interpolate(
                 logits,
@@ -896,7 +899,7 @@ def _infer_visualization_predictions(
             batch_inputs.append(window)
         inputs = torch.from_numpy(np.stack(batch_inputs)).to(device=device, dtype=torch.float32)
         with _autocast_context(config, device=device):
-            logits = model(_to_model_input(inputs)).squeeze(1)
+            logits = model(_to_model_input(inputs, config)).squeeze(1)
             probs = torch.sigmoid(logits).detach().float().cpu().numpy()
         probs = np.nan_to_num(probs, nan=0.0, posinf=1.0, neginf=0.0)
         for batch_index, start in enumerate(batch_starts):
@@ -1099,14 +1102,9 @@ def _maybe_compile(model: nn.Module, *, device: torch.device) -> nn.Module:
         return model
 
 
-def _to_model_input(images: Tensor) -> Tensor:
-    """Convert `(B, T, C, H, W)` images to `(B, C, T, H, W)`."""
-    if images.ndim != 5:
-        raise ValueError(
-            "Expected images with shape (B, T, C, H, W), "
-            f"got {tuple(images.shape)}."
-        )
-    return images.permute(0, 2, 1, 3, 4).contiguous()
+def _to_model_input(images: Tensor, config: DictConfig) -> Tensor:
+    """Convert batched RGB frames into the configured model input layout."""
+    return to_model_input(images, config.get("model", {}) or {})
 
 
 def _resolve_progress_total(loader: DataLoader[Any], *, max_batches: int | None) -> int | None:
@@ -1257,9 +1255,13 @@ def _seed_everything(seed: int) -> None:
 def _configure_runtime(config: DictConfig) -> None:
     """Apply matmul and TF32 runtime settings from the config."""
     training_cfg = config.get("training", {}) or {}
+    data_cfg = config.get("data", {}) or {}
     matmul_precision = training_cfg.get("matmul_precision")
     if matmul_precision:
         torch.set_float32_matmul_precision(str(matmul_precision))
+    sharing_strategy = data_cfg.get("sharing_strategy")
+    if sharing_strategy not in (None, ""):
+        torch.multiprocessing.set_sharing_strategy(str(sharing_strategy))
     if torch.cuda.is_available():
         allow_tf32 = bool(training_cfg.get("allow_tf32", True))
         fp32_mode = "tf32" if allow_tf32 else "ieee"

--- a/src/tasks/ball_detection/training/pseudo_labeling.py
+++ b/src/tasks/ball_detection/training/pseudo_labeling.py
@@ -15,6 +15,8 @@ import torch
 from torch import nn
 from tqdm.auto import tqdm
 
+from src.tasks.ball_detection.input_adapter import to_model_input
+
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
@@ -464,7 +466,9 @@ def _infer_chunk_predictions(
             batch.append(np.stack(frames))
         inputs = torch.from_numpy(np.stack(batch)).to(device=device, dtype=torch.float32)
         with torch.inference_mode():
-            probs = torch.sigmoid(model(_to_model_input(inputs))).squeeze(1).cpu().numpy()
+            probs = torch.sigmoid(
+                model(_to_model_input(inputs, config))
+            ).squeeze(1).cpu().numpy()
         probs = np.nan_to_num(probs, nan=0.0, posinf=1.0, neginf=0.0)
 
         for batch_index, start in enumerate(batch_starts):
@@ -637,13 +641,9 @@ def _batched(values: Sequence[int], batch_size: int) -> Iterator[list[int]]:
         yield batch
 
 
-def _to_model_input(images: torch.Tensor) -> torch.Tensor:
-    """Convert pseudo inference input from ``(B, T, C, H, W)`` to ``(B, C, T, H, W)``."""
-    if images.ndim != 5:
-        raise ValueError(
-            f"Expected pseudo input with shape (B, T, C, H, W), got {tuple(images.shape)}."
-        )
-    return images.permute(0, 2, 1, 3, 4).contiguous()
+def _to_model_input(images: torch.Tensor, config: DictConfig) -> torch.Tensor:
+    """Convert cached RGB frames into the configured model input layout."""
+    return to_model_input(images, config.get("model", {}) or {})
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

- Add a ball-detection input adapter that supports both RGB and MDD model inputs.
- Switch the STUNet config and training/pseudo-label inference paths to use the shared adapter.
- Align model channel resolution with `model.input_mode` so config mismatches fail early.

## Changes

- Add `src/tasks/ball_detection/input_adapter.py` to centralize input-mode validation, channel resolution, RGB passthrough, and RGB-to-MDD conversion.
- Update `SpatioTemporalUNet.from_config()` to derive `in_channels` from the configured input mode instead of trusting a raw default.
- Route training, evaluation, visualization inference, and pseudo-label generation through the shared adapter, and set the STUNet default config to `input_mode: mdd` with 2 input channels.

## Validation

- User confirmed training completed successfully with this change set.
- `python -m compileall /workspace/src/tasks/ball_detection`

## Notes

- This PR intentionally excludes unrelated working tree changes in `.devcontainer/devcontainer.json`, `third_party/DINO`, and `.codex/agents/`.
