### PR TITLE
fix: Enable net clearance by default

### DIFF
--- a/src/tasks/blcs/configs/targeted_velocity/default.yaml
+++ b/src/tasks/blcs/configs/targeted_velocity/default.yaml
@@ -20,8 +20,8 @@ refine_speed_scale_max: 1.4
 refine_max_azimuth_adjust_deg: 15.0
 refine_max_frames: 1200
 
-# Net clearance disabled (single-shot sampling)
-net_clearance_enabled: false
+# Net clearance enabled by default
+net_clearance_enabled: true
 net_clearance_min: 0.1
 net_clearance_max_attempts: 12
 net_clearance_max_frames: 600

--- a/src/tasks/blcs/generate_dataset/simulation/targeted_velocity_sampler.py
+++ b/src/tasks/blcs/generate_dataset/simulation/targeted_velocity_sampler.py
@@ -72,8 +72,8 @@ class TargetedVelocityConfig:
     refine_max_frames: int = 1200
 
     # Net clearance constraint (optional)
-    # NOTE: Disabled by default in favour of single-shot sampling
-    net_clearance_enabled: bool = False
+    # NOTE: Enabled by default to avoid low-clearance net-fault-heavy samples
+    net_clearance_enabled: bool = True
     net_clearance_min: float = 0.1
     net_clearance_max_attempts: int = 12
     net_clearance_max_frames: int = 600


### PR DESCRIPTION
## Summary

- Enable BLCS targeted velocity net clearance by default based on real-data validation showing reduced net_fault frequency and longer rallies.

## Changes

- Set `net_clearance_enabled: true` in the BLCS targeted velocity default config.
- Change `TargetedVelocityConfig.net_clearance_enabled` default to `True`.
- Update inline comments to reflect the new default behavior.

## Validation

- `python - <<PY ...` to confirm `TargetedVelocityConfig().net_clearance_enabled` returns `True`.
- `python -m pytest tests src/tasks/blcs -k targeted_velocity -q` (collected 0 items; no targeted tests currently exist).

## Related Issues

- References #
