### PR TITLE
fix: add task-aware court eval outputs

### DIFF
--- a/src/tasks/court_detection/configs/eval.yaml
+++ b/src/tasks/court_detection/configs/eval.yaml
@@ -1,0 +1,17 @@
+task: kp
+checkpoint: null
+data_dir: data/court
+split: val
+num_samples: 10
+device: cuda
+output_dir: outputs/court_detection/eval
+alpha: 0.45
+mask_dir_name: line_masks
+augmentation: {}
+
+hydra:
+  run:
+    dir: ${output_dir}/${now:%Y-%m-%d_%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/tasks/court_detection/inference/__init__.py
+++ b/src/tasks/court_detection/inference/__init__.py
@@ -1,5 +1,8 @@
 """Inference components for court detection."""
 
-from src.tasks.court_detection.inference.predictor import CourtKeypointPredictor
+from src.tasks.court_detection.inference.predictor import (
+    CourtDetectionPredictor,
+    CourtKeypointPredictor,
+)
 
-__all__ = ["CourtKeypointPredictor"]  # noqa: F401
+__all__ = ["CourtDetectionPredictor", "CourtKeypointPredictor"]  # noqa: F401

--- a/src/tasks/court_detection/inference/predictor.py
+++ b/src/tasks/court_detection/inference/predictor.py
@@ -1,4 +1,4 @@
-"""Inference predictor for court keypoint detection."""
+"""Inference predictors for court detection tasks."""
 
 from __future__ import annotations
 
@@ -8,7 +8,6 @@ from typing import Any, Self
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 import torchvision.transforms.functional as TF
 from PIL import Image
 from torch import Tensor
@@ -20,25 +19,19 @@ from src.tasks.court_detection.training.lightning_module import (
 )
 
 
-class CourtKeypointPredictor(BasePredictor):
-    """Predictor for court keypoint detection using CourtUNet.
-
-    Loads a Lightning checkpoint and runs keypoint heatmap inference.
-
-    Attributes:
-        model: CourtUNet instance.
-        device: Device to run inference on.
-        short_side: Short side resize for preprocessing.
-    """
+class CourtDetectionPredictor(BasePredictor):
+    """Unified predictor for court detection tasks."""
 
     def __init__(
         self,
         model: torch.nn.Module,
         device: torch.device,
+        task: str,
         short_side: int = 640,
     ) -> None:
         self.model = model
         self.device = device
+        self.task = task
         self.short_side = short_side
 
         self.model.to(self.device)
@@ -51,42 +44,34 @@ class CourtKeypointPredictor(BasePredictor):
         device: str | torch.device = "cpu",
         **kwargs: Any,
     ) -> Self:
-        """Load predictor from a Lightning checkpoint.
-
-        Parameters
-        ----------
-        checkpoint_path:
-            Path to ``.ckpt`` checkpoint file.
-        device:
-            Device to run inference on.
-
-        Returns
-        -------
-        CourtKeypointPredictor
-        """
+        """Load predictor from a Lightning checkpoint."""
         checkpoints = cls._ensure_checkpoint(checkpoint_path)
         resolved_device = cls._resolve_device(device)
 
         lightning_module = CourtDetectionLightningModule.load_from_checkpoint(
             checkpoints[0],
             map_location=resolved_device,
+            weights_only=False,
         )
 
         model = lightning_module.model
         data_cfg = dict(lightning_module.config.get("data", {}))
         aug_cfg = data_cfg.get("augmentation", {})
+        task = str(data_cfg.get("task", "seg"))
         short_side = int(aug_cfg.get("val_short_side", 640))
 
-        return cls(model=model, device=resolved_device, short_side=short_side)
+        return cls(
+            model=model,
+            device=resolved_device,
+            task=task,
+            short_side=short_side,
+        )
 
-    def preprocess(self, image: np.ndarray | Image.Image) -> tuple[Tensor, int, int]:
-        """Preprocess image for inference.
-
-        Returns
-        -------
-        tuple
-            (tensor ``[1, 3, H', W']``, original_height, original_width)
-        """
+    def preprocess(
+        self,
+        image: np.ndarray | Image.Image,
+    ) -> tuple[Tensor, int, int, int, int]:
+        """Preprocess image for inference."""
         if isinstance(image, np.ndarray):
             image = Image.fromarray(image)
 
@@ -104,68 +89,54 @@ class CourtKeypointPredictor(BasePredictor):
 
         img_tensor = TF.to_tensor(image)
         img_tensor = TF.normalize(img_tensor, IMAGENET_MEAN, IMAGENET_STD)
-        return img_tensor.unsqueeze(0).to(self.device), orig_h, orig_w
+        return img_tensor.unsqueeze(0).to(self.device), orig_h, orig_w, new_h, new_w
 
     @torch.no_grad()
     def predict(
         self,
         image: np.ndarray | Image.Image | Tensor,
-        return_heatmaps: bool = False,
+        return_logits: bool = False,
     ) -> dict[str, Tensor]:
-        """Run inference on a single image.
-
-        Returns
-        -------
-        dict
-            - ``keypoints``: ``(K, 2)`` pixel coordinates on CPU.
-            - ``heatmaps`` (optional): ``(K, H, W)`` raw logits on CPU.
-        """
+        """Run inference on a single image."""
         if isinstance(image, (np.ndarray, Image.Image)):
-            image_tensor, orig_h, orig_w = self.preprocess(image)
+            image_tensor, orig_h, orig_w, resized_h, resized_w = self.preprocess(image)
         else:
             image_tensor = image.to(self.device)
             if image_tensor.ndim == 3:
                 image_tensor = image_tensor.unsqueeze(0)
             orig_h, orig_w = image_tensor.shape[-2], image_tensor.shape[-1]
+            resized_h, resized_w = orig_h, orig_w
 
-        logits = self.model(image_tensor)  # [1, K, H, W]
+        logits = self.model(image_tensor)  # [1, C, H, W]
+        result: dict[str, Tensor]
 
-        coords = self._heatmaps_to_coords(logits)[0].cpu()  # (K, 2)
-        coords[:, 0] *= orig_w
-        coords[:, 1] *= orig_h
+        if self.task == "kp":
+            coords = self._heatmaps_to_coords(logits)[0].cpu()
+            coords[:, 0] *= orig_w / resized_w
+            coords[:, 1] *= orig_h / resized_h
+            result = {"keypoints": coords}
+        elif self.task == "seg":
+            result = {"mask": logits.argmax(dim=1)[0].cpu()}
+        elif self.task == "line":
+            result = {"mask": torch.sigmoid(logits)[0, 0].cpu()}
+        else:
+            raise ValueError(f"Unsupported task: {self.task}")
 
-        result: dict[str, Tensor] = {"keypoints": coords}
-        if return_heatmaps:
-            result["heatmaps"] = logits[0].cpu()
+        if return_logits:
+            result["logits"] = logits[0].cpu()
         return result
 
     @staticmethod
     def _heatmaps_to_coords(heatmaps: Tensor) -> Tensor:
-        """Convert heatmaps to keypoint coordinates using soft-argmax.
-
-        Parameters
-        ----------
-        heatmaps:
-            ``[B, K, H, W]`` raw logits.
-
-        Returns
-        -------
-        Tensor
-            ``[B, K, 2]`` in normalised ``[0, 1]`` range.
-        """
-        bsz, num_kp, height, width = heatmaps.shape
-        device = heatmaps.device
-
+        """Convert heatmaps to keypoint coordinates using per-channel argmax."""
+        bsz, num_kp, _, width = heatmaps.shape
         heatmaps_flat = heatmaps.view(bsz, num_kp, -1)
-        probs = F.softmax(heatmaps_flat, dim=-1)
-
-        y_coords = torch.linspace(0, 1, height, device=device)
-        x_coords = torch.linspace(0, 1, width, device=device)
-        yy, xx = torch.meshgrid(y_coords, x_coords, indexing="ij")
-        xx_flat = xx.reshape(-1)
-        yy_flat = yy.reshape(-1)
-
-        x = (probs * xx_flat.view(1, 1, -1)).sum(dim=-1)
-        y = (probs * yy_flat.view(1, 1, -1)).sum(dim=-1)
-
+        max_idx = heatmaps_flat.argmax(dim=-1)
+        x = (max_idx % width).float()
+        y = torch.div(max_idx, width, rounding_mode="floor").float()
         return torch.stack([x, y], dim=-1)
+
+
+class CourtKeypointPredictor(CourtDetectionPredictor):
+    """Backward-compatible alias for keypoint predictor usage."""
+

--- a/src/tasks/court_detection/scripts/eval.py
+++ b/src/tasks/court_detection/scripts/eval.py
@@ -1,0 +1,238 @@
+"""Evaluate a court detection model on a random subset of the dataset.
+
+Loads a Lightning checkpoint, samples N items from the selected split, runs
+inference, and saves task-specific visualisations under the configured output
+directory.
+
+Usage:
+    python -m src.tasks.court_detection.scripts.eval task=kp checkpoint=<path/to/model.ckpt>
+    python -m src.tasks.court_detection.scripts.eval task=seg checkpoint=<ckpt> num_samples=20 split=val
+    python -m src.tasks.court_detection.scripts.eval task=line checkpoint=<ckpt> device=cpu
+
+Notes:
+    - Hydra loads configuration from ``src/tasks/court_detection/configs/eval.yaml``.
+    - ``task`` must be specified explicitly and must match the checkpoint task.
+    - ``num_samples=-1`` evaluates the entire split.
+    - Seg/line overlays share the same alpha-blend helper.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from pathlib import Path
+
+import cv2
+import hydra
+import numpy as np
+import torch
+from omegaconf import DictConfig
+from PIL import Image, ImageDraw
+
+from src.tasks.court_detection.data.court_kp_dataset import CourtKPDataset
+from src.tasks.court_detection.data.court_line_dataset import CourtLineDataset
+from src.tasks.court_detection.data.court_seg_dataset import CourtSegDataset
+from src.tasks.court_detection.inference import CourtDetectionPredictor
+
+_SEG_PALETTE = np.array([
+    [0, 0, 0],
+    [255, 100, 100],
+    [100, 100, 255],
+    [100, 255, 100],
+    [255, 255, 100],
+    [255, 100, 255],
+    [100, 255, 255],
+], dtype=np.uint8)
+
+
+def _save_heatmap_grid(
+    heatmaps: torch.Tensor,
+    save_path: Path,
+    ncols: int = 7,
+) -> None:
+    """Save all keypoint heatmaps as a single grid PNG."""
+    k, h, w = heatmaps.shape
+    nrows = math.ceil(k / ncols)
+    grid = Image.new("L", (ncols * w, nrows * h), color=0)
+
+    for idx in range(k):
+        ch = heatmaps[idx].float()
+        ch_min, ch_max = ch.min(), ch.max()
+        if ch_max > ch_min:
+            ch = (ch - ch_min) / (ch_max - ch_min)
+        else:
+            ch = torch.zeros_like(ch)
+        arr = (ch.numpy() * 255).astype(np.uint8)
+        tile = Image.fromarray(arr, mode="L")
+        row, col = divmod(idx, ncols)
+        grid.paste(tile, (col * w, row * h))
+
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    grid.save(save_path)
+
+
+def _save_kp_overlay(
+    original_image: Image.Image,
+    keypoints: torch.Tensor,
+    save_path: Path,
+    radius: int = 6,
+) -> None:
+    """Save the original image with predicted keypoints overlaid."""
+    img = original_image.convert("RGB").copy()
+    draw = ImageDraw.Draw(img)
+    for x, y in keypoints.numpy():
+        x0, y0 = float(x) - radius, float(y) - radius
+        x1, y1 = float(x) + radius, float(y) + radius
+        draw.ellipse([x0, y0, x1, y1], outline=(255, 0, 0), width=2)
+
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(save_path)
+
+
+def _colorize_seg_mask(mask: np.ndarray) -> np.ndarray:
+    """Map label mask ``[H, W]`` to an RGB image."""
+    return _SEG_PALETTE[mask]
+
+
+def _colorize_line_heatmap(mask: np.ndarray) -> np.ndarray:
+    """Map line probability heatmap ``[H, W]`` to an RGB image."""
+    heatmap_u8 = np.clip(mask * 255.0, 0, 255).astype(np.uint8)
+    return cv2.cvtColor(
+        cv2.applyColorMap(heatmap_u8, cv2.COLORMAP_JET),
+        cv2.COLOR_BGR2RGB,
+    )
+
+
+def _save_rgb_image(image: np.ndarray, save_path: Path) -> None:
+    """Save an RGB uint8 image."""
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(image).save(save_path)
+
+
+def _alpha_blend_overlay(
+    original_image: Image.Image,
+    overlay_rgb: np.ndarray,
+    alpha: float = 0.45,
+) -> Image.Image:
+    """Alpha-blend an RGB overlay onto the original image."""
+    base = np.asarray(original_image.convert("RGB"), dtype=np.uint8)
+    if overlay_rgb.shape[:2] != base.shape[:2]:
+        overlay_rgb = cv2.resize(
+            overlay_rgb,
+            (base.shape[1], base.shape[0]),
+            interpolation=cv2.INTER_NEAREST,
+        )
+
+    blended = (
+        base.astype(np.float32) * (1.0 - alpha) +
+        overlay_rgb.astype(np.float32) * alpha
+    )
+    return Image.fromarray(np.clip(blended, 0, 255).astype(np.uint8))
+
+
+def _build_dataset(cfg: DictConfig) -> CourtKPDataset | CourtSegDataset | CourtLineDataset:
+    """Build the dataset matching the configured task."""
+    aug_cfg = dict(cfg.get("augmentation", {}))
+    if cfg.task == "kp":
+        return CourtKPDataset(
+            root=cfg.data_dir,
+            split=cfg.split,
+            is_train=False,
+            config=aug_cfg,
+        )
+    if cfg.task == "seg":
+        return CourtSegDataset(
+            root=cfg.data_dir,
+            split=cfg.split,
+            is_train=False,
+            config=aug_cfg,
+        )
+    if cfg.task == "line":
+        return CourtLineDataset(
+            root=cfg.data_dir,
+            split=cfg.split,
+            is_train=False,
+            config=aug_cfg,
+            mask_dir_name=str(cfg.get("mask_dir_name", "line_masks")),
+        )
+    raise ValueError(f"Unsupported task: {cfg.task}")
+
+
+@hydra.main(
+    version_base="1.3",
+    config_path="../configs",
+    config_name="eval",
+)
+def main(cfg: DictConfig) -> None:
+    """Evaluate court detection and save task-specific visual results."""
+    if not cfg.checkpoint:
+        raise ValueError(
+            "checkpoint must be specified. "
+            "Pass checkpoint=<path/to/model.ckpt> on the command line."
+        )
+
+    if not cfg.task:
+        raise ValueError("task must be specified explicitly: kp, seg, or line.")
+
+    output_dir = Path(cfg.output_dir)
+    predictor = CourtDetectionPredictor.load_from_checkpoint(
+        cfg.checkpoint,
+        device=cfg.device,
+    )
+    if predictor.task != cfg.task:
+        raise ValueError(
+            f"Configured task '{cfg.task}' does not match checkpoint task '{predictor.task}'."
+        )
+
+    dataset = _build_dataset(cfg)
+    n = len(dataset)
+    num_samples = int(cfg.num_samples)
+    if num_samples < 0 or num_samples >= n:
+        indices = list(range(n))
+    else:
+        indices = random.sample(range(n), num_samples)
+
+    images_dir = Path(cfg.data_dir) / "images"
+
+    for idx in indices:
+        entry = dataset._entries[idx]
+        image_id: str = entry["id"]
+
+        img_path = images_dir / f"{image_id}.png"
+        if not img_path.exists():
+            img_path = images_dir / f"{image_id}.jpg"
+        original_image = Image.open(img_path).convert("RGB")
+
+        result = predictor.predict(original_image, return_logits=True)
+
+        if cfg.task == "kp":
+            _save_heatmap_grid(
+                result["logits"],
+                output_dir / "heatmaps" / f"{image_id}_heatmap_grid.png",
+            )
+            _save_kp_overlay(
+                original_image,
+                result["keypoints"],
+                output_dir / "overlays" / f"{image_id}_overlay.png",
+            )
+            continue
+
+        if cfg.task == "seg":
+            heatmap_rgb = _colorize_seg_mask(result["mask"].numpy().astype(np.uint8))
+        else:
+            heatmap_rgb = _colorize_line_heatmap(result["mask"].numpy())
+
+        _save_rgb_image(
+            heatmap_rgb,
+            output_dir / "heatmaps" / f"{image_id}_heatmap.png",
+        )
+        overlay = _alpha_blend_overlay(original_image, heatmap_rgb, alpha=float(cfg.alpha))
+        overlay_path = output_dir / "overlays" / f"{image_id}_overlay.png"
+        overlay_path.parent.mkdir(parents=True, exist_ok=True)
+        overlay.save(overlay_path)
+
+    print(f"Saved {len(indices)} results to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Extend `src.tasks.court_detection.scripts.eval` to support `kp`, `seg`, and `line` through an explicit `task` config.
- Unify court detection inference preprocessing while switching keypoint output to argmax-based decoding for correctly scaled overlays.
- Remove keypoint JSON export and standardize eval outputs around heatmaps and overlays.

## Changes

- Add a task-aware `CourtDetectionPredictor` and export it from the inference package.
- Rewrite `eval.py` to share dataset/input handling across tasks and branch only on output formatting.
- Add a shared alpha-blend overlay helper for `seg` and `line`, plus explicit eval config fields such as `task` and `alpha`.

## Validation

- `.venv/bin/python -m py_compile src/tasks/court_detection/inference/predictor.py src/tasks/court_detection/scripts/eval.py`
- `.venv/bin/python -m src.tasks.court_detection.scripts.eval task=kp 'checkpoint="outputs/court_detection/kp/logs/version_2/checkpoints/court-detection-epoch=50.ckpt"' num_samples=1 device=cpu output_dir=outputs/court_detection/eval_smoke`
- `.venv/bin/python - <<'PY' ... CourtDetectionPredictor.load_from_checkpoint(...).predict(..., return_logits=True) ... PY`

## Related Issues

- References #
