### PR TITLE
chore: update DINO checkpoint script paths

### DIFF
--- a/checkpoints/DINO/analyze/ball_feature_consistency.py
+++ b/checkpoints/DINO/analyze/ball_feature_consistency.py
@@ -20,6 +20,7 @@ Outputs:
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,13 @@ IMAGENET_MEAN = [0.485, 0.456, 0.406]
 IMAGENET_STD = [0.229, 0.224, 0.225]
 RESNET_BACKBONE_CHOICES = ["resnet50", "resnet101"]
 BACKBONE_CHOICES = RESNET_BACKBONE_CHOICES + SWIN_BACKBONE_CHOICES
+DEFAULT_WEIGHTS_ROOT = Path(
+    os.environ.get(
+        "MODEL_WEIGHTS_ROOT",
+        "/mnt/d/weights" if Path("/mnt/d/weights").exists() else "D:/weights",
+    )
+)
+DINO_WEIGHTS_DIR = DEFAULT_WEIGHTS_ROOT / "DINO"
 
 
 def parse_args() -> argparse.Namespace:
@@ -119,12 +127,12 @@ def parse_args() -> argparse.Namespace:
 
 def default_checkpoint_path(backbone: str) -> Path:
     if backbone in RESNET_BACKBONE_CHOICES:
-        return Path("/workspace/checkpoints/DINO/backbone_body_state.pth")
-    return Path("/workspace/checkpoints/DINO/checkpoint0027_5scale_swin.pth")
+        return DINO_WEIGHTS_DIR / "backbone_body_state.pth"
+    return DINO_WEIGHTS_DIR / "checkpoint0027_5scale_swin.pth"
 
 
 def default_output_dir(clip_dir: Path, backbone: str) -> Path:
-    return Path("/workspace/checkpoints/DINO/analyze/output") / f"{clip_dir.name}_{backbone}"
+    return DINO_WEIGHTS_DIR / "analyze" / "output" / f"{clip_dir.name}_{backbone}"
 
 
 def load_model_for_consistency(

--- a/checkpoints/DINO/scripts/download_checkpoint0011_5scale.py
+++ b/checkpoints/DINO/scripts/download_checkpoint0011_5scale.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import os
 import sys
 from pathlib import Path
 
@@ -12,7 +13,13 @@ import gdown
 
 
 FILE_ID = "1DEoJzk8NL1hHQqTtDSkSHj5K6PRJ8bXq"
-DEFAULT_OUTPUT = Path("/workspace/checkpoints/DINO/checkpoint0011_5scale.pth")
+DEFAULT_WEIGHTS_ROOT = Path(
+    os.environ.get(
+        "MODEL_WEIGHTS_ROOT",
+        "/mnt/d/weights" if Path("/mnt/d/weights").exists() else "D:/weights",
+    )
+)
+DEFAULT_OUTPUT = DEFAULT_WEIGHTS_ROOT / "DINO" / "checkpoint0011_5scale.pth"
 EXPECTED_SHA256 = "1ccc1b6b7139813e4d3bfbeecfcf88347ebc226829769a0bf16c4a114c275cc0"
 
 

--- a/checkpoints/DINO/scripts/download_checkpoint0027_5scale_swin.py
+++ b/checkpoints/DINO/scripts/download_checkpoint0027_5scale_swin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import os
 import sys
 from pathlib import Path
 
@@ -12,7 +13,13 @@ import gdown
 
 
 FILE_ID = "14h4UCi-HsDL01ZQRbpV47dzMST_py_vM"
-DEFAULT_OUTPUT = Path("/workspace/checkpoints/DINO/checkpoint0027_5scale_swin.pth")
+DEFAULT_WEIGHTS_ROOT = Path(
+    os.environ.get(
+        "MODEL_WEIGHTS_ROOT",
+        "/mnt/d/weights" if Path("/mnt/d/weights").exists() else "D:/weights",
+    )
+)
+DEFAULT_OUTPUT = DEFAULT_WEIGHTS_ROOT / "DINO" / "checkpoint0027_5scale_swin.pth"
 EXPECTED_SHA256: str | None = "17ddce1592816a0c63a2edc94d4a0877ffeb086f397a6657e151c703a4c850b5"
 
 

--- a/checkpoints/DINO/scripts/inspect_dino_backbone_output.py
+++ b/checkpoints/DINO/scripts/inspect_dino_backbone_output.py
@@ -9,6 +9,7 @@ prints the output container type plus each feature map's key and shape.
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 
 import torch
@@ -16,12 +17,21 @@ import torch
 from load_dino_backbone import load_backbone_body_state
 
 
+DEFAULT_WEIGHTS_ROOT = Path(
+    os.environ.get(
+        "MODEL_WEIGHTS_ROOT",
+        "/mnt/d/weights" if Path("/mnt/d/weights").exists() else "D:/weights",
+    )
+)
+DINO_WEIGHTS_DIR = DEFAULT_WEIGHTS_ROOT / "DINO"
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--checkpoint",
         type=Path,
-        default=Path("/workspace/checkpoints/DINO/backbone_body_state.pth"),
+        default=DINO_WEIGHTS_DIR / "backbone_body_state.pth",
         help="Path to a trimmed backbone-body checkpoint.",
     )
     parser.add_argument(

--- a/checkpoints/DINO/scripts/inspect_dino_swin_backbone_output.py
+++ b/checkpoints/DINO/scripts/inspect_dino_swin_backbone_output.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -19,12 +20,21 @@ from checkpoints.DINO.scripts.load_dino_swin_backbone import (
 )
 
 
+DEFAULT_WEIGHTS_ROOT = Path(
+    os.environ.get(
+        "MODEL_WEIGHTS_ROOT",
+        "/mnt/d/weights" if Path("/mnt/d/weights").exists() else "D:/weights",
+    )
+)
+DINO_WEIGHTS_DIR = DEFAULT_WEIGHTS_ROOT / "DINO"
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--checkpoint",
         type=Path,
-        default=Path("/workspace/checkpoints/DINO/swin_backbone_state_checkpoint0027_5scale.pth"),
+        default=DINO_WEIGHTS_DIR / "swin_backbone_state_checkpoint0027_5scale.pth",
         help="Path to a trimmed Swin backbone checkpoint.",
     )
     parser.add_argument(

--- a/checkpoints/DINO/scripts/load_dino_backbone.py
+++ b/checkpoints/DINO/scripts/load_dino_backbone.py
@@ -18,12 +18,22 @@ from __future__ import annotations
 
 import argparse
 from collections import OrderedDict
+import os
 from pathlib import Path
 
 import torch
 import torchvision
 from torch import nn
 from torchvision.models._utils import IntermediateLayerGetter
+
+
+DEFAULT_WEIGHTS_ROOT = Path(
+    os.environ.get(
+        "MODEL_WEIGHTS_ROOT",
+        "/mnt/d/weights" if Path("/mnt/d/weights").exists() else "D:/weights",
+    )
+)
+DINO_WEIGHTS_DIR = DEFAULT_WEIGHTS_ROOT / "DINO"
 
 
 class FrozenBatchNorm2d(nn.Module):
@@ -149,7 +159,7 @@ def load_backbone_body_state(
     """Load a trimmed DINO backbone-body state dict into ``DINOBackbone``.
 
     This function is intended for checkpoints like
-    ``/workspace/checkpoints/DINO/backbone_body_state.pth``, where the saved
+    ``D:/weights/DINO/backbone_body_state.pth``, where the saved
     keys correspond directly to the ResNet body, for example
     ``conv1.weight`` and ``layer4.2.conv3.weight``. The function constructs a
     ``DINOBackbone`` instance with the requested architecture settings, then
@@ -192,7 +202,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--checkpoint",
         type=Path,
-        default=Path("/workspace/checkpoints/DINO/checkpoint0011_5scale.pth"),
+        default=DINO_WEIGHTS_DIR / "checkpoint0011_5scale.pth",
         help="Path to the full DINO checkpoint.",
     )
     parser.add_argument(

--- a/checkpoints/DINO/scripts/load_dino_swin_backbone.py
+++ b/checkpoints/DINO/scripts/load_dino_swin_backbone.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 import sys
 from collections import Counter, OrderedDict
 from pathlib import Path
@@ -26,6 +27,15 @@ if str(THIRD_PARTY_DINO_ROOT) not in sys.path:
 
 import torch
 from torch import nn
+
+
+DEFAULT_WEIGHTS_ROOT = Path(
+    os.environ.get(
+        "MODEL_WEIGHTS_ROOT",
+        "/mnt/d/weights" if Path("/mnt/d/weights").exists() else "D:/weights",
+    )
+)
+DINO_WEIGHTS_DIR = DEFAULT_WEIGHTS_ROOT / "DINO"
 
 
 def load_swin_builder():
@@ -241,7 +251,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--checkpoint",
         type=Path,
-        default=Path("/workspace/checkpoints/DINO/checkpoint0027_5scale_swin.pth"),
+        default=DINO_WEIGHTS_DIR / "checkpoint0027_5scale_swin.pth",
         help="Path to the full DINO checkpoint.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

- update DINO helper scripts to resolve checkpoint locations from a configurable weights root
- remove hard-coded `/workspace/checkpoints/DINO/...` defaults from download, inspect, load, and analysis scripts

## Changes

- add shared `MODEL_WEIGHTS_ROOT` / `DINO_WEIGHTS_DIR` path resolution in DINO scripts
- default to `/mnt/d/weights` when present, otherwise `D:/weights`, while still honoring the `MODEL_WEIGHTS_ROOT` environment variable
- point script defaults and output directories at the resolved DINO weights directory

## Validation

- static review of the staged `checkpoints/DINO/**` script changes
- no runtime validation was run because these scripts depend on local checkpoint files and environment-specific weight locations

## Related Issues

- References #

