### PR TITLE
[codex] Add Swin DINO pseudo-3D training support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "third_party/TrackNet"]
 	path = third_party/TrackNet
 	url = https://github.com/yastrebksv/TrackNet.git
+[submodule "third_party/DINO"]
+	path = third_party/DINO
+	url = https://github.com/IDEA-Research/DINO.git

--- a/checkpoints/DINO/scripts/load_dino_swin_backbone.py
+++ b/checkpoints/DINO/scripts/load_dino_swin_backbone.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Load the Swin backbone from a full DINO checkpoint.
 
-This script mirrors the Swin backbone path defined in `tmp_DINO` and targets
+This script mirrors the Swin backbone path defined in `third_party/DINO` and targets
 full DINO checkpoints whose model weights contain keys like
 `backbone.0.patch_embed.proj.weight`.
 """
@@ -18,24 +18,33 @@ from types import SimpleNamespace
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[3]
-TMP_DINO_ROOT = ROOT / "tmp_DINO"
+THIRD_PARTY_DINO_ROOT = ROOT / "third_party" / "DINO"
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
-if str(TMP_DINO_ROOT) not in sys.path:
-    sys.path.insert(0, str(TMP_DINO_ROOT))
+if str(THIRD_PARTY_DINO_ROOT) not in sys.path:
+    sys.path.insert(0, str(THIRD_PARTY_DINO_ROOT))
 
 import torch
 from torch import nn
 
 
 def load_swin_builder():
-    """Load tmp_DINO's Swin builder without importing the full DINO package."""
+    """Load third_party/DINO's Swin builder without importing the full DINO package."""
 
-    module_path = TMP_DINO_ROOT / "models" / "dino" / "swin_transformer.py"
-    spec = importlib.util.spec_from_file_location("tmp_dino_swin_transformer", module_path)
+    module_path = THIRD_PARTY_DINO_ROOT / "models" / "dino" / "swin_transformer.py"
+    if not module_path.exists():
+        raise FileNotFoundError(
+            f"Swin transformer builder not found at {module_path}. "
+            "Initialize third_party/DINO before using Swin backbones."
+        )
+    module_name = "third_party_dino_swin_transformer"
+    if module_name in sys.modules:
+        return sys.modules[module_name].build_swin_transformer
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
     if spec is None or spec.loader is None:
         raise ImportError(f"Unable to load module spec from {module_path}")
     module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module.build_swin_transformer
 

--- a/src/tasks/ball_detection/configs/data/rgb_sequence.yaml
+++ b/src/tasks/ball_detection/configs/data/rgb_sequence.yaml
@@ -11,13 +11,12 @@ pin_memory: true
 sample_stride: 4
 
 image_size: [288, 512]
-heatmap_size: [144, 256]
-gaussian_size: 3
-gaussian_variance: 1.0
+heatmap_size: [288, 512]
+gaussian_variance: 15.0
 
 augmentation:
   camera_rotation:
-    enabled: false
+    enabled: true
     prob: 0.35
     max_center_angle_deg: 1.2
     max_angular_velocity_deg_per_frame: 0.2
@@ -25,6 +24,27 @@ augmentation:
   horizontal_flip:
     enabled: true
     prob: 0.5
+  affine:
+    enabled: true
+    prob: 0.35
+    rotation_deg_range: [-10.0, 10.0]
+    scale_range: [1.0, 1.0]
+    translate_x_ratio_range: [-0.1, 0.1]
+    translate_y_ratio_range: [-0.1, 0.1]
+    shear_x_deg_range: [-2.0, 2.0]
+    shear_y_deg_range: [-1.0, 1.0]
+    border_mode: reflect101
+  scale_and_crop:
+    enabled: true
+    prob: 0.35
+    scale_range: [1.0, 3.0]
+    border_mode: reflect101
+  ball_area_zero_mask:
+    enabled: true
+    prob: 0.35
+    mask_width_ratio_range: [0.04, 0.12]
+    mask_height_ratio_range: [0.04, 0.12]
+    num_frames_range: [1, 3]
   brightness_gain:
     enabled: true
     jitter: 0.1
@@ -38,6 +58,10 @@ augmentation:
     enabled: true
     std: 0.012
   gaussian_blur:
-    enabled: false
-    prob: 0.12
+    enabled: true
+    prob: 0.35
     kernel_size: 3
+  normalize_imagenet:
+    enabled: true
+    mean: [0.485, 0.456, 0.406]
+    std: [0.229, 0.224, 0.225]

--- a/src/tasks/ball_detection/configs/model/dino_pseudo3d.yaml
+++ b/src/tasks/ball_detection/configs/model/dino_pseudo3d.yaml
@@ -4,10 +4,24 @@ in_channels: 3
 num_classes: 1
 num_frames: 8
 input_layout: bcthw
+# ResNet example:
+# backbone_name: resnet50
+# backbone_checkpoint_path: /workspace/checkpoints/DINO/backbone_body_state.pth
+#
+# Swin example:
+# backbone_name: swin_L_384_22k
+# backbone_checkpoint_path: /workspace/checkpoints/DINO/swin_backbone_state_checkpoint0027_5scale.pth
+# Swin-only options:
+# backbone_pretrain_img_size: null  # auto-resolve from backbone_name, e.g. 384
+# backbone_use_checkpoint: false    # enable only when you need lower GPU memory
 backbone_checkpoint_path: /workspace/checkpoints/DINO/backbone_body_state.pth
 backbone_name: resnet50
 backbone_dilation: false
 return_interm_indices: [0, 1, 2, 3]
+# Swin only. Ignored for ResNet backbones.
+backbone_pretrain_img_size: null
+# Swin only. Trades speed for lower activation memory during training.
+backbone_use_checkpoint: false
 backbone_strict: true
 freeze_backbone: true
 decoder_expand_ratio: 4.0

--- a/src/tasks/ball_detection/data/argumentation.py
+++ b/src/tasks/ball_detection/data/argumentation.py
@@ -15,6 +15,106 @@ from torch.utils.data import get_worker_info
 Frames = list[np.ndarray]
 Coords = list[tuple[float, float]]
 Visibility = list[float]
+IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+
+
+def normalize_frames_imagenet(
+    frames: Frames,
+    *,
+    mean: np.ndarray = IMAGENET_MEAN,
+    std: np.ndarray = IMAGENET_STD,
+) -> Frames:
+    """Apply ImageNet normalization to HWC float frames."""
+    mean_arr = np.asarray(mean, dtype=np.float32).reshape(1, 1, 3)
+    std_arr = np.asarray(std, dtype=np.float32).reshape(1, 1, 3)
+    return [((frame - mean_arr) / std_arr).astype(np.float32) for frame in frames]
+
+
+def normalize_tensor_images_imagenet(
+    images: torch.Tensor,
+    *,
+    mean: Sequence[float] = (0.485, 0.456, 0.406),
+    std: Sequence[float] = (0.229, 0.224, 0.225),
+) -> torch.Tensor:
+    """Apply ImageNet normalization to ``(..., 3, H, W)`` image tensors."""
+    if images.ndim < 3 or images.shape[-3] != 3:
+        raise ValueError(
+            "Expected images with shape (..., 3, H, W) for ImageNet normalization, "
+            f"got {tuple(images.shape)}."
+        )
+    view_shape = [1] * images.ndim
+    view_shape[-3] = 3
+    mean_tensor = images.new_tensor(mean).view(*view_shape)
+    std_tensor = images.new_tensor(std).view(*view_shape)
+    return (images - mean_tensor) / std_tensor
+
+
+def denormalize_tensor_images_imagenet(
+    images: torch.Tensor,
+    *,
+    mean: Sequence[float] = (0.485, 0.456, 0.406),
+    std: Sequence[float] = (0.229, 0.224, 0.225),
+) -> torch.Tensor:
+    """Undo ImageNet normalization for ``(..., 3, H, W)`` image tensors."""
+    if images.ndim < 3 or images.shape[-3] != 3:
+        raise ValueError(
+            "Expected images with shape (..., 3, H, W) for ImageNet denormalization, "
+            f"got {tuple(images.shape)}."
+        )
+    view_shape = [1] * images.ndim
+    view_shape[-3] = 3
+    mean_tensor = images.new_tensor(mean).view(*view_shape)
+    std_tensor = images.new_tensor(std).view(*view_shape)
+    return images * std_tensor + mean_tensor
+
+
+def _resolve_border_mode(name: str) -> int:
+    """Map config border mode names to OpenCV constants."""
+    return {
+        "constant": cv2.BORDER_CONSTANT,
+        "reflect": cv2.BORDER_REFLECT,
+        "reflect101": cv2.BORDER_REFLECT_101,
+        "replicate": cv2.BORDER_REPLICATE,
+    }.get(name, cv2.BORDER_REFLECT_101)
+
+
+def _apply_affine_to_sequence(
+    frames: Frames,
+    coords: Coords,
+    visibility: Visibility,
+    *,
+    matrix: np.ndarray,
+    border_mode: int,
+) -> tuple[Frames, Coords, Visibility]:
+    """Warp frames and transform visible coordinates with one affine matrix."""
+    height, width = frames[0].shape[:2]
+    out_frames: Frames = []
+    out_coords: Coords = []
+    out_visibility: Visibility = []
+
+    for frame, (x, y), vis in zip(frames, coords, visibility):
+        warped = cv2.warpAffine(
+            frame,
+            matrix,
+            (width, height),
+            flags=cv2.INTER_LINEAR,
+            borderMode=border_mode,
+        )
+        if vis > 0:
+            new_x = float(matrix[0, 0] * x + matrix[0, 1] * y + matrix[0, 2])
+            new_y = float(matrix[1, 0] * x + matrix[1, 1] * y + matrix[1, 2])
+            if new_x < 0 or new_x >= width or new_y < 0 or new_y >= height:
+                out_coords.append((0.0, 0.0))
+                out_visibility.append(0.0)
+            else:
+                out_coords.append((new_x, new_y))
+                out_visibility.append(float(vis))
+        else:
+            out_coords.append((0.0, 0.0))
+            out_visibility.append(0.0)
+        out_frames.append(warped.astype(np.float32, copy=False))
+    return out_frames, out_coords, out_visibility
 
 
 class BaseArgumentation:
@@ -69,12 +169,7 @@ class CameraRotationArgumentation(BaseArgumentation):
         t_ref = (len(frames) - 1) / 2.0
         angles_deg = [theta0 + omega * (frame_idx - t_ref) for frame_idx in range(len(frames))]
 
-        border_mode = {
-            "constant": cv2.BORDER_CONSTANT,
-            "reflect": cv2.BORDER_REFLECT,
-            "reflect101": cv2.BORDER_REFLECT_101,
-            "replicate": cv2.BORDER_REPLICATE,
-        }.get(self.border_mode, cv2.BORDER_REFLECT_101)
+        border_mode = _resolve_border_mode(self.border_mode)
 
         out_frames: Frames = []
         out_coords: Coords = []
@@ -246,6 +341,116 @@ class GaussianNoiseArgumentation(BaseArgumentation):
         return out_frames, coords, visibility
 
 
+class AffineArgumentation(BaseArgumentation):
+    """Apply one sequence-consistent affine transform."""
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        super().__init__(config)
+        self.enabled = bool(self.config.get("enabled", False))
+        self.prob = float(self.config.get("prob", 0.0))
+        self.rotation_deg_range = self._parse_float_range(
+            self.config.get("rotation_deg_range", (0.0, 0.0)),
+            "rotation_deg_range",
+        )
+        self.scale_range = self._parse_float_range(
+            self.config.get("scale_range", (1.0, 1.0)),
+            "scale_range",
+        )
+        self.translate_x_ratio_range = self._parse_float_range(
+            self.config.get("translate_x_ratio_range", (0.0, 0.0)),
+            "translate_x_ratio_range",
+        )
+        self.translate_y_ratio_range = self._parse_float_range(
+            self.config.get("translate_y_ratio_range", (0.0, 0.0)),
+            "translate_y_ratio_range",
+        )
+        self.shear_x_deg_range = self._parse_float_range(
+            self.config.get("shear_x_deg_range", (0.0, 0.0)),
+            "shear_x_deg_range",
+        )
+        self.shear_y_deg_range = self._parse_float_range(
+            self.config.get("shear_y_deg_range", (0.0, 0.0)),
+            "shear_y_deg_range",
+        )
+        self.border_mode = str(self.config.get("border_mode", "reflect101"))
+
+    @staticmethod
+    def _parse_float_range(value: Any, name: str) -> tuple[float, float]:
+        if not isinstance(value, Sequence) or len(value) != 2:
+            raise ValueError(f"{name} must be a sequence with two elements.")
+        low = float(value[0])
+        high = float(value[1])
+        if low > high:
+            raise ValueError(f"{name} must satisfy min <= max.")
+        return low, high
+
+    def forward(
+        self,
+        frames: Frames,
+        coords: Coords,
+        visibility: Visibility,
+        *,
+        rng: random.Random,
+    ) -> tuple[Frames, Coords, Visibility]:
+        """Apply one affine transform to the whole sequence."""
+        if not self.enabled or rng.random() >= self.prob:
+            return frames, coords, visibility
+
+        height, width = frames[0].shape[:2]
+        center_x = (width - 1) / 2.0
+        center_y = (height - 1) / 2.0
+
+        rotation_rad = np.deg2rad(rng.uniform(*self.rotation_deg_range))
+        scale = rng.uniform(*self.scale_range)
+        if scale <= 0.0:
+            return frames, coords, visibility
+        shear_x_rad = np.deg2rad(rng.uniform(*self.shear_x_deg_range))
+        shear_y_rad = np.deg2rad(rng.uniform(*self.shear_y_deg_range))
+        translate_x = width * rng.uniform(*self.translate_x_ratio_range)
+        translate_y = height * rng.uniform(*self.translate_y_ratio_range)
+
+        center_to_origin = np.array(
+            [[1.0, 0.0, -center_x], [0.0, 1.0, -center_y], [0.0, 0.0, 1.0]],
+            dtype=np.float32,
+        )
+        scale_matrix = np.array(
+            [[scale, 0.0, 0.0], [0.0, scale, 0.0], [0.0, 0.0, 1.0]],
+            dtype=np.float32,
+        )
+        shear_matrix = np.array(
+            [
+                [1.0, np.tan(shear_x_rad), 0.0],
+                [np.tan(shear_y_rad), 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+        cos_theta = float(np.cos(rotation_rad))
+        sin_theta = float(np.sin(rotation_rad))
+        rotation_matrix = np.array(
+            [[cos_theta, -sin_theta, 0.0], [sin_theta, cos_theta, 0.0], [0.0, 0.0, 1.0]],
+            dtype=np.float32,
+        )
+        recenter = np.array(
+            [
+                [1.0, 0.0, center_x + translate_x],
+                [0.0, 1.0, center_y + translate_y],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+        full_matrix = recenter @ rotation_matrix @ shear_matrix @ scale_matrix @ center_to_origin
+        affine_matrix = full_matrix[:2, :]
+
+        return _apply_affine_to_sequence(
+            frames,
+            coords,
+            visibility,
+            matrix=affine_matrix,
+            border_mode=_resolve_border_mode(self.border_mode),
+        )
+
+
 class GaussianBlurArgumentation(BaseArgumentation):
     """Apply sequence-consistent Gaussian blur."""
 
@@ -279,6 +484,187 @@ class GaussianBlurArgumentation(BaseArgumentation):
         return out_frames, coords, visibility
 
 
+class ScaleAndCropArgumentation(BaseArgumentation):
+    """Scale around the image center, then center-crop back to the original size."""
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        super().__init__(config)
+        self.enabled = bool(self.config.get("enabled", False))
+        self.prob = float(self.config.get("prob", 0.0))
+        self.scale_range = AffineArgumentation._parse_float_range(
+            self.config.get("scale_range", (1.0, 1.0)),
+            "scale_range",
+        )
+        self.border_mode = str(self.config.get("border_mode", "reflect101"))
+
+    def forward(
+        self,
+        frames: Frames,
+        coords: Coords,
+        visibility: Visibility,
+        *,
+        rng: random.Random,
+    ) -> tuple[Frames, Coords, Visibility]:
+        """Apply one zoom centered on the mean visible ball position."""
+        if not self.enabled or rng.random() >= self.prob:
+            return frames, coords, visibility
+
+        scale = rng.uniform(*self.scale_range)
+        if scale <= 0.0 or np.isclose(scale, 1.0):
+            return frames, coords, visibility
+
+        height, width = frames[0].shape[:2]
+        visible_coords = [(x, y) for (x, y), vis in zip(coords, visibility) if vis > 0]
+        if visible_coords:
+            center_x = float(sum(x for x, _ in visible_coords) / len(visible_coords))
+            center_y = float(sum(y for _, y in visible_coords) / len(visible_coords))
+        else:
+            center_x = (width - 1) / 2.0
+            center_y = (height - 1) / 2.0
+        matrix = np.array(
+            [
+                [scale, 0.0, center_x - scale * center_x],
+                [0.0, scale, center_y - scale * center_y],
+            ],
+            dtype=np.float32,
+        )
+
+        return _apply_affine_to_sequence(
+            frames,
+            coords,
+            visibility,
+            matrix=matrix,
+            border_mode=_resolve_border_mode(self.border_mode),
+        )
+
+
+class BallAreaZeroMaskArgumentation(BaseArgumentation):
+    """Zero-mask a rectangle around the visible ball for sampled frames."""
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        super().__init__(config)
+        self.enabled = bool(self.config.get("enabled", False))
+        self.prob = float(self.config.get("prob", 0.0))
+        self.mask_width_ratio_range = self._parse_ratio_range(
+            self.config.get("mask_width_ratio_range", (0.0, 0.0)),
+            "mask_width_ratio_range",
+        )
+        self.mask_height_ratio_range = self._parse_ratio_range(
+            self.config.get("mask_height_ratio_range", (0.0, 0.0)),
+            "mask_height_ratio_range",
+        )
+        self.num_frames_range = self._parse_int_range(
+            self.config.get("num_frames_range", (0, 0)),
+            "num_frames_range",
+        )
+
+    @staticmethod
+    def _parse_ratio_range(value: Any, name: str) -> tuple[float, float]:
+        if not isinstance(value, Sequence) or len(value) != 2:
+            raise ValueError(f"{name} must be a sequence with two elements.")
+        low = float(value[0])
+        high = float(value[1])
+        if low < 0.0 or high < 0.0:
+            raise ValueError(f"{name} must be non-negative.")
+        if low > high:
+            raise ValueError(f"{name} must satisfy min <= max.")
+        return low, high
+
+    @staticmethod
+    def _parse_int_range(value: Any, name: str) -> tuple[int, int]:
+        if not isinstance(value, Sequence) or len(value) != 2:
+            raise ValueError(f"{name} must be a sequence with two elements.")
+        low = int(value[0])
+        high = int(value[1])
+        if low < 0 or high < 0:
+            raise ValueError(f"{name} must be non-negative.")
+        if low > high:
+            raise ValueError(f"{name} must satisfy min <= max.")
+        return low, high
+
+    def forward(
+        self,
+        frames: Frames,
+        coords: Coords,
+        visibility: Visibility,
+        *,
+        rng: random.Random,
+    ) -> tuple[Frames, Coords, Visibility]:
+        """Apply zero masks centered on sampled visible ball locations."""
+        if not self.enabled or rng.random() >= self.prob:
+            return frames, coords, visibility
+
+        visible_indices = [idx for idx, vis in enumerate(visibility) if vis > 0]
+        if not visible_indices:
+            return frames, coords, visibility
+
+        min_frames, max_frames = self.num_frames_range
+        if max_frames <= 0:
+            return frames, coords, visibility
+
+        num_frames = rng.randint(min_frames, max_frames)
+        num_frames = min(num_frames, len(visible_indices))
+        if num_frames <= 0:
+            return frames, coords, visibility
+
+        selected_indices = rng.sample(visible_indices, k=num_frames)
+        out_frames = [frame.astype(np.float32, copy=True) for frame in frames]
+
+        for frame_idx in selected_indices:
+            frame = out_frames[frame_idx]
+            height, width = frame.shape[:2]
+            x, y = coords[frame_idx]
+            mask_width = int(round(width * rng.uniform(*self.mask_width_ratio_range)))
+            mask_height = int(round(height * rng.uniform(*self.mask_height_ratio_range)))
+            mask_width = max(1, min(mask_width, width))
+            mask_height = max(1, min(mask_height, height))
+
+            center_x = int(round(x))
+            center_y = int(round(y))
+            x0 = max(0, center_x - mask_width // 2)
+            y0 = max(0, center_y - mask_height // 2)
+            x1 = min(width, x0 + mask_width)
+            y1 = min(height, y0 + mask_height)
+            x0 = max(0, x1 - mask_width)
+            y0 = max(0, y1 - mask_height)
+            frame[y0:y1, x0:x1] = 0.0
+
+        return out_frames, coords, visibility
+
+
+class ImageNetNormalizeArgumentation(BaseArgumentation):
+    """Apply ImageNet channel normalization with DINO-compatible constants."""
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        super().__init__(config)
+        self.enabled = bool(self.config.get("enabled", True))
+        mean = self.config.get("mean", IMAGENET_MEAN.tolist())
+        std = self.config.get("std", IMAGENET_STD.tolist())
+        if not isinstance(mean, Sequence) or len(mean) != 3:
+            raise ValueError("normalize_imagenet.mean must contain 3 values.")
+        if not isinstance(std, Sequence) or len(std) != 3:
+            raise ValueError("normalize_imagenet.std must contain 3 values.")
+        self.mean = np.asarray(mean, dtype=np.float32).reshape(1, 1, 3)
+        self.std = np.asarray(std, dtype=np.float32).reshape(1, 1, 3)
+        if np.any(self.std <= 0.0):
+            raise ValueError("normalize_imagenet.std values must be positive.")
+
+    def forward(
+        self,
+        frames: Frames,
+        coords: Coords,
+        visibility: Visibility,
+        *,
+        rng: random.Random,
+    ) -> tuple[Frames, Coords, Visibility]:
+        """Normalize RGB frames with the same formula as TVF.normalize."""
+        del rng
+        if not self.enabled:
+            return frames, coords, visibility
+        out_frames = normalize_frames_imagenet(frames, mean=self.mean, std=self.std)
+        return out_frames, coords, visibility
+
+
 class BallDetectionArgumentation:
     """Compose and apply all configured sequence augmentations."""
 
@@ -287,12 +673,32 @@ class BallDetectionArgumentation:
         self.transforms: list[BaseArgumentation] = [
             CameraRotationArgumentation(dict(config.get("camera_rotation", {}) or {})),
             HorizontalFlipArgumentation(dict(config.get("horizontal_flip", {}) or {})),
+            AffineArgumentation(dict(config.get("affine", {}) or {})),
+            ScaleAndCropArgumentation(dict(config.get("scale_and_crop", {}) or {})),
             BrightnessGainArgumentation(dict(config.get("brightness_gain", {}) or {})),
             ContrastArgumentation(dict(config.get("contrast", {}) or {})),
             GammaArgumentation(dict(config.get("gamma", {}) or {})),
             GaussianNoiseArgumentation(dict(config.get("gaussian_noise", {}) or {})),
             GaussianBlurArgumentation(dict(config.get("gaussian_blur", {}) or {})),
+            BallAreaZeroMaskArgumentation(dict(config.get("ball_area_zero_mask", {}) or {})),
+            ImageNetNormalizeArgumentation(dict(config.get("normalize_imagenet", {}) or {})),
         ]
+
+    @classmethod
+    def from_eval_config(
+        cls,
+        config: dict[str, Any] | None = None,
+    ) -> "BallDetectionArgumentation | None":
+        """Build an eval-only pipeline that keeps deterministic preprocessing."""
+        config = config or {}
+        normalize_cfg = dict(config.get("normalize_imagenet", {}) or {})
+        if not bool(normalize_cfg.get("enabled", False)):
+            return None
+        return cls(
+            {
+                "normalize_imagenet": normalize_cfg,
+            }
+        )
 
     def forward(
         self,
@@ -328,12 +734,21 @@ def make_sample_rng(sample_idx: int) -> random.Random:
 __all__ = [
     "BallDetectionArgumentation",
     "BaseArgumentation",
+    "AffineArgumentation",
     "BrightnessGainArgumentation",
     "CameraRotationArgumentation",
     "ContrastArgumentation",
     "GammaArgumentation",
+    "BallAreaZeroMaskArgumentation",
     "GaussianBlurArgumentation",
     "GaussianNoiseArgumentation",
     "HorizontalFlipArgumentation",
+    "ImageNetNormalizeArgumentation",
+    "IMAGENET_MEAN",
+    "IMAGENET_STD",
+    "ScaleAndCropArgumentation",
+    "denormalize_tensor_images_imagenet",
     "make_sample_rng",
+    "normalize_frames_imagenet",
+    "normalize_tensor_images_imagenet",
 ]

--- a/src/tasks/ball_detection/data/dataset.py
+++ b/src/tasks/ball_detection/data/dataset.py
@@ -86,15 +86,12 @@ class BallDetectionDataset(Dataset[BallDetectionSample]):
         self.sample_stride = int(data_cfg.get("sample_stride", 1))
         self.image_size = self._parse_size(data_cfg.get("image_size", [288, 512]), name="data.image_size")
         self.heatmap_size = self._parse_size(data_cfg.get("heatmap_size", [144, 256]), name="data.heatmap_size")
-        self.gaussian_size = int(data_cfg.get("gaussian_size", 3))
         self.gaussian_variance = float(data_cfg.get("gaussian_variance", 1.0))
 
         if self.num_frames <= 0:
             raise ValueError("model.num_frames must be positive.")
         if self.sample_stride <= 0:
             raise ValueError("data.sample_stride must be positive.")
-        if self.gaussian_size < 0:
-            raise ValueError("data.gaussian_size must be non-negative.")
         if self.gaussian_variance <= 0:
             raise ValueError("data.gaussian_variance must be positive.")
 
@@ -336,29 +333,12 @@ class BallDetectionDataset(Dataset[BallDetectionSample]):
         center_x: float,
         center_y: float,
     ) -> np.ndarray:
-        heatmap = np.zeros((height, width), dtype=np.float32)
-        cx_int = int(round(center_x))
-        cy_int = int(round(center_y))
-        if cx_int < 0 or cy_int < 0 or cx_int >= width or cy_int >= height:
-            return heatmap
+        x = np.arange(0, width, 1, float)
+        y = np.arange(0, height, 1, float)
+        y, x = np.meshgrid(y, x, indexing='ij')
+        sigma_sq2 = 2 * self.gaussian_variance
+        heatmap = np.exp(-((x - center_x)**2 + (y - center_y)**2) / sigma_sq2)
 
-        size = self.gaussian_size
-        yy, xx = np.mgrid[-size : size + 1, -size : size + 1]
-        kernel = np.exp(-(xx**2 + yy**2) / (2.0 * self.gaussian_variance)).astype(np.float32)
-        kernel /= max(float(kernel.max()), 1e-8)
-
-        y_start = max(0, cy_int - size)
-        y_end = min(height, cy_int + size + 1)
-        x_start = max(0, cx_int - size)
-        x_end = min(width, cx_int + size + 1)
-
-        kernel_y_start = size - (cy_int - y_start)
-        kernel_y_end = kernel_y_start + (y_end - y_start)
-        kernel_x_start = size - (cx_int - x_start)
-        kernel_x_end = kernel_x_start + (x_end - x_start)
-        heatmap[y_start:y_end, x_start:x_end] = kernel[
-            kernel_y_start:kernel_y_end, kernel_x_start:kernel_x_end
-        ]
         return heatmap
 
     @staticmethod

--- a/src/tasks/ball_detection/models/dino_pseudo3d.py
+++ b/src/tasks/ball_detection/models/dino_pseudo3d.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -120,19 +121,32 @@ def _make_decoder_stage(
 
 
 class DINOPseudo3DBallDetector(nn.Module):
-    """Ball detector with a DINO ResNet backbone and pseudo-3D decoder."""
+    """Ball detector with a DINO backbone and pseudo-3D decoder."""
 
-    _FEATURE_CHANNELS = (256, 512, 1024, 2048)
+    _RESNET_BACKBONES = {"resnet50", "resnet101"}
+    _SWIN_BACKBONES = {
+        "swin_T_224_1k": (96, 192, 384, 768),
+        "swin_B_224_22k": (128, 256, 512, 1024),
+        "swin_B_384_22k": (128, 256, 512, 1024),
+        "swin_L_224_22k": (192, 384, 768, 1536),
+        "swin_L_384_22k": (192, 384, 768, 1536),
+    }
+    _DEFAULT_RESNET_CHECKPOINT = Path("/workspace/checkpoints/DINO/backbone_body_state.pth")
+    _DEFAULT_SWIN_CHECKPOINT = Path(
+        "/workspace/checkpoints/DINO/swin_backbone_state_checkpoint0027_5scale.pth"
+    )
 
     def __init__(
         self,
         *,
         in_channels: int = 3,
         num_classes: int = 1,
-        backbone_checkpoint_path: str | Path = "/workspace/checkpoints/DINO/backbone_body_state.pth",
+        backbone_checkpoint_path: str | Path | None = None,
         backbone_name: str = "resnet50",
         backbone_dilation: bool = False,
         return_interm_indices: tuple[int, ...] = (0, 1, 2, 3),
+        backbone_pretrain_img_size: int | None = None,
+        backbone_use_checkpoint: bool = False,
         backbone_strict: bool = True,
         freeze_backbone: bool = True,
         expand_ratio: float = 4.0,
@@ -152,15 +166,22 @@ class DINOPseudo3DBallDetector(nn.Module):
 
         self.in_channels = int(in_channels)
         self.num_classes = int(num_classes)
+        self.backbone_name = str(backbone_name)
         self.return_interm_indices = tuple(return_interm_indices)
         self.freeze_backbone = bool(freeze_backbone)
 
-        self.backbone, load_result = load_backbone_body_state(
-            checkpoint_path=Path(backbone_checkpoint_path),
-            backbone=backbone_name,
-            dilation=backbone_dilation,
+        resolved_checkpoint = self._resolve_checkpoint_path(
+            backbone_name=self.backbone_name,
+            backbone_checkpoint_path=backbone_checkpoint_path,
+        )
+        self.backbone, load_result = self._load_backbone(
+            checkpoint_path=resolved_checkpoint,
+            backbone_name=self.backbone_name,
+            backbone_dilation=backbone_dilation,
             return_interm_indices=list(self.return_interm_indices),
-            strict=backbone_strict,
+            backbone_pretrain_img_size=backbone_pretrain_img_size,
+            backbone_use_checkpoint=backbone_use_checkpoint,
+            backbone_strict=backbone_strict,
         )
         if backbone_strict and (
             load_result.missing_keys or load_result.unexpected_keys
@@ -174,7 +195,7 @@ class DINOPseudo3DBallDetector(nn.Module):
             for parameter in self.backbone.parameters():
                 parameter.requires_grad = False
 
-        c1, c2, c3, c4 = self._FEATURE_CHANNELS
+        c1, c2, c3, c4 = self._feature_channels_for_backbone(self.backbone_name)
         self.decode4 = _make_decoder_stage(
             in_channels=c4,
             mid_channels=c4,
@@ -209,20 +230,24 @@ class DINOPseudo3DBallDetector(nn.Module):
     def from_config(cls, config: DictConfig) -> "DINOPseudo3DBallDetector":
         """Create the model from a composed Hydra config."""
         model_cfg = config.get("model", {}) or {}
+        checkpoint_path = model_cfg.get("backbone_checkpoint_path")
         return cls(
             in_channels=resolve_model_in_channels(model_cfg),
             num_classes=int(model_cfg.get("num_classes", 1)),
-            backbone_checkpoint_path=str(
-                model_cfg.get(
-                    "backbone_checkpoint_path",
-                    "/workspace/checkpoints/DINO/backbone_body_state.pth",
-                )
+            backbone_checkpoint_path=(
+                None if checkpoint_path is None else str(checkpoint_path)
             ),
             backbone_name=str(model_cfg.get("backbone_name", "resnet50")),
             backbone_dilation=bool(model_cfg.get("backbone_dilation", False)),
             return_interm_indices=tuple(
                 int(index) for index in model_cfg.get("return_interm_indices", [0, 1, 2, 3])
             ),
+            backbone_pretrain_img_size=(
+                None
+                if model_cfg.get("backbone_pretrain_img_size") is None
+                else int(model_cfg.get("backbone_pretrain_img_size"))
+            ),
+            backbone_use_checkpoint=bool(model_cfg.get("backbone_use_checkpoint", False)),
             backbone_strict=bool(model_cfg.get("backbone_strict", True)),
             freeze_backbone=bool(model_cfg.get("freeze_backbone", True)),
             expand_ratio=float(model_cfg.get("decoder_expand_ratio", 4.0)),
@@ -282,6 +307,83 @@ class DINOPseudo3DBallDetector(nn.Module):
             mode="trilinear",
             align_corners=False,
         )
+
+    @classmethod
+    def _resolve_checkpoint_path(
+        cls,
+        *,
+        backbone_name: str,
+        backbone_checkpoint_path: str | Path | None,
+    ) -> Path:
+        if backbone_checkpoint_path is not None and str(backbone_checkpoint_path).strip():
+            return Path(backbone_checkpoint_path)
+        if backbone_name in cls._RESNET_BACKBONES:
+            return cls._DEFAULT_RESNET_CHECKPOINT
+        if backbone_name in cls._SWIN_BACKBONES:
+            return cls._DEFAULT_SWIN_CHECKPOINT
+        raise ValueError(f"Unsupported DINO backbone: {backbone_name}")
+
+    @classmethod
+    def _feature_channels_for_backbone(cls, backbone_name: str) -> tuple[int, int, int, int]:
+        if backbone_name in cls._RESNET_BACKBONES:
+            return (256, 512, 1024, 2048)
+        if backbone_name in cls._SWIN_BACKBONES:
+            return cls._SWIN_BACKBONES[backbone_name]
+        raise ValueError(f"Unsupported DINO backbone: {backbone_name}")
+
+    @classmethod
+    def _load_backbone(
+        cls,
+        *,
+        checkpoint_path: Path,
+        backbone_name: str,
+        backbone_dilation: bool,
+        return_interm_indices: list[int],
+        backbone_pretrain_img_size: int | None,
+        backbone_use_checkpoint: bool,
+        backbone_strict: bool,
+    ) -> tuple[nn.Module, nn.modules.module._IncompatibleKeys]:
+        if backbone_name in cls._RESNET_BACKBONES:
+            return load_backbone_body_state(
+                checkpoint_path=checkpoint_path,
+                backbone=backbone_name,
+                dilation=backbone_dilation,
+                return_interm_indices=return_interm_indices,
+                strict=backbone_strict,
+            )
+        if backbone_name not in cls._SWIN_BACKBONES:
+            raise ValueError(f"Unsupported DINO backbone: {backbone_name}")
+
+        load_swin_backbone_state = cls._load_swin_backbone_loader()
+        resolved_pretrain_img_size = (
+            int(backbone_pretrain_img_size)
+            if backbone_pretrain_img_size is not None
+            else cls._infer_swin_pretrain_img_size(backbone_name)
+        )
+        return load_swin_backbone_state(
+            checkpoint_path,
+            backbone=backbone_name,
+            pretrain_img_size=resolved_pretrain_img_size,
+            dilation=backbone_dilation,
+            return_interm_indices=return_interm_indices,
+            use_checkpoint=backbone_use_checkpoint,
+            strict=backbone_strict,
+        )
+
+    @staticmethod
+    def _infer_swin_pretrain_img_size(backbone_name: str) -> int:
+        return int(backbone_name.split("_")[-2])
+
+    @staticmethod
+    def _load_swin_backbone_loader():
+        try:
+            module = importlib.import_module("checkpoints.DINO.scripts.load_dino_swin_backbone")
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to import Swin DINO backbone loader. "
+                "Check that the DINO Swin builder sources are available in this workspace."
+            ) from exc
+        return module.load_swin_backbone_state
 
 
 __all__ = [

--- a/src/tasks/ball_detection/scripts/train.py
+++ b/src/tasks/ball_detection/scripts/train.py
@@ -36,6 +36,7 @@ from torch.utils.data import DataLoader
 from tqdm.auto import tqdm
 
 from src.tasks.ball_detection.data.argumentation import BallDetectionArgumentation
+from src.tasks.ball_detection.data.argumentation import normalize_tensor_images_imagenet
 from src.tasks.ball_detection.data.dataset import BallDetectionDataset
 from src.tasks.ball_detection.data.types import BallDetectionBatch
 from src.tasks.ball_detection.input_adapter import to_model_input
@@ -394,18 +395,21 @@ def _build_eval_dataloaders(
     num_workers = int(data_cfg.get("num_workers", 4))
     pin_memory = bool(data_cfg.get("pin_memory", True))
     persistent_workers = num_workers > 0
+    eval_argumentation = BallDetectionArgumentation.from_eval_config(
+        dict(data_cfg.get("augmentation", {}) or {})
+    )
 
     val_dataset = BallDetectionDataset(
         data_dir=data_dir,
         split_file=str(split_cfg.get("val_file", "val.txt")),
         config=config,
-        argumentation=None,
+        argumentation=eval_argumentation,
     )
     test_dataset = BallDetectionDataset(
         data_dir=data_dir,
         split_file=str(split_cfg.get("test_file", "test.txt")),
         config=config,
-        argumentation=None,
+        argumentation=eval_argumentation,
     )
     eval_kwargs = {
         "batch_size": batch_size,
@@ -898,6 +902,8 @@ def _infer_visualization_predictions(
             )
             batch_inputs.append(window)
         inputs = torch.from_numpy(np.stack(batch_inputs)).to(device=device, dtype=torch.float32)
+        if _visualization_uses_imagenet_normalization(config):
+            inputs = normalize_tensor_images_imagenet(inputs)
         with _autocast_context(config, device=device):
             logits = model(_to_model_input(inputs, config)).squeeze(1)
             probs = torch.sigmoid(logits).detach().float().cpu().numpy()
@@ -934,6 +940,13 @@ def _infer_visualization_predictions(
             )
         )
     return predictions
+
+
+def _visualization_uses_imagenet_normalization(config: DictConfig) -> bool:
+    """Return whether visualization inference should mirror dataset normalization."""
+    augmentation_cfg = config.data.get("augmentation", {}) or {}
+    normalize_cfg = augmentation_cfg.get("normalize_imagenet", {}) or {}
+    return bool(normalize_cfg.get("enabled", False))
 
 
 def _write_visualization_video(

--- a/src/tasks/ball_detection/scripts/visualize_augmentation.py
+++ b/src/tasks/ball_detection/scripts/visualize_augmentation.py
@@ -24,7 +24,10 @@ import numpy as np
 import torch
 from omegaconf import DictConfig, OmegaConf
 
-from src.tasks.ball_detection.data.argumentation import BallDetectionArgumentation
+from src.tasks.ball_detection.data.argumentation import (
+    BallDetectionArgumentation,
+    denormalize_tensor_images_imagenet,
+)
 from src.tasks.ball_detection.data.dataset import BallDetectionDataset, ClipWindow
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -229,12 +232,24 @@ def _render_contact_sheet(
 
 def _tensor_sequence_to_frames(images: torch.Tensor) -> list[np.ndarray]:
     """Convert ``(T, 3, H, W)`` tensor images into RGB ``uint8`` frames."""
+    images_to_render = images
+    if _uses_imagenet_normalization(images):
+        images_to_render = denormalize_tensor_images_imagenet(images)
     frames: list[np.ndarray] = []
-    for image in images.cpu().numpy():
+    for image in images_to_render.cpu().numpy():
         frame = np.transpose(image, (1, 2, 0))
         frame = np.clip(frame * 255.0, 0.0, 255.0).astype(np.uint8)
         frames.append(frame)
     return frames
+
+
+def _uses_imagenet_normalization(images: torch.Tensor) -> bool:
+    """Heuristically detect normalized RGB tensors for preview rendering."""
+    if images.ndim != 4 or images.shape[1] != 3:
+        return False
+    min_value = float(images.min().item())
+    max_value = float(images.max().item())
+    return min_value < 0.0 or max_value > 1.0
 
 
 def _annotate_frames(

--- a/src/tasks/ball_detection/training/pseudo_labeling.py
+++ b/src/tasks/ball_detection/training/pseudo_labeling.py
@@ -15,6 +15,7 @@ import torch
 from torch import nn
 from tqdm.auto import tqdm
 
+from src.tasks.ball_detection.data.argumentation import normalize_tensor_images_imagenet
 from src.tasks.ball_detection.input_adapter import to_model_input
 
 if TYPE_CHECKING:
@@ -465,6 +466,8 @@ def _infer_chunk_predictions(
                 frames.append(frame.transpose(2, 0, 1))
             batch.append(np.stack(frames))
         inputs = torch.from_numpy(np.stack(batch)).to(device=device, dtype=torch.float32)
+        if _uses_imagenet_normalization(config):
+            inputs = normalize_tensor_images_imagenet(inputs)
         with torch.inference_mode():
             probs = torch.sigmoid(
                 model(_to_model_input(inputs, config))
@@ -644,6 +647,13 @@ def _batched(values: Sequence[int], batch_size: int) -> Iterator[list[int]]:
 def _to_model_input(images: torch.Tensor, config: DictConfig) -> torch.Tensor:
     """Convert cached RGB frames into the configured model input layout."""
     return to_model_input(images, config.get("model", {}) or {})
+
+
+def _uses_imagenet_normalization(config: DictConfig) -> bool:
+    """Return whether pseudo-label inference should mirror dataset normalization."""
+    augmentation_cfg = config.data.get("augmentation", {}) or {}
+    normalize_cfg = augmentation_cfg.get("normalize_imagenet", {}) or {}
+    return bool(normalize_cfg.get("enabled", False))
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

- Add Swin DINO backbone support to the pseudo-3D ball detector training flow.
- Expand ball-detection augmentation and normalization handling so training, pseudo-labeling, and visualization use the same assumptions.
- Update DINO submodule wiring and checkpoint loader integration for the new backbone path.

## Changes

- Add Swin backbone selection, checkpoint resolution, and loader integration in the DINO pseudo-3D model and config.
- Add sequence-consistent affine augmentation plus ImageNet normalization helpers in the ball-detection data pipeline.
- Apply the updated preprocessing flow in training, pseudo-labeling, and augmentation visualization scripts.

## Validation

- `python -m pytest`
- `python -m mypy src` currently fails with a mypy internal error in this repository environment.
- `pre-commit run --all-files` currently fails on pre-existing repo-wide lint findings outside this change set.

## Related Issues

- References #

## Notes

- Draft PR to keep follow-up validation and review separate from the feature commit.
