### PR TITLE
Add DINO Swin-L checkpoint scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ checkpoints/DINO/*
 !checkpoints/DINO/README.md
 !checkpoints/DINO/scripts/
 !checkpoints/DINO/scripts/*.py
+!checkpoints/DINO/analyze/
+checkpoints/DINO/analyze/*
+!checkpoints/DINO/analyze/ball_feature_consistency.py
 *.pt
 *.pth
 *.ckpt

--- a/checkpoints/DINO/README.md
+++ b/checkpoints/DINO/README.md
@@ -6,10 +6,18 @@ backbone-only exports used in this workspace.
 ## Files
 
 - `checkpoint0011_5scale.pth`: Official full DINO checkpoint from IDEA-Research.
+- `checkpoint0027_5scale_swin.pth`: Official full DINO 5-scale Swin-L checkpoint
+  from IDEA-Research.
 - `backbone_body_state.pth`: Trimmed backbone body state dict with keys like
   `conv1.weight` and `layer4.2.conv3.weight`.
 - `dino_backbone_module_state.pth`: `DINOBackbone.state_dict()` export with keys
   like `body.conv1.weight`.
+- `swin_backbone_state_checkpoint0027_5scale.pth`: Trimmed Swin backbone state
+  dict with keys like `patch_embed.proj.weight` and
+  `layers.3.blocks.1.mlp.fc2.weight`.
+- `dino_swin_backbone_module_state_checkpoint0027_5scale.pth`:
+  `DINOSwinBackbone.state_dict()` export with keys like
+  `backbone.patch_embed.proj.weight`.
 
 ## Download
 
@@ -33,6 +41,18 @@ python /workspace/checkpoints/DINO/scripts/download_checkpoint0011_5scale.py \
   --output /tmp/checkpoint0011_5scale.pth
 ```
 
+To download the Swin-L 5-scale checkpoint:
+
+```bash
+python /workspace/checkpoints/DINO/scripts/download_checkpoint0027_5scale_swin.py
+```
+
+Expected checksum:
+
+```text
+17ddce1592816a0c63a2edc94d4a0877ffeb086f397a6657e151c703a4c850b5
+```
+
 ## Backbone Extraction
 
 To extract the ResNet backbone body state dict from the full checkpoint:
@@ -44,9 +64,116 @@ python /workspace/checkpoints/DINO/scripts/load_dino_backbone.py \
   --strict
 ```
 
+
+## Backbone Output Structure
+
+To inspect the forward output structure of the loaded backbone:
+
+```bash
+python /workspace/checkpoints/DINO/scripts/inspect_dino_backbone_output.py --strict
+```
+
+With the default `800x800` dummy input, the backbone returns an `OrderedDict`
+of four feature maps:
+
+```text
+[0] shape=(1, 256, 200, 200)
+[1] shape=(1, 512, 100, 100)
+[2] shape=(1, 1024, 50, 50)
+[3] shape=(1, 2048, 25, 25)
+```
+
+These correspond to the ResNet `layer1` through `layer4` outputs. The loaded
+backbone ends at `layer4`. In DINO's 5-scale setup, the fifth feature level is
+not emitted by this backbone wrapper and is instead created later by the full
+DINO model from the deepest backbone feature.
+
+## Swin Backbone Extraction
+
+To extract the Swin-L backbone from the full Swin checkpoint:
+
+```bash
+python /workspace/checkpoints/DINO/scripts/load_dino_swin_backbone.py \
+  --save-backbone-state /workspace/checkpoints/DINO/swin_backbone_state_checkpoint0027_5scale.pth \
+  --save-full-backbone-module /workspace/checkpoints/DINO/dino_swin_backbone_module_state_checkpoint0027_5scale.pth \
+  --strict
+```
+
+Observed checkpoint metadata from the executed run:
+
+- top-level keys: `model`, `optimizer`, `lr_scheduler`, `epoch`, `args`
+- checkpoint size: `2615534683` bytes (`2.44 GB`)
+- model key count: `722`
+- extracted backbone key count: `357`
+- resolved backbone config: `swin_L_384_22k`, `return_interm_indices=[0,1,2,3]`,
+  `use_checkpoint=True`
+- load result: `missing_keys=[]`, `unexpected_keys=[]`
+
+## Swin Backbone Output Structure
+
+To inspect the forward output structure of the loaded Swin backbone:
+
+```bash
+python /workspace/checkpoints/DINO/scripts/inspect_dino_swin_backbone_output.py \
+  --checkpoint /workspace/checkpoints/DINO/swin_backbone_state_checkpoint0027_5scale.pth \
+  --use-checkpoint \
+  --device cuda \
+  --height 384 \
+  --width 384 \
+  --strict
+```
+
+With the executed `384x384` dummy input on CUDA, the backbone returns an
+`OrderedDict` of four feature maps:
+
+```text
+[0] shape=(1, 192, 96, 96)
+[1] shape=(1, 384, 48, 48)
+[2] shape=(1, 768, 24, 24)
+[3] shape=(1, 1536, 12, 12)
+```
+
+As with the ResNet case, the Swin backbone itself emits four stages. The
+detector's fifth feature level is produced later by the full DINO model through
+`input_proj`.
+
+## Swin Analysis
+
+The investigation artifacts for `checkpoint0027_5scale_swin.pth` are generated
+under:
+
+```text
+/workspace/checkpoints/DINO/analyze/output/checkpoint0027_5scale_swin
+```
+
+Run:
+
+```bash
+python /workspace/checkpoints/DINO/analyze/analyze_checkpoint0027_5scale_swin.py \
+  --device cuda \
+  --strict
+```
+
+Generated artifacts:
+
+- `summary.json`: checkpoint metadata, key-prefix breakdown, resolved backbone
+  config, and dummy forward output structure.
+- `dummy_forward_outputs.pt`: CPU copies of the dummy forward feature tensors.
+
+Key findings recorded in `summary.json`:
+
+- `checkpoint_args_subset.modelname = "catdet5.1_dn_2_st_exc"`
+- `checkpoint_args_subset.backbone = "swin_L_384_22k"`
+- `checkpoint_args_subset.epochs = 36`
+- `model_prefix_counts_depth2` shows `backbone.0` has `357` parameters and
+  `input_proj.0` through `input_proj.4` are present in the full detector,
+  confirming the fifth feature level is downstream of the backbone.
+
 ## Notes
 
 - The download source is the public Google Drive file linked from the
   IDEA-Research DINO release assets.
 - `checkpoint0011_5scale.pth` is the full detector checkpoint, not just the
   backbone.
+- `checkpoint0027_5scale_swin.pth` is also a full detector checkpoint, not just
+  the backbone.

--- a/checkpoints/DINO/README.md
+++ b/checkpoints/DINO/README.md
@@ -139,35 +139,29 @@ detector's fifth feature level is produced later by the full DINO model through
 
 ## Swin Analysis
 
-The investigation artifacts for `checkpoint0027_5scale_swin.pth` are generated
-under:
-
-```text
-/workspace/checkpoints/DINO/analyze/output/checkpoint0027_5scale_swin
-```
-
-Run:
+Ball-point feature consistency for the Swin checkpoint can be generated with the
+shared analyzer:
 
 ```bash
-python /workspace/checkpoints/DINO/analyze/analyze_checkpoint0027_5scale_swin.py \
+python /workspace/checkpoints/DINO/analyze/ball_feature_consistency.py \
+  --backbone swin_L_384_22k \
+  --checkpoint /workspace/checkpoints/DINO/checkpoint0027_5scale_swin.pth \
+  --clip-dir /workspace/data/tennis/game1/Clip1 \
   --device cuda \
   --strict
 ```
 
 Generated artifacts:
 
-- `summary.json`: checkpoint metadata, key-prefix breakdown, resolved backbone
-  config, and dummy forward output structure.
-- `dummy_forward_outputs.pt`: CPU copies of the dummy forward feature tensors.
+- `ball_features.pt`: sampled per-frame features and load metadata.
+- `ball_feature_consistency_per_frame.csv`: per-frame norms and cosine values.
+- `ball_feature_consistency_summary.csv`: aggregated consistency metrics by scale.
 
-Key findings recorded in `summary.json`:
+The default output directory for this run is:
 
-- `checkpoint_args_subset.modelname = "catdet5.1_dn_2_st_exc"`
-- `checkpoint_args_subset.backbone = "swin_L_384_22k"`
-- `checkpoint_args_subset.epochs = 36`
-- `model_prefix_counts_depth2` shows `backbone.0` has `357` parameters and
-  `input_proj.0` through `input_proj.4` are present in the full detector,
-  confirming the fifth feature level is downstream of the backbone.
+```text
+/workspace/checkpoints/DINO/analyze/output/Clip1_swin_L_384_22k
+```
 
 ## Notes
 

--- a/checkpoints/DINO/analyze/ball_feature_consistency.py
+++ b/checkpoints/DINO/analyze/ball_feature_consistency.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Analyze ball-point feature consistency across DINO backbone scales.
+
+This script follows the official DINO evaluation preprocessing path from
+`tmp_DINO/datasets/coco.py`:
+- deterministic resize with short side 800 and max side 1333
+- ImageNet mean/std normalization
+
+For each frame in a clip, the script resizes the image as DINO evaluation does,
+runs a DINO backbone on CUDA by default when available, samples the feature
+vector at the resized ball coordinate for each returned scale, and summarizes
+how consistent those features are over time.
+
+Outputs:
+- `ball_features.pt`: per-frame metadata and sampled feature tensors.
+- `ball_feature_consistency_per_frame.csv`: per-frame norms and cosine values.
+- `ball_feature_consistency_summary.csv`: scale-wise aggregate statistics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pandas as pd
+import torch
+import torch.nn.functional as F
+from PIL import Image
+from torch import nn
+from torchvision.transforms import functional as TVF
+
+from checkpoints.DINO.scripts.load_dino_backbone import load_backbone_body_state
+from checkpoints.DINO.scripts.load_dino_swin_backbone import (
+    BACKBONE_CHOICES as SWIN_BACKBONE_CHOICES,
+    DINOSwinBackbone,
+    extract_backbone_state as extract_swin_backbone_state,
+    get_model_state as get_swin_model_state,
+    load_checkpoint as load_swin_checkpoint,
+    resolve_backbone_config,
+)
+
+DINO_EVAL_SHORT_SIDE = 800
+DINO_EVAL_MAX_SIZE = 1333
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+RESNET_BACKBONE_CHOICES = ["resnet50", "resnet101"]
+BACKBONE_CHOICES = RESNET_BACKBONE_CHOICES + SWIN_BACKBONE_CHOICES
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--clip-dir",
+        type=Path,
+        default=Path("/workspace/data/tennis/game1/Clip1"),
+        help="Directory containing frame images and Label.csv.",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        help=(
+            "Checkpoint path. ResNet backbones expect a trimmed backbone-body "
+            "checkpoint by default, while Swin backbones expect the full DINO "
+            "checkpoint unless you pass a custom path."
+        ),
+    )
+    parser.add_argument(
+        "--backbone",
+        default="resnet50",
+        choices=BACKBONE_CHOICES,
+        help="Backbone architecture to analyze.",
+    )
+    parser.add_argument(
+        "--dilation",
+        action="store_true",
+        help="Enable dilation in the last ResNet or Swin stage when supported.",
+    )
+    parser.add_argument(
+        "--return-interm-indices",
+        type=int,
+        nargs="+",
+        default=[0, 1, 2, 3],
+        help="Intermediate layers returned by the backbone wrapper.",
+    )
+    parser.add_argument(
+        "--pretrain-img-size",
+        type=int,
+        help="Optional Swin pretraining image size override.",
+    )
+    parser.add_argument(
+        "--device",
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Torch device used for inference.",
+    )
+    parser.add_argument(
+        "--visibility-threshold",
+        type=int,
+        default=1,
+        help="Minimum visibility value required to include a frame in consistency stats.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for analysis outputs. Defaults depend on the clip and backbone.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Use strict=True when loading the backbone checkpoint.",
+    )
+    return parser.parse_args()
+
+
+def default_checkpoint_path(backbone: str) -> Path:
+    if backbone in RESNET_BACKBONE_CHOICES:
+        return Path("/workspace/checkpoints/DINO/backbone_body_state.pth")
+    return Path("/workspace/checkpoints/DINO/checkpoint0027_5scale_swin.pth")
+
+
+def default_output_dir(clip_dir: Path, backbone: str) -> Path:
+    return Path("/workspace/checkpoints/DINO/analyze/output") / f"{clip_dir.name}_{backbone}"
+
+
+def load_model_for_consistency(
+    args: argparse.Namespace,
+) -> tuple[nn.Module, nn.modules.module._IncompatibleKeys, dict[str, Any]]:
+    checkpoint_path = args.checkpoint or default_checkpoint_path(args.backbone)
+
+    if args.backbone in RESNET_BACKBONE_CHOICES:
+        model, load_result = load_backbone_body_state(
+            checkpoint_path,
+            backbone=args.backbone,
+            dilation=args.dilation,
+            return_interm_indices=args.return_interm_indices,
+            strict=args.strict,
+        )
+        metadata = {
+            "checkpoint": str(checkpoint_path),
+            "checkpoint_type": "trimmed_resnet_backbone",
+            "resolved_backbone": args.backbone,
+            "resolved_return_interm_indices": list(args.return_interm_indices),
+            "resolved_dilation": bool(args.dilation),
+        }
+        return model, load_result, metadata
+
+    checkpoint = load_swin_checkpoint(checkpoint_path)
+    resolved = resolve_backbone_config(
+        checkpoint,
+        backbone=args.backbone,
+        pretrain_img_size=args.pretrain_img_size,
+        dilation=args.dilation,
+        return_interm_indices=args.return_interm_indices,
+        use_checkpoint=None,
+    )
+    model = DINOSwinBackbone(
+        backbone=resolved.backbone,
+        pretrain_img_size=resolved.pretrain_img_size,
+        dilation=resolved.dilation,
+        return_interm_indices=resolved.return_interm_indices,
+        use_checkpoint=resolved.use_checkpoint,
+    )
+    backbone_state = extract_swin_backbone_state(get_swin_model_state(checkpoint))
+    load_result = model.backbone.load_state_dict(backbone_state, strict=args.strict)
+    metadata = {
+        "checkpoint": str(checkpoint_path),
+        "checkpoint_type": "full_swin_dino_checkpoint",
+        "resolved_backbone": resolved.backbone,
+        "resolved_return_interm_indices": list(resolved.return_interm_indices),
+        "resolved_dilation": bool(resolved.dilation),
+        "resolved_pretrain_img_size": int(resolved.pretrain_img_size),
+        "resolved_use_checkpoint": bool(resolved.use_checkpoint),
+    }
+    return model, load_result, metadata
+
+
+def dino_eval_resized_size(image_width: int, image_height: int) -> tuple[int, int]:
+    """Return the DINO eval resize output size as (width, height)."""
+
+    size = DINO_EVAL_SHORT_SIDE
+    max_size = DINO_EVAL_MAX_SIZE
+    min_original_size = float(min((image_width, image_height)))
+    max_original_size = float(max((image_width, image_height)))
+    if max_original_size / min_original_size * size > max_size:
+        size = int(round(max_size * min_original_size / max_original_size))
+
+    if image_width < image_height:
+        out_width = size
+        out_height = int(size * image_height / image_width)
+    else:
+        out_height = size
+        out_width = int(size * image_width / image_height)
+    return out_width, out_height
+
+
+def preprocess_like_dino_eval(image_path: Path) -> tuple[torch.Tensor, dict[str, int | float]]:
+    """Apply DINO eval preprocessing to one frame."""
+
+    image = Image.open(image_path).convert("RGB")
+    original_width, original_height = image.size
+    resized_width, resized_height = dino_eval_resized_size(original_width, original_height)
+    resized_image = TVF.resize(image, [resized_height, resized_width])
+    tensor = TVF.to_tensor(resized_image)
+    tensor = TVF.normalize(tensor, mean=IMAGENET_MEAN, std=IMAGENET_STD)
+    meta = {
+        "original_width": original_width,
+        "original_height": original_height,
+        "resized_width": resized_width,
+        "resized_height": resized_height,
+        "scale_x": resized_width / original_width,
+        "scale_y": resized_height / original_height,
+    }
+    image.close()
+    resized_image.close()
+    return tensor, meta
+
+
+def sample_feature_at_point(
+    feature_map: torch.Tensor,
+    x: float,
+    y: float,
+    image_width: int,
+    image_height: int,
+) -> torch.Tensor:
+    """Sample a feature vector from a feature map at a resized image coordinate."""
+
+    x_norm = (float(x) / float(image_width - 1)) * 2.0 - 1.0
+    y_norm = (float(y) / float(image_height - 1)) * 2.0 - 1.0
+    grid = torch.tensor([[[[x_norm, y_norm]]]], device=feature_map.device, dtype=feature_map.dtype)
+    sampled = F.grid_sample(
+        feature_map,
+        grid,
+        mode="bilinear",
+        padding_mode="border",
+        align_corners=True,
+    )
+    return sampled[0, :, 0, 0].detach().cpu()
+
+
+def cosine_to_previous(features: torch.Tensor) -> list[float | None]:
+    values: list[float | None] = [None]
+    if features.shape[0] <= 1:
+        return values
+    normalized = F.normalize(features, dim=1)
+    cosines = (normalized[1:] * normalized[:-1]).sum(dim=1)
+    values.extend(float(v) for v in cosines)
+    return values
+
+
+def build_frame_table(df: pd.DataFrame) -> pd.DataFrame:
+    table = df.copy()
+    table["frame_name"] = table["file name"].astype(str)
+    table["frame_index"] = table["frame_name"].str.replace(".jpg", "", regex=False).astype(int)
+    table["x"] = table["x-coordinate"].astype(float)
+    table["y"] = table["y-coordinate"].astype(float)
+    table["has_coordinates"] = table[["x", "y"]].notna().all(axis=1)
+    table["eligible"] = table["has_coordinates"] & (table["visibility"].fillna(-1) >= 0)
+    return table.sort_values("frame_index").reset_index(drop=True)
+
+
+def summarize_scale(
+    frame_df: pd.DataFrame,
+    feature_tensor: torch.Tensor,
+    scale_key: str,
+    visibility_threshold: int,
+) -> dict[str, Any]:
+    valid_mask = frame_df["eligible"] & (
+        frame_df["visibility"].fillna(-1) >= visibility_threshold
+    )
+    valid_rows = frame_df.loc[valid_mask].copy()
+    valid_features = feature_tensor[valid_mask.to_numpy(dtype=bool, copy=True)]
+
+    if len(valid_rows) == 0:
+        return {
+            "scale": scale_key,
+            "num_valid_frames": 0,
+            "num_consecutive_pairs": 0,
+            "mean_feature_norm": None,
+            "std_feature_norm": None,
+            "mean_cosine_prev": None,
+            "std_cosine_prev": None,
+            "mean_cosine_prev_gap1": None,
+            "std_cosine_prev_gap1": None,
+        }
+
+    feature_norms = valid_features.norm(dim=1)
+    cosine_prev = cosine_to_previous(valid_features)
+    valid_rows["feature_norm"] = feature_norms.tolist()
+    valid_rows["cosine_prev"] = cosine_prev
+    valid_rows["frame_gap_prev"] = valid_rows["frame_index"].diff()
+
+    gap1 = valid_rows["frame_gap_prev"] == 1
+    gap1_cosines = valid_rows.loc[gap1, "cosine_prev"].dropna().astype(float)
+    all_cosines = valid_rows["cosine_prev"].dropna().astype(float)
+
+    return {
+        "scale": scale_key,
+        "num_valid_frames": int(len(valid_rows)),
+        "num_consecutive_pairs": int(gap1.sum()),
+        "mean_feature_norm": float(feature_norms.mean()),
+        "std_feature_norm": float(feature_norms.std(unbiased=False)),
+        "mean_cosine_prev": float(all_cosines.mean()) if not all_cosines.empty else None,
+        "std_cosine_prev": float(all_cosines.std(ddof=0)) if not all_cosines.empty else None,
+        "mean_cosine_prev_gap1": float(gap1_cosines.mean()) if not gap1_cosines.empty else None,
+        "std_cosine_prev_gap1": float(gap1_cosines.std(ddof=0)) if not gap1_cosines.empty else None,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    clip_dir = args.clip_dir
+    label_path = clip_dir / "Label.csv"
+    if not label_path.exists():
+        raise FileNotFoundError(f"Missing label file: {label_path}")
+
+    checkpoint_path = args.checkpoint or default_checkpoint_path(args.backbone)
+    output_dir = args.output_dir or default_output_dir(clip_dir, args.backbone)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    args.checkpoint = checkpoint_path
+    args.output_dir = output_dir
+
+    model, load_result, load_metadata = load_model_for_consistency(args)
+    device = torch.device(args.device)
+    model = model.to(device)
+    model.eval()
+
+    labels = build_frame_table(pd.read_csv(label_path))
+    scale_keys: list[str] | None = None
+    per_scale_features: dict[str, list[torch.Tensor]] = {}
+    frame_records: list[dict[str, Any]] = []
+
+    with torch.no_grad():
+        for row in labels.itertuples(index=False):
+            image_path = clip_dir / row.frame_name
+            if not image_path.exists():
+                raise FileNotFoundError(f"Missing frame image: {image_path}")
+
+            image_tensor, preprocess_meta = preprocess_like_dino_eval(image_path)
+            image_tensor = image_tensor.unsqueeze(0).to(device, non_blocking=True)
+            outputs = model(image_tensor)
+            if scale_keys is None:
+                scale_keys = list(outputs.keys())
+                per_scale_features = {str(key): [] for key in scale_keys}
+
+            resized_x = None
+            resized_y = None
+            if row.eligible:
+                resized_x = float(row.x) * float(preprocess_meta["scale_x"])
+                resized_y = float(row.y) * float(preprocess_meta["scale_y"])
+
+            record = {
+                "frame_name": row.frame_name,
+                "frame_index": int(row.frame_index),
+                "visibility": None if pd.isna(row.visibility) else int(row.visibility),
+                "status": None if pd.isna(row.status) else float(row.status),
+                "x": None if pd.isna(row.x) else float(row.x),
+                "y": None if pd.isna(row.y) else float(row.y),
+                "resized_x": resized_x,
+                "resized_y": resized_y,
+                "original_width": int(preprocess_meta["original_width"]),
+                "original_height": int(preprocess_meta["original_height"]),
+                "resized_width": int(preprocess_meta["resized_width"]),
+                "resized_height": int(preprocess_meta["resized_height"]),
+                "scale_x": float(preprocess_meta["scale_x"]),
+                "scale_y": float(preprocess_meta["scale_y"]),
+                "has_coordinates": bool(row.has_coordinates),
+                "eligible": bool(row.eligible),
+            }
+
+            for key in scale_keys:
+                feature_map = outputs[key]
+                key_str = str(key)
+                record[f"scale_{key_str}_shape"] = tuple(feature_map.shape)
+                if row.eligible and resized_x is not None and resized_y is not None:
+                    feature = sample_feature_at_point(
+                        feature_map=feature_map,
+                        x=resized_x,
+                        y=resized_y,
+                        image_width=int(preprocess_meta["resized_width"]),
+                        image_height=int(preprocess_meta["resized_height"]),
+                    )
+                else:
+                    feature = torch.full((feature_map.shape[1],), float("nan"))
+                per_scale_features[key_str].append(feature)
+                record[f"scale_{key_str}_norm"] = None if torch.isnan(feature).any() else float(feature.norm())
+
+            frame_records.append(record)
+
+    assert scale_keys is not None
+    frame_df = pd.DataFrame(frame_records).sort_values("frame_index").reset_index(drop=True)
+    stacked_features = {
+        key: torch.stack(feature_list, dim=0) for key, feature_list in per_scale_features.items()
+    }
+
+    per_frame_rows: list[dict[str, Any]] = []
+    summary_rows: list[dict[str, Any]] = []
+    eligibility_mask = frame_df["eligible"] & (
+        frame_df["visibility"].fillna(-1) >= args.visibility_threshold
+    )
+
+    for key in scale_keys:
+        key_str = str(key)
+        features = stacked_features[key_str]
+        valid_features = features[eligibility_mask.to_numpy(dtype=bool, copy=True)]
+        valid_frame_df = frame_df.loc[eligibility_mask].copy()
+        valid_frame_df["feature_norm"] = valid_features.norm(dim=1).tolist()
+        valid_frame_df["cosine_prev"] = cosine_to_previous(valid_features)
+        valid_frame_df["frame_gap_prev"] = valid_frame_df["frame_index"].diff()
+        valid_frame_df["scale"] = key_str
+        per_frame_rows.extend(
+            valid_frame_df[
+                [
+                    "scale",
+                    "frame_name",
+                    "frame_index",
+                    "visibility",
+                    "status",
+                    "x",
+                    "y",
+                    "resized_x",
+                    "resized_y",
+                    "feature_norm",
+                    "cosine_prev",
+                    "frame_gap_prev",
+                ]
+            ].to_dict(orient="records")
+        )
+        summary_rows.append(
+            summarize_scale(
+                frame_df=frame_df,
+                feature_tensor=features,
+                scale_key=key_str,
+                visibility_threshold=args.visibility_threshold,
+            )
+        )
+
+    feature_payload = {
+        "clip_dir": str(clip_dir),
+        "checkpoint": str(checkpoint_path),
+        "backbone": args.backbone,
+        "preprocess": {
+            "short_side": DINO_EVAL_SHORT_SIDE,
+            "max_size": DINO_EVAL_MAX_SIZE,
+            "mean": IMAGENET_MEAN,
+            "std": IMAGENET_STD,
+        },
+        "load_metadata": load_metadata,
+        "load_result": {
+            "missing_keys": list(load_result.missing_keys),
+            "unexpected_keys": list(load_result.unexpected_keys),
+        },
+        "frame_table": frame_df,
+        "scale_keys": [str(k) for k in scale_keys],
+        "sampled_features": stacked_features,
+    }
+    torch.save(feature_payload, output_dir / "ball_features.pt")
+    pd.DataFrame(per_frame_rows).to_csv(
+        output_dir / "ball_feature_consistency_per_frame.csv",
+        index=False,
+    )
+    summary_df = pd.DataFrame(summary_rows)
+    summary_df.to_csv(output_dir / "ball_feature_consistency_summary.csv", index=False)
+
+    print("Analysis complete")
+    print(f"  clip_dir: {clip_dir}")
+    print(f"  checkpoint: {checkpoint_path}")
+    print(f"  backbone: {load_metadata['resolved_backbone']}")
+    print(f"  device: {device}")
+    print(f"  output_dir: {output_dir}")
+    print(f"  missing_keys: {list(load_result.missing_keys)}")
+    print(f"  unexpected_keys: {list(load_result.unexpected_keys)}")
+    print("Scale summary")
+    for row in summary_rows:
+        print(
+            "  scale={scale} valid={num_valid_frames} gap1_pairs={num_consecutive_pairs} "
+            "mean_cos_prev_gap1={mean_cosine_prev_gap1}".format(**row)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/checkpoints/DINO/scripts/download_checkpoint0027_5scale_swin.py
+++ b/checkpoints/DINO/scripts/download_checkpoint0027_5scale_swin.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Download the official DINO 5-scale Swin-L checkpoint from Google Drive."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+import gdown
+
+
+FILE_ID = "14h4UCi-HsDL01ZQRbpV47dzMST_py_vM"
+DEFAULT_OUTPUT = Path("/workspace/checkpoints/DINO/checkpoint0027_5scale_swin.pth")
+EXPECTED_SHA256: str | None = "17ddce1592816a0c63a2edc94d4a0877ffeb086f397a6657e151c703a4c850b5"
+
+
+def compute_sha256(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    """Compute the SHA256 checksum of a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Output path for the downloaded checkpoint.",
+    )
+    parser.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Do not re-download if the output file already exists.",
+    )
+    parser.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="Skip SHA256 verification after download.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.skip_existing and args.output.exists():
+        print(f"Skipping download because file already exists: {args.output}")
+    else:
+        url = f"https://drive.google.com/uc?id={FILE_ID}"
+        result = gdown.download(url=url, output=str(args.output), quiet=False, fuzzy=True)
+        if result is None:
+            raise RuntimeError("gdown failed to download the checkpoint")
+
+    sha256 = compute_sha256(args.output)
+    print(f"sha256: {sha256}")
+
+    if args.no_verify or EXPECTED_SHA256 is None:
+        if EXPECTED_SHA256 is None:
+            print("Skipped fixed SHA256 verification because EXPECTED_SHA256 is unset")
+        else:
+            print("Skipped SHA256 verification")
+        return
+
+    if sha256 != EXPECTED_SHA256:
+        raise ValueError(
+            "Downloaded file checksum does not match the expected checkpoint: "
+            f"{sha256} != {EXPECTED_SHA256}"
+        )
+    print("SHA256 verification passed")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise

--- a/checkpoints/DINO/scripts/inspect_dino_backbone_output.py
+++ b/checkpoints/DINO/scripts/inspect_dino_backbone_output.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Inspect the forward output structure of a loaded DINO backbone.
+
+This script loads a trimmed DINO backbone-body checkpoint via
+`load_backbone_body_state`, runs a dummy tensor through the returned model, and
+prints the output container type plus each feature map's key and shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+
+from load_dino_backbone import load_backbone_body_state
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=Path("/workspace/checkpoints/DINO/backbone_body_state.pth"),
+        help="Path to a trimmed backbone-body checkpoint.",
+    )
+    parser.add_argument(
+        "--backbone",
+        default="resnet50",
+        choices=["resnet50", "resnet101"],
+        help="Backbone architecture defined in DINO backbone.py.",
+    )
+    parser.add_argument(
+        "--dilation",
+        action="store_true",
+        help="Enable dilation in the last ResNet stage.",
+    )
+    parser.add_argument(
+        "--return-interm-indices",
+        type=int,
+        nargs="+",
+        default=[0, 1, 2, 3],
+        help="Intermediate layers returned by DINO Backbone.",
+    )
+    parser.add_argument(
+        "--height",
+        type=int,
+        default=800,
+        help="Dummy input height.",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=800,
+        help="Dummy input width.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=1,
+        help="Dummy input batch size.",
+    )
+    parser.add_argument(
+        "--device",
+        default="cpu",
+        help="Torch device for the dummy forward pass.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Use strict=True when loading the backbone-body checkpoint.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    model, load_result = load_backbone_body_state(
+        args.checkpoint,
+        backbone=args.backbone,
+        dilation=args.dilation,
+        return_interm_indices=args.return_interm_indices,
+        strict=args.strict,
+    )
+    device = torch.device(args.device)
+    model = model.to(device)
+    model.eval()
+
+    dummy = torch.randn(args.batch_size, 3, args.height, args.width, device=device)
+
+    with torch.no_grad():
+        outputs = model(dummy)
+
+    print("Load result")
+    print(f"  checkpoint: {args.checkpoint}")
+    print(f"  missing_keys: {list(load_result.missing_keys)}")
+    print(f"  unexpected_keys: {list(load_result.unexpected_keys)}")
+    print("Dummy input")
+    print(f"  shape: {tuple(dummy.shape)}")
+    print(f"  dtype: {dummy.dtype}")
+    print(f"  device: {dummy.device}")
+    print("Forward output")
+    print(f"  type: {type(outputs).__name__}")
+
+    for key, value in outputs.items():
+        print(
+            f"  [{key}] shape={tuple(value.shape)} dtype={value.dtype} device={value.device}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/checkpoints/DINO/scripts/inspect_dino_swin_backbone_output.py
+++ b/checkpoints/DINO/scripts/inspect_dino_swin_backbone_output.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Inspect the forward output structure of a loaded DINO Swin backbone."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import torch
+
+from checkpoints.DINO.scripts.load_dino_swin_backbone import (
+    BACKBONE_CHOICES,
+    load_swin_backbone_state,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=Path("/workspace/checkpoints/DINO/swin_backbone_state_checkpoint0027_5scale.pth"),
+        help="Path to a trimmed Swin backbone checkpoint.",
+    )
+    parser.add_argument(
+        "--backbone",
+        default="swin_L_384_22k",
+        choices=BACKBONE_CHOICES,
+        help="Backbone architecture defined in tmp_DINO Swin wrapper.",
+    )
+    parser.add_argument(
+        "--pretrain-img-size",
+        type=int,
+        default=384,
+        help="Pretraining image size for the Swin backbone.",
+    )
+    parser.add_argument(
+        "--dilation",
+        action="store_true",
+        help="Enable dilation in the last Swin stage.",
+    )
+    parser.add_argument(
+        "--return-interm-indices",
+        type=int,
+        nargs="+",
+        default=[0, 1, 2, 3],
+        help="Intermediate Swin stages returned by the wrapper.",
+    )
+    parser.add_argument(
+        "--use-checkpoint",
+        action="store_true",
+        help="Enable Swin activation checkpointing during model construction.",
+    )
+    parser.add_argument(
+        "--height",
+        type=int,
+        default=384,
+        help="Dummy input height.",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=384,
+        help="Dummy input width.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=1,
+        help="Dummy input batch size.",
+    )
+    parser.add_argument(
+        "--device",
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Torch device for the dummy forward pass.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Use strict=True when loading the trimmed backbone checkpoint.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    model, load_result = load_swin_backbone_state(
+        args.checkpoint,
+        backbone=args.backbone,
+        pretrain_img_size=args.pretrain_img_size,
+        dilation=args.dilation,
+        return_interm_indices=args.return_interm_indices,
+        use_checkpoint=args.use_checkpoint,
+        strict=args.strict,
+    )
+    device = torch.device(args.device)
+    model = model.to(device)
+    model.eval()
+
+    dummy = torch.randn(args.batch_size, 3, args.height, args.width, device=device)
+
+    with torch.no_grad():
+        outputs = model(dummy)
+
+    print("Load result")
+    print(f"  checkpoint: {args.checkpoint}")
+    print(f"  missing_keys: {list(load_result.missing_keys)}")
+    print(f"  unexpected_keys: {list(load_result.unexpected_keys)}")
+    print("Dummy input")
+    print(f"  shape: {tuple(dummy.shape)}")
+    print(f"  dtype: {dummy.dtype}")
+    print(f"  device: {dummy.device}")
+    print("Forward output")
+    print(f"  type: {type(outputs).__name__}")
+
+    for key, value in outputs.items():
+        print(
+            f"  [{key}] shape={tuple(value.shape)} dtype={value.dtype} device={value.device}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/checkpoints/DINO/scripts/load_dino_swin_backbone.py
+++ b/checkpoints/DINO/scripts/load_dino_swin_backbone.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Load the Swin backbone from a full DINO checkpoint.
+
+This script mirrors the Swin backbone path defined in `tmp_DINO` and targets
+full DINO checkpoints whose model weights contain keys like
+`backbone.0.patch_embed.proj.weight`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from collections import Counter, OrderedDict
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+TMP_DINO_ROOT = ROOT / "tmp_DINO"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(TMP_DINO_ROOT) not in sys.path:
+    sys.path.insert(0, str(TMP_DINO_ROOT))
+
+import torch
+from torch import nn
+
+
+def load_swin_builder():
+    """Load tmp_DINO's Swin builder without importing the full DINO package."""
+
+    module_path = TMP_DINO_ROOT / "models" / "dino" / "swin_transformer.py"
+    spec = importlib.util.spec_from_file_location("tmp_dino_swin_transformer", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load module spec from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.build_swin_transformer
+
+
+build_swin_transformer = load_swin_builder()
+
+
+BACKBONE_CHOICES = [
+    "swin_T_224_1k",
+    "swin_B_224_22k",
+    "swin_B_384_22k",
+    "swin_L_224_22k",
+    "swin_L_384_22k",
+]
+
+
+class DINOSwinBackbone(nn.Module):
+    """Thin wrapper that exposes Swin raw features as an OrderedDict."""
+
+    def __init__(
+        self,
+        *,
+        backbone: str = "swin_L_384_22k",
+        pretrain_img_size: int = 384,
+        dilation: bool = False,
+        return_interm_indices: list[int] | None = None,
+        use_checkpoint: bool = False,
+    ) -> None:
+        super().__init__()
+        if return_interm_indices is None:
+            return_interm_indices = [0, 1, 2, 3]
+        self.backbone = build_swin_transformer(
+            backbone,
+            pretrain_img_size=pretrain_img_size,
+            out_indices=tuple(return_interm_indices),
+            dilation=dilation,
+            use_checkpoint=use_checkpoint,
+        )
+        self.backbone_name = backbone
+        self.pretrain_img_size = pretrain_img_size
+        self.return_interm_indices = return_interm_indices
+        self.dilation = dilation
+        self.use_checkpoint = use_checkpoint
+
+    def forward_raw(self, x: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        return self.backbone.forward_raw(x)
+
+    def forward(self, x: torch.Tensor) -> OrderedDict[str, torch.Tensor]:
+        outputs = self.forward_raw(x)
+        keys = [str(index) for index in self.return_interm_indices]
+        return OrderedDict(zip(keys, outputs, strict=True))
+
+
+def checkpoint_args_to_dict(args: Any) -> dict[str, Any]:
+    """Convert checkpoint args object into a JSON-serializable dict."""
+    if args is None:
+        return {}
+    if isinstance(args, dict):
+        raw = args
+    elif hasattr(args, "__dict__"):
+        raw = vars(args)
+    else:
+        raise TypeError(f"Unsupported args type: {type(args)!r}")
+    result: dict[str, Any] = {}
+    for key, value in raw.items():
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            result[key] = value
+        elif isinstance(value, (list, tuple)):
+            result[key] = list(value)
+        else:
+            result[key] = str(value)
+    return result
+
+
+def infer_pretrain_img_size(backbone: str) -> int:
+    return int(backbone.split("_")[-2])
+
+
+def load_checkpoint(checkpoint_path: Path) -> dict[str, Any]:
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    if not isinstance(checkpoint, dict):
+        raise TypeError(f"Expected dict checkpoint, got {type(checkpoint)!r}")
+    return checkpoint
+
+
+def get_model_state(checkpoint: dict[str, Any]) -> dict[str, torch.Tensor]:
+    state = checkpoint["model"] if "model" in checkpoint else checkpoint
+    if not isinstance(state, dict):
+        raise TypeError(f"Expected state dict, got {type(state)!r}")
+    return state
+
+
+def extract_backbone_state(
+    state_dict: dict[str, torch.Tensor],
+    prefix: str = "backbone.0.",
+) -> OrderedDict[str, torch.Tensor]:
+    extracted = OrderedDict(
+        (key[len(prefix) :], value)
+        for key, value in state_dict.items()
+        if key.startswith(prefix)
+    )
+    if not extracted:
+        raise KeyError(f"No keys found with prefix {prefix!r}")
+    return extracted
+
+
+def summarize_key_prefixes(state_dict: dict[str, torch.Tensor], depth: int = 3) -> dict[str, int]:
+    counter = Counter()
+    for key in state_dict:
+        prefix = ".".join(key.split(".")[:depth])
+        counter[prefix] += 1
+    return dict(counter.most_common())
+
+
+def build_metadata_namespace(
+    *,
+    backbone: str,
+    pretrain_img_size: int,
+    dilation: bool,
+    return_interm_indices: list[int],
+    use_checkpoint: bool,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        backbone=backbone,
+        pretrain_img_size=pretrain_img_size,
+        dilation=dilation,
+        return_interm_indices=return_interm_indices,
+        use_checkpoint=use_checkpoint,
+    )
+
+
+def resolve_backbone_config(
+    checkpoint: dict[str, Any],
+    *,
+    backbone: str | None,
+    pretrain_img_size: int | None,
+    dilation: bool | None,
+    return_interm_indices: list[int] | None,
+    use_checkpoint: bool | None,
+) -> SimpleNamespace:
+    args_dict = checkpoint_args_to_dict(checkpoint.get("args"))
+    resolved_backbone = backbone or args_dict.get("backbone") or "swin_L_384_22k"
+    if resolved_backbone not in BACKBONE_CHOICES:
+        raise ValueError(f"Unsupported backbone: {resolved_backbone}")
+    resolved_pretrain_img_size = (
+        pretrain_img_size
+        if pretrain_img_size is not None
+        else infer_pretrain_img_size(resolved_backbone)
+    )
+    resolved_dilation = dilation if dilation is not None else bool(args_dict.get("dilation", False))
+    resolved_return_interm = (
+        return_interm_indices
+        if return_interm_indices is not None
+        else list(args_dict.get("return_interm_indices", [0, 1, 2, 3]))
+    )
+    resolved_use_checkpoint = (
+        use_checkpoint if use_checkpoint is not None else bool(args_dict.get("use_checkpoint", False))
+    )
+    return build_metadata_namespace(
+        backbone=resolved_backbone,
+        pretrain_img_size=resolved_pretrain_img_size,
+        dilation=resolved_dilation,
+        return_interm_indices=resolved_return_interm,
+        use_checkpoint=resolved_use_checkpoint,
+    )
+
+
+def load_swin_backbone_state(
+    checkpoint_path: str | Path,
+    *,
+    backbone: str = "swin_L_384_22k",
+    pretrain_img_size: int = 384,
+    dilation: bool = False,
+    return_interm_indices: list[int] | None = None,
+    use_checkpoint: bool = False,
+    strict: bool = True,
+) -> tuple[DINOSwinBackbone, nn.modules.module._IncompatibleKeys]:
+    """Load a trimmed Swin backbone checkpoint into ``DINOSwinBackbone``."""
+
+    model = DINOSwinBackbone(
+        backbone=backbone,
+        pretrain_img_size=pretrain_img_size,
+        dilation=dilation,
+        return_interm_indices=return_interm_indices,
+        use_checkpoint=use_checkpoint,
+    )
+    state_dict = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    load_result = model.backbone.load_state_dict(state_dict, strict=strict)
+    return model, load_result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=Path("/workspace/checkpoints/DINO/checkpoint0027_5scale_swin.pth"),
+        help="Path to the full DINO checkpoint.",
+    )
+    parser.add_argument(
+        "--backbone",
+        choices=BACKBONE_CHOICES,
+        help="Backbone architecture. Defaults to checkpoint metadata when available.",
+    )
+    parser.add_argument(
+        "--pretrain-img-size",
+        type=int,
+        help="Pretraining image size. Defaults to the backbone name suffix.",
+    )
+    parser.add_argument(
+        "--dilation",
+        action="store_true",
+        default=None,
+        help="Enable dilation in the last Swin stage.",
+    )
+    parser.add_argument(
+        "--no-dilation",
+        action="store_false",
+        dest="dilation",
+        help="Disable dilation in the last Swin stage.",
+    )
+    parser.add_argument(
+        "--return-interm-indices",
+        type=int,
+        nargs="+",
+        help="Intermediate Swin stages returned by the backbone wrapper.",
+    )
+    parser.add_argument(
+        "--use-checkpoint",
+        action="store_true",
+        default=None,
+        help="Enable Swin activation checkpointing.",
+    )
+    parser.add_argument(
+        "--no-use-checkpoint",
+        action="store_false",
+        dest="use_checkpoint",
+        help="Disable Swin activation checkpointing.",
+    )
+    parser.add_argument(
+        "--save-backbone-state",
+        type=Path,
+        help="Optional output path for the trimmed Swin backbone state dict.",
+    )
+    parser.add_argument(
+        "--save-full-backbone-module",
+        type=Path,
+        help="Optional output path for the loaded DINOSwinBackbone state dict.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Use strict=True when loading the extracted backbone weights.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    checkpoint = load_checkpoint(args.checkpoint)
+    state_dict = get_model_state(checkpoint)
+    backbone_state = extract_backbone_state(state_dict)
+    resolved = resolve_backbone_config(
+        checkpoint,
+        backbone=args.backbone,
+        pretrain_img_size=args.pretrain_img_size,
+        dilation=args.dilation,
+        return_interm_indices=args.return_interm_indices,
+        use_checkpoint=args.use_checkpoint,
+    )
+
+    print("Checkpoint analysis")
+    print(f"  checkpoint: {args.checkpoint}")
+    print(f"  top_level_keys: {list(checkpoint.keys())}")
+    print(f"  total model keys: {len(state_dict)}")
+    print(f"  extracted backbone keys: {len(backbone_state)}")
+    print(f"  backbone: {resolved.backbone}")
+    print(f"  pretrain_img_size: {resolved.pretrain_img_size}")
+    print(f"  dilation: {resolved.dilation}")
+    print(f"  return_interm_indices: {resolved.return_interm_indices}")
+    print(f"  use_checkpoint: {resolved.use_checkpoint}")
+    print("  model prefix counts:")
+    for prefix, count in summarize_key_prefixes(state_dict).items():
+        print(f"    {prefix}: {count}")
+    print("  sample extracted keys:")
+    for key in list(backbone_state.keys())[:10]:
+        print(f"    {key}")
+
+    if args.save_backbone_state is not None:
+        args.save_backbone_state.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(backbone_state, args.save_backbone_state)
+        print(f"Saved trimmed backbone state to: {args.save_backbone_state}")
+        load_path = args.save_backbone_state
+    else:
+        load_path = args.checkpoint.with_suffix(".swin_backbone.tmp.pth")
+        torch.save(backbone_state, load_path)
+
+    model, load_result = load_swin_backbone_state(
+        load_path,
+        backbone=resolved.backbone,
+        pretrain_img_size=resolved.pretrain_img_size,
+        dilation=resolved.dilation,
+        return_interm_indices=resolved.return_interm_indices,
+        use_checkpoint=resolved.use_checkpoint,
+        strict=args.strict,
+    )
+
+    print("Load result")
+    print(f"  load_source: {load_path}")
+    print(f"  missing_keys: {list(load_result.missing_keys)}")
+    print(f"  unexpected_keys: {list(load_result.unexpected_keys)}")
+
+    if args.save_full_backbone_module is not None:
+        args.save_full_backbone_module.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(model.state_dict(), args.save_full_backbone_module)
+        print(f"Saved loaded DINOSwinBackbone state to: {args.save_full_backbone_module}")
+
+    if args.save_backbone_state is None and load_path.exists():
+        load_path.unlink()
+
+    summary = {
+        "checkpoint": str(args.checkpoint),
+        "top_level_keys": list(checkpoint.keys()),
+        "resolved_config": {
+            "backbone": resolved.backbone,
+            "pretrain_img_size": resolved.pretrain_img_size,
+            "dilation": resolved.dilation,
+            "return_interm_indices": resolved.return_interm_indices,
+            "use_checkpoint": resolved.use_checkpoint,
+        },
+        "load_result": {
+            "missing_keys": list(load_result.missing_keys),
+            "unexpected_keys": list(load_result.unexpected_keys),
+        },
+    }
+    print("Resolved summary json")
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add helper scripts and README guidance for downloading, extracting, and inspecting the DINO 5-scale Swin-L checkpoint under `checkpoints/DINO`.
- Keep this as a stacked PR on top of `feat/ball-detection-dino-pseudo3d` so the review scope stays limited to the checkpoint tooling changes.

## Changes

- Add a download helper for `checkpoint0027_5scale_swin.pth` with SHA256 verification.
- Add scripts to extract and inspect DINO Swin backbone outputs, plus a ResNet backbone inspection helper for comparison.
- Update `checkpoints/DINO/README.md` with the Swin-L checkpoint workflow and output-shape notes.

## Validation

- Reviewed the staged file set and diff stat via the repository preflight scripts.
- Did not run the helper scripts end-to-end in this pass.

## Related Issues

- References #

## Notes

- `tmp_DINO/` is intentionally excluded from this PR.
- `load_dino_swin_backbone.py` currently depends on `tmp_DINO` content, and the README also references an ignored `checkpoints/DINO/analyze/*` path. Those reproducibility constraints should be reviewed during merge.
