### PR TITLE
refactor: Unify spatial heatmap utilities

### DIFF
--- a/src/tasks/ball_detection/README.md
+++ b/src/tasks/ball_detection/README.md
@@ -14,7 +14,7 @@ Ball Detection は、テニス動画からボール位置ヒートマップを�
 | モジュール | キー | 形状 | 説明 |
 |-----------|------|------|------|
 | `BallDetectionDataset` | `images` | `(B, T, 3, H, W)` | RGB 時系列入力 |
-| `BallDetectionDataset` | `heatmaps` | `(B, T, Hh, Wh)` | 教師ヒートマップ |
+| `BallDetectionDataset` | `heatmaps` | `(B, T, Hh, Wh)` | 正規化座標から共有 utils で生成した教師ヒートマップ |
 | `BallDetectionDataset` | `coords` | `(B, T, 2)` | 元画像ピクセル座標の GT |
 | `BallDetectionDataset` | `visibility` | `(B, T)` | 各フレームのボール可視フラグ |
 | `BallDetectionDataset` | `original_size` | `(B, 2)` | 元画像サイズ `(width, height)` |
@@ -31,7 +31,7 @@ Ball Detection は、テニス動画からボール位置ヒートマップを�
 **学習・評価での扱い:**
 
 - 学習時は `sigmoid(logits)` をヒートマップ確率として扱います。
-- 評価時はヒートマップ peak を元画像座標へ戻し、`precision / recall / f1 / mean_distance_px`
+- 評価時は `src/utils/data/heatmaps.py` の hard argmax で正規化座標を復元し、元画像座標へ戻して `precision / recall / f1 / mean_distance_px`
   を計算します。
 
 ## 実行コマンド

--- a/src/tasks/ball_detection/configs/data/rgb_sequence.yaml
+++ b/src/tasks/ball_detection/configs/data/rgb_sequence.yaml
@@ -12,7 +12,7 @@ sample_stride: 4
 
 image_size: [288, 512]
 heatmap_size: [288, 512]
-gaussian_variance: 15.0
+sigma_ratio: 0.012
 
 augmentation:
   camera_rotation:

--- a/src/tasks/ball_detection/configs/preview_heatmaps.yaml
+++ b/src/tasks/ball_detection/configs/preview_heatmaps.yaml
@@ -1,0 +1,28 @@
+defaults:
+  - model: stunet
+  - data: rgb_sequence
+  - _self_
+
+hydra:
+  run:
+    dir: ${preview.output_dir}/${now:%Y-%m-%d_%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false
+
+preview:
+  split: train
+  sample_indices: [0, 4, 8]
+  max_samples: 3
+  ratios: [0.003, 0.006, 0.012, 0.024]
+  output_dir: outputs/ball_detection/heatmap_preview
+  layout:
+    tile_gap: 12
+    header_height: 30
+    text_scale: 0.55
+    text_thickness: 1
+    background_rgb: [24, 24, 24]
+  draw:
+    gt_radius: 5
+    argmax_radius: 4
+    thickness: 2

--- a/src/tasks/ball_detection/data/dataset.py
+++ b/src/tasks/ball_detection/data/dataset.py
@@ -21,6 +21,7 @@ from src.tasks.ball_detection.data.argumentation import (
     make_sample_rng,
 )
 from src.tasks.ball_detection.data.types import BallDetectionSample
+from src.utils.data.heatmaps import generate_gaussian_heatmap
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -86,14 +87,14 @@ class BallDetectionDataset(Dataset[BallDetectionSample]):
         self.sample_stride = int(data_cfg.get("sample_stride", 1))
         self.image_size = self._parse_size(data_cfg.get("image_size", [288, 512]), name="data.image_size")
         self.heatmap_size = self._parse_size(data_cfg.get("heatmap_size", [144, 256]), name="data.heatmap_size")
-        self.gaussian_variance = float(data_cfg.get("gaussian_variance", 1.0))
+        self.sigma_ratio = float(data_cfg.get("sigma_ratio", 0.0066))
 
         if self.num_frames <= 0:
             raise ValueError("model.num_frames must be positive.")
         if self.sample_stride <= 0:
             raise ValueError("data.sample_stride must be positive.")
-        if self.gaussian_variance <= 0:
-            raise ValueError("data.gaussian_variance must be positive.")
+        if self.sigma_ratio <= 0:
+            raise ValueError("data.sigma_ratio must be positive.")
 
         self.windows = self._build_windows()
         if self.pseudo_manifest_paths:
@@ -145,17 +146,16 @@ class BallDetectionDataset(Dataset[BallDetectionSample]):
         coords_original: list[tuple[float, float]] = []
         for frame, (x_img, y_img), vis in zip(frames_hwc, coords_image, visibility):
             image_tensors.append(np.transpose(frame, (2, 0, 1)))
+            center_xy = self._to_normalized_xy(x_img=x_img, y_img=y_img, width=image_w, height=image_h)
+            heatmaps.append(
+                generate_gaussian_heatmap(
+                    size_hw=self.heatmap_size,
+                    center_xy=center_xy,
+                    sigma_ratio=self.sigma_ratio,
+                    visible=vis > 0,
+                ).cpu().numpy()
+            )
             if vis > 0:
-                x_hm = x_img * heatmap_w / image_w
-                y_hm = y_img * heatmap_h / image_h
-                heatmaps.append(
-                    self._generate_heatmap(
-                        height=heatmap_h,
-                        width=heatmap_w,
-                        center_x=x_hm,
-                        center_y=y_hm,
-                    )
-                )
                 coords_original.append(
                     (
                         x_img * original_w / max(image_w, 1),
@@ -163,7 +163,6 @@ class BallDetectionDataset(Dataset[BallDetectionSample]):
                     )
                 )
             else:
-                heatmaps.append(np.zeros((heatmap_h, heatmap_w), dtype=np.float32))
                 coords_original.append((0.0, 0.0))
 
         sample: BallDetectionSample = {
@@ -325,21 +324,23 @@ class BallDetectionDataset(Dataset[BallDetectionSample]):
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         return image.astype(np.float32) / 255.0
 
-    def _generate_heatmap(
-        self,
+    @staticmethod
+    def _to_normalized_xy(
         *,
-        height: int,
+        x_img: float,
+        y_img: float,
         width: int,
-        center_x: float,
-        center_y: float,
-    ) -> np.ndarray:
-        x = np.arange(0, width, 1, float)
-        y = np.arange(0, height, 1, float)
-        y, x = np.meshgrid(y, x, indexing='ij')
-        sigma_sq2 = 2 * self.gaussian_variance
-        heatmap = np.exp(-((x - center_x)**2 + (y - center_y)**2) / sigma_sq2)
-
-        return heatmap
+        height: int,
+    ) -> tuple[float, float]:
+        if width <= 1:
+            x_norm = 0.0
+        else:
+            x_norm = x_img / float(width - 1)
+        if height <= 1:
+            y_norm = 0.0
+        else:
+            y_norm = y_img / float(height - 1)
+        return x_norm, y_norm
 
     @staticmethod
     def _parse_size(value: Any, *, name: str) -> tuple[int, int]:

--- a/src/tasks/ball_detection/inference/predictor.py
+++ b/src/tasks/ball_detection/inference/predictor.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from typing import Any, Self
 
 import torch
-import torch.nn.functional as F
 from torch import Tensor
 
 from src.tasks.ball_detection.data.utils.input_adapter import to_model_input
 from src.tasks.ball_detection.training.lightning_module import BallDetectionLightningModule
 from src.tasks.base.inference.predictor import BasePredictor
+from src.utils.data.heatmaps import heatmaps_to_argmax
 
 
 class BallDetectionPredictor(BasePredictor):
@@ -88,7 +88,7 @@ class BallDetectionPredictor(BasePredictor):
 
         Returns:
             Dictionary with CPU tensors:
-                - ``coords``: Predicted peak coordinates in heatmap space,
+                - ``coords``: Predicted normalized peak coordinates,
                   shape ``(B, T, 2)`` as ``(x, y)``.
                 - ``visibility``: Peak confidence per frame, shape ``(B, T)``.
                 - ``heatmaps``: Probability heatmaps ``(B, T, H, W)`` if
@@ -100,13 +100,7 @@ class BallDetectionPredictor(BasePredictor):
         # (B, 1, T, H, W) -> (B, T, H, W)
         logits = logits.squeeze(1)
         heatmaps = torch.sigmoid(logits)
-
-        b, t, h, w = heatmaps.shape
-        flat = heatmaps.reshape(b, t, -1)
-        peak_values, peak_indices = flat.max(dim=-1)
-        pred_x = (peak_indices % w).float()
-        pred_y = torch.div(peak_indices, w, rounding_mode="floor").float()
-        coords = torch.stack([pred_x, pred_y], dim=-1)
+        coords, peak_values = heatmaps_to_argmax(heatmaps)
 
         result: dict[str, Tensor] = {
             "coords": coords.cpu(),

--- a/src/tasks/ball_detection/scripts/preview_heatmaps.py
+++ b/src/tasks/ball_detection/scripts/preview_heatmaps.py
@@ -1,0 +1,259 @@
+"""Render qualitative ball heatmap previews for multiple sigma ratios.
+
+Usage:
+    python -m src.tasks.ball_detection.scripts.preview_heatmaps
+    python -m src.tasks.ball_detection.scripts.preview_heatmaps preview.ratios=[0.004,0.008,0.016]
+    python -m src.tasks.ball_detection.scripts.preview_heatmaps preview.sample_indices=[10,20] preview.split=val
+
+Notes:
+    - Hydra loads configuration from `src/tasks/ball_detection/configs/preview_heatmaps.yaml`.
+    - The script renders one representative frame per selected sample window.
+    - Each panel overlays a generated heatmap and argmax point on the source frame.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar, cast
+
+import cv2
+import hydra
+import numpy as np
+import torch
+from omegaconf import DictConfig
+
+from src.tasks.ball_detection.data.dataset import BallDetectionDataset
+from src.utils.data.heatmaps import generate_gaussian_heatmap, heatmaps_to_argmax
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
+    """Typed wrapper for ``hydra.main``."""
+    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+
+
+@hydra_main(
+    config_path="../configs",
+    config_name="preview_heatmaps",
+    version_base="1.3",
+)
+def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
+    """Hydra entry point."""
+    output_dir = Path(str(cfg.preview.output_dir)).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    split_name = str(cfg.preview.split)
+    dataset = BallDetectionDataset(
+        data_dir=cfg.data.data_dir,
+        split_file=_resolve_split_file(cfg, split_name),
+        config=cfg,
+        argumentation=None,
+    )
+    sample_indices = _resolve_sample_indices(cfg, len(dataset))
+
+    manifest: list[dict[str, Any]] = []
+    for sample_index in sample_indices:
+        sample = dataset[sample_index]
+        frame_index = _select_frame_index(sample["visibility"])
+        image = _tensor_to_image(sample["images"][frame_index])
+        height, width = image.shape[:2]
+
+        original_size = sample["original_size"].cpu().numpy()
+        original_w = float(original_size[0])
+        original_h = float(original_size[1])
+        center_xy = (
+            float(sample["coords"][frame_index, 0].item() / max(original_w - 1.0, 1.0)),
+            float(sample["coords"][frame_index, 1].item() / max(original_h - 1.0, 1.0)),
+        )
+        visible = bool(sample["visibility"][frame_index].item() > 0.5)
+
+        panels = [_annotate_original(image, center_xy, visible, cfg)]
+        ratios = [float(value) for value in cfg.preview.ratios]
+        ratio_records: list[dict[str, Any]] = []
+        for sigma_ratio in ratios:
+            heatmap = generate_gaussian_heatmap(
+                size_hw=(height, width),
+                center_xy=center_xy,
+                sigma_ratio=sigma_ratio,
+                visible=visible,
+            )
+            argmax_xy, peak_value = heatmaps_to_argmax(heatmap)
+            panel = _render_ratio_panel(
+                image=image,
+                heatmap=heatmap,
+                sigma_ratio=sigma_ratio,
+                gt_center_xy=center_xy,
+                argmax_xy=tuple(float(v) for v in argmax_xy.tolist()),
+                peak_value=float(peak_value.item()),
+                cfg=cfg,
+            )
+            panels.append(panel)
+            ratio_records.append(
+                {
+                    "sigma_ratio": sigma_ratio,
+                    "argmax_xy": tuple(float(v) for v in argmax_xy.tolist()),
+                    "peak_value": float(peak_value.item()),
+                }
+            )
+
+        canvas = _compose_row(panels, ["original", *[f"ratio={ratio:.4f}" for ratio in ratios]], cfg)
+        file_stem = f"sample_{sample_index:05d}_frame_{frame_index:02d}"
+        image_path = output_dir / f"{file_stem}.png"
+        cv2.imwrite(str(image_path), cv2.cvtColor(canvas, cv2.COLOR_RGB2BGR))
+
+        window = dataset.windows[sample_index]
+        manifest.append(
+            {
+                "sample_index": sample_index,
+                "frame_index": frame_index,
+                "clip_dir": str(window.clip_dir),
+                "frame_name": window.frame_names[window.start_index + frame_index],
+                "output_image": str(image_path),
+                "visible": visible,
+                "center_xy": center_xy,
+                "ratios": ratio_records,
+            }
+        )
+
+    (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(f"Saved {len(manifest)} ball heatmap preview(s) to {output_dir}")
+    return 0
+
+
+def _resolve_split_file(cfg: DictConfig, split_name: str) -> str:
+    split_cfg = cfg.data.split
+    key = f"{split_name}_file"
+    if key not in split_cfg:
+        available = ", ".join(sorted(split_cfg.keys()))
+        raise ValueError(f"Unknown preview.split={split_name!r}. Available: {available}")
+    return str(split_cfg[key])
+
+
+def _resolve_sample_indices(cfg: DictConfig, dataset_size: int) -> list[int]:
+    explicit = [int(value) for value in cfg.preview.sample_indices]
+    if explicit:
+        sample_indices = explicit
+    else:
+        sample_indices = list(range(min(int(cfg.preview.max_samples), dataset_size)))
+    for sample_index in sample_indices:
+        if sample_index < 0 or sample_index >= dataset_size:
+            raise IndexError(f"preview sample_index={sample_index} is out of range for dataset size {dataset_size}.")
+    return sample_indices
+
+
+def _select_frame_index(visibility: torch.Tensor) -> int:
+    visible_indices = torch.nonzero(visibility > 0.5, as_tuple=False).flatten()
+    if len(visible_indices) > 0:
+        return int(visible_indices[0].item())
+    return 0
+
+
+def _tensor_to_image(image: torch.Tensor) -> np.ndarray:
+    image_np = image.detach().cpu().permute(1, 2, 0).numpy()
+    image_np = np.clip(image_np * 255.0, 0, 255).astype(np.uint8)
+    return image_np
+
+
+def _annotate_original(
+    image: np.ndarray,
+    center_xy: tuple[float, float],
+    visible: bool,
+    cfg: DictConfig,
+) -> np.ndarray:
+    canvas = image.copy()
+    if visible:
+        _draw_point(
+            canvas,
+            center_xy,
+            radius=int(cfg.preview.draw.gt_radius),
+            color=(255, 80, 80),
+            thickness=int(cfg.preview.draw.thickness),
+        )
+    return canvas
+
+
+def _render_ratio_panel(
+    *,
+    image: np.ndarray,
+    heatmap: torch.Tensor,
+    sigma_ratio: float,
+    gt_center_xy: tuple[float, float],
+    argmax_xy: tuple[float, float],
+    peak_value: float,
+    cfg: DictConfig,
+) -> np.ndarray:
+    overlay = image.copy()
+    heatmap_np = np.clip(heatmap.detach().cpu().numpy(), 0.0, 1.0)
+    heatmap_cm = cv2.applyColorMap((heatmap_np * 255).astype(np.uint8), cv2.COLORMAP_JET)
+    heatmap_cm = cv2.cvtColor(heatmap_cm, cv2.COLOR_BGR2RGB)
+    overlay = cv2.addWeighted(overlay, 0.55, heatmap_cm, 0.45, 0.0)
+
+    if peak_value > 0:
+        _draw_point(
+            overlay,
+            argmax_xy,
+            radius=int(cfg.preview.draw.argmax_radius),
+            color=(80, 255, 120),
+            thickness=int(cfg.preview.draw.thickness),
+        )
+        _draw_point(
+            overlay,
+            gt_center_xy,
+            radius=int(cfg.preview.draw.gt_radius),
+            color=(255, 80, 80),
+            thickness=1,
+        )
+    return overlay
+
+
+def _draw_point(
+    image: np.ndarray,
+    center_xy: tuple[float, float],
+    *,
+    radius: int,
+    color: tuple[int, int, int],
+    thickness: int,
+) -> None:
+    height, width = image.shape[:2]
+    x_px = int(round(center_xy[0] * max(width - 1, 0)))
+    y_px = int(round(center_xy[1] * max(height - 1, 0)))
+    cv2.circle(image, (x_px, y_px), radius, color, thickness=thickness, lineType=cv2.LINE_AA)
+
+
+def _compose_row(
+    panels: list[np.ndarray],
+    titles: list[str],
+    cfg: DictConfig,
+) -> np.ndarray:
+    tile_gap = int(cfg.preview.layout.tile_gap)
+    header_height = int(cfg.preview.layout.header_height)
+    text_scale = float(cfg.preview.layout.text_scale)
+    text_thickness = int(cfg.preview.layout.text_thickness)
+    background_rgb = tuple(int(v) for v in cfg.preview.layout.background_rgb)
+
+    height, width = panels[0].shape[:2]
+    row_width = len(panels) * width + (len(panels) - 1) * tile_gap
+    canvas = np.full((header_height + height, row_width, 3), background_rgb, dtype=np.uint8)
+
+    cursor_x = 0
+    for panel, title in zip(panels, titles, strict=True):
+        canvas[header_height:, cursor_x : cursor_x + width] = panel
+        cv2.putText(
+            canvas,
+            title,
+            (cursor_x + 6, max(header_height - 8, 12)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            text_scale,
+            (245, 245, 245),
+            text_thickness,
+            lineType=cv2.LINE_AA,
+        )
+        cursor_x += width + tile_gap
+    return canvas
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src/tasks/ball_detection/training/lightning_module.py
+++ b/src/tasks/ball_detection/training/lightning_module.py
@@ -100,7 +100,6 @@ class BallDetectionLightningModule(BaseLightningModule):
             "target_coords": batch["coords"],
             "target_visibility": batch["visibility"],
             "original_size": batch["original_size"],
-            "heatmap_size": batch["heatmap_size"],
         }
 
     def training_step(self, batch: dict[str, Tensor], batch_idx: int) -> Tensor:
@@ -111,7 +110,6 @@ class BallDetectionLightningModule(BaseLightningModule):
             outputs["target_coords"],
             outputs["target_visibility"],
             outputs["original_size"],
-            outputs["heatmap_size"],
         )
         return outputs["loss"]
 
@@ -130,7 +128,6 @@ class BallDetectionLightningModule(BaseLightningModule):
             outputs["target_coords"],
             outputs["target_visibility"],
             outputs["original_size"],
-            outputs["heatmap_size"],
         )
 
     def on_validation_epoch_end(self) -> None:
@@ -148,7 +145,6 @@ class BallDetectionLightningModule(BaseLightningModule):
             outputs["target_coords"],
             outputs["target_visibility"],
             outputs["original_size"],
-            outputs["heatmap_size"],
         )
 
     def on_test_epoch_end(self) -> None:

--- a/src/tasks/ball_detection/training/metrics.py
+++ b/src/tasks/ball_detection/training/metrics.py
@@ -6,6 +6,8 @@ import torch
 from torch import Tensor
 from torchmetrics import Metric
 
+from src.utils.data.heatmaps import heatmaps_to_argmax
+
 
 class BallDetectionMetrics(Metric):
     """Distance-based frame metrics derived from predicted heatmaps.
@@ -43,7 +45,6 @@ class BallDetectionMetrics(Metric):
         target_coords: Tensor,
         target_visibility: Tensor,
         original_size: Tensor,
-        heatmap_size: Tensor,
     ) -> None:
         """Update frame-level metric state.
 
@@ -53,8 +54,6 @@ class BallDetectionMetrics(Metric):
                 shape (B, T, 2).
             target_visibility: Target visibility flags, shape (B, T).
             original_size: Original frame size in ``(width, height)`` ordering,
-                shape (B, 2).
-            heatmap_size: Heatmap size in ``(width, height)`` ordering,
                 shape (B, 2).
         """
         if pred_heatmaps.ndim != 4:
@@ -77,30 +76,19 @@ class BallDetectionMetrics(Metric):
                 "original_size must have shape (B, 2), "
                 f"got {tuple(original_size.shape)}."
             )
-        if heatmap_size.shape != (pred_heatmaps.shape[0], 2):
-            raise ValueError(
-                "heatmap_size must have shape (B, 2), "
-                f"got {tuple(heatmap_size.shape)}."
-            )
 
-        batch_size, num_frames, _, width = pred_heatmaps.shape
-        flat_heatmaps = pred_heatmaps.reshape(batch_size, num_frames, -1)
-        peak_values, peak_indices = flat_heatmaps.max(dim=-1)
-        pred_x = (peak_indices % width).to(target_coords.dtype)
-        pred_y = torch.div(peak_indices, width, rounding_mode="floor").to(target_coords.dtype)
-        pred_coords = torch.stack([pred_x, pred_y], dim=-1)
+        batch_size = pred_heatmaps.shape[0]
+        pred_coords_normalized, peak_values = heatmaps_to_argmax(pred_heatmaps)
 
-        heatmap_width = heatmap_size[:, 0].view(batch_size, 1)
-        heatmap_height = heatmap_size[:, 1].view(batch_size, 1)
         original_width = original_size[:, 0].view(batch_size, 1)
         original_height = original_size[:, 1].view(batch_size, 1)
 
-        pred_coords_original = torch.empty_like(pred_coords)
-        pred_coords_original[..., 0] = pred_coords[..., 0] * original_width / torch.clamp(
-            heatmap_width, min=1.0
+        pred_coords_original = torch.empty_like(pred_coords_normalized, dtype=target_coords.dtype)
+        pred_coords_original[..., 0] = pred_coords_normalized[..., 0].to(target_coords.dtype) * (
+            torch.clamp(original_width - 1.0, min=0.0)
         )
-        pred_coords_original[..., 1] = pred_coords[..., 1] * original_height / torch.clamp(
-            heatmap_height, min=1.0
+        pred_coords_original[..., 1] = pred_coords_normalized[..., 1].to(target_coords.dtype) * (
+            torch.clamp(original_height - 1.0, min=0.0)
         )
 
         distances_original = torch.norm(pred_coords_original - target_coords, dim=-1)

--- a/src/tasks/court_detection/configs/data/court_kp.yaml
+++ b/src/tasks/court_detection/configs/data/court_kp.yaml
@@ -5,7 +5,7 @@ num_workers: 4
 pin_memory: true
 
 num_keypoints: 14
-gaussian_sigma: 3.0
+sigma_ratio: 0.012
 
 hflip_swap_pairs:
   - [0, 1]

--- a/src/tasks/court_detection/configs/preview_heatmaps.yaml
+++ b/src/tasks/court_detection/configs/preview_heatmaps.yaml
@@ -1,0 +1,27 @@
+defaults:
+  - data: court_kp
+  - _self_
+
+hydra:
+  run:
+    dir: ${preview.output_dir}/${now:%Y-%m-%d_%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false
+
+preview:
+  split: train
+  sample_indices: [0, 8, 16]
+  max_samples: 3
+  ratios: [0.003, 0.006, 0.012, 0.024]
+  output_dir: outputs/court_detection/heatmap_preview
+  layout:
+    tile_gap: 12
+    header_height: 30
+    text_scale: 0.55
+    text_thickness: 1
+    background_rgb: [24, 24, 24]
+  draw:
+    gt_radius: 4
+    argmax_radius: 2
+    thickness: 2

--- a/src/tasks/court_detection/data/court_kp_dataset.py
+++ b/src/tasks/court_detection/data/court_kp_dataset.py
@@ -1,8 +1,4 @@
-"""Court keypoint heatmap dataset.
-
-Loads court images and 14-keypoint annotations, generates per-keypoint
-Gaussian heatmaps after spatial augmentation.
-"""
+"""Court keypoint heatmap dataset."""
 
 from __future__ import annotations
 
@@ -23,45 +19,7 @@ from src.tasks.court_detection.data.augmentation import (
     _pil_to_tensor_image,
     build_kp_transforms,
 )
-
-
-def generate_gaussian_heatmap(
-    h: int,
-    w: int,
-    cx: float,
-    cy: float,
-    sigma: float = 3.0,
-) -> np.ndarray:
-    """Generate a Gaussian heatmap centred at ``(cx, cy)``.
-
-    Returns
-    -------
-    np.ndarray
-        ``(H, W)`` float32 in ``[0, 1]``.
-    """
-    cx_int, cy_int = int(round(cx)), int(round(cy))
-    if cx_int < 0 or cy_int < 0 or cx_int >= w or cy_int >= h:
-        return np.zeros((h, w), dtype=np.float32)
-
-    size = int(3 * sigma)
-    yy, xx = np.mgrid[-size : size + 1, -size : size + 1]
-    kernel = np.exp(-(xx ** 2 + yy ** 2) / (2.0 * sigma ** 2))
-    kernel = kernel / kernel.max()
-
-    heatmap = np.zeros((h, w), dtype=np.float32)
-
-    y_start = max(0, cy_int - size)
-    y_end = min(h, cy_int + size + 1)
-    x_start = max(0, cx_int - size)
-    x_end = min(w, cx_int + size + 1)
-
-    ky_start = size - (cy_int - y_start)
-    ky_end = ky_start + (y_end - y_start)
-    kx_start = size - (cx_int - x_start)
-    kx_end = kx_start + (x_end - x_start)
-
-    heatmap[y_start:y_end, x_start:x_end] = kernel[ky_start:ky_end, kx_start:kx_end]
-    return heatmap
+from src.utils.data.heatmaps import generate_gaussian_heatmaps
 
 
 class CourtKPDataset(Dataset):
@@ -99,7 +57,7 @@ class CourtKPDataset(Dataset):
             self._entries: list[dict] = json.load(f)
 
         cfg = config or {}
-        self.gaussian_sigma = cfg.get("gaussian_sigma", 3.0)
+        self.sigma_ratio = float(cfg.get("sigma_ratio", 0.01))
 
         self.spatial_transforms, self.image_transforms = build_kp_transforms(
             is_train=is_train,
@@ -141,19 +99,29 @@ class CourtKPDataset(Dataset):
             img = t(img)
 
         w, h = img.size
-        heatmaps = np.zeros((len(kps), h, w), dtype=np.float32)
-        for k_idx, (cx, cy) in enumerate(kps):
-            heatmaps[k_idx] = generate_gaussian_heatmap(
-                h, w, float(cx), float(cy), sigma=self.gaussian_sigma,
-            )
-
         img_tensor = _pil_to_tensor_image(img)
         img_tensor = TF.normalize(img_tensor, IMAGENET_MEAN, IMAGENET_STD)
-        heatmap_tensor = torch.from_numpy(heatmaps)
+        kps_tensor = torch.from_numpy(kps)
+
+        normalized_kps = kps_tensor.clone()
+        if w > 1:
+            normalized_kps[:, 0] = normalized_kps[:, 0] / float(w - 1)
+        else:
+            normalized_kps[:, 0] = 0.0
+        if h > 1:
+            normalized_kps[:, 1] = normalized_kps[:, 1] / float(h - 1)
+        else:
+            normalized_kps[:, 1] = 0.0
+
+        heatmap_tensor = generate_gaussian_heatmaps(
+            size_hw=(h, w),
+            centers_xy=normalized_kps,
+            sigma_ratio=self.sigma_ratio,
+        )
 
         return {
             "image": img_tensor,
             "heatmap": heatmap_tensor,
-            "keypoints": torch.from_numpy(kps),
+            "keypoints": kps_tensor,
             "image_id": image_id,
         }

--- a/src/tasks/court_detection/data/datamodule.py
+++ b/src/tasks/court_detection/data/datamodule.py
@@ -139,7 +139,7 @@ class CourtDetectionDataModule(pl.LightningDataModule):
             "gaussian_blur_kernel": list(aug_cfg.get("gaussian_blur_kernel", [3, 5, 7, 9])),
             "gaussian_blur_sigma": tuple(aug_cfg.get("gaussian_blur_sigma", (0.1, 3.0))),
             "gaussian_blur_prob": float(aug_cfg.get("gaussian_blur_prob", 0.5)),
-            "gaussian_sigma": float(self.config.get("data", {}).get("gaussian_sigma", 3.0)),
+            "sigma_ratio": float(self.config.get("data", {}).get("sigma_ratio", 0.01)),
         }
 
     def setup(self, stage: str | None = None) -> None:

--- a/src/tasks/court_detection/inference/predictor.py
+++ b/src/tasks/court_detection/inference/predictor.py
@@ -8,7 +8,6 @@ from typing import Any, Self
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 import torchvision.transforms.functional as TF
 from PIL import Image
 from torch import Tensor
@@ -18,6 +17,7 @@ from src.tasks.court_detection.data.augmentation import IMAGENET_MEAN, IMAGENET_
 from src.tasks.court_detection.training.lightning_module import (
     CourtDetectionLightningModule,
 )
+from src.utils.data.heatmaps import heatmaps_to_argmax
 
 
 class CourtKeypointPredictor(BasePredictor):
@@ -131,8 +131,14 @@ class CourtKeypointPredictor(BasePredictor):
         logits = self.model(image_tensor)  # [1, K, H, W]
 
         coords = self._heatmaps_to_coords(logits)[0].cpu()  # (K, 2)
-        coords[:, 0] *= orig_w
-        coords[:, 1] *= orig_h
+        if orig_w > 1:
+            coords[:, 0] *= float(orig_w - 1)
+        else:
+            coords[:, 0] = 0.0
+        if orig_h > 1:
+            coords[:, 1] *= float(orig_h - 1)
+        else:
+            coords[:, 1] = 0.0
 
         result: dict[str, Tensor] = {"keypoints": coords}
         if return_heatmaps:
@@ -141,7 +147,7 @@ class CourtKeypointPredictor(BasePredictor):
 
     @staticmethod
     def _heatmaps_to_coords(heatmaps: Tensor) -> Tensor:
-        """Convert heatmaps to keypoint coordinates using soft-argmax.
+        """Convert heatmaps to normalized keypoint coordinates via argmax.
 
         Parameters
         ----------
@@ -153,19 +159,5 @@ class CourtKeypointPredictor(BasePredictor):
         Tensor
             ``[B, K, 2]`` in normalised ``[0, 1]`` range.
         """
-        bsz, num_kp, height, width = heatmaps.shape
-        device = heatmaps.device
-
-        heatmaps_flat = heatmaps.view(bsz, num_kp, -1)
-        probs = F.softmax(heatmaps_flat, dim=-1)
-
-        y_coords = torch.linspace(0, 1, height, device=device)
-        x_coords = torch.linspace(0, 1, width, device=device)
-        yy, xx = torch.meshgrid(y_coords, x_coords, indexing="ij")
-        xx_flat = xx.reshape(-1)
-        yy_flat = yy.reshape(-1)
-
-        x = (probs * xx_flat.view(1, 1, -1)).sum(dim=-1)
-        y = (probs * yy_flat.view(1, 1, -1)).sum(dim=-1)
-
-        return torch.stack([x, y], dim=-1)
+        coords, _ = heatmaps_to_argmax(heatmaps)
+        return coords

--- a/src/tasks/court_detection/scripts/preview_heatmaps.py
+++ b/src/tasks/court_detection/scripts/preview_heatmaps.py
@@ -1,0 +1,227 @@
+"""Render qualitative court-keypoint heatmap previews for multiple sigma ratios.
+
+Usage:
+    python -m src.tasks.court_detection.scripts.preview_heatmaps
+    python -m src.tasks.court_detection.scripts.preview_heatmaps preview.ratios=[0.004,0.008,0.016]
+    python -m src.tasks.court_detection.scripts.preview_heatmaps preview.sample_indices=[10,20] preview.split=val
+
+Notes:
+    - Hydra loads configuration from `src/tasks/court_detection/configs/preview_heatmaps.yaml`.
+    - The script reads raw court keypoint annotations and images without training augmentation.
+    - Each panel overlays the max-pooled heatmap plus decoded argmax points for all keypoints.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar, cast
+
+import cv2
+import hydra
+import numpy as np
+from omegaconf import DictConfig
+from PIL import Image
+
+from src.utils.data.heatmaps import generate_gaussian_heatmaps, heatmaps_to_argmax
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
+    """Typed wrapper for ``hydra.main``."""
+    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+
+
+@hydra_main(
+    config_path="../configs",
+    config_name="preview_heatmaps",
+    version_base="1.3",
+)
+def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
+    """Hydra entry point."""
+    output_dir = Path(str(cfg.preview.output_dir)).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    data_dir = Path(str(cfg.data.data_dir)).expanduser()
+    entries = json.loads((data_dir / f"data_{cfg.preview.split}.json").read_text(encoding="utf-8"))
+    sample_indices = _resolve_sample_indices(cfg, len(entries))
+
+    manifest: list[dict[str, Any]] = []
+    for sample_index in sample_indices:
+        entry = entries[sample_index]
+        image_id = str(entry["id"])
+        image = _load_image(data_dir, image_id)
+        height, width = image.shape[:2]
+        keypoints = np.asarray(entry["kps"], dtype=np.float32)
+        centers_xy = np.stack(
+            [
+                keypoints[:, 0] / max(width - 1, 1),
+                keypoints[:, 1] / max(height - 1, 1),
+            ],
+            axis=-1,
+        )
+
+        panels = [_annotate_original(image, centers_xy, cfg)]
+        ratios = [float(value) for value in cfg.preview.ratios]
+        ratio_records: list[dict[str, Any]] = []
+        for sigma_ratio in ratios:
+            heatmaps = generate_gaussian_heatmaps(
+                size_hw=(height, width),
+                centers_xy=centers_xy,
+                sigma_ratio=sigma_ratio,
+            )
+            argmax_xy, peak_values = heatmaps_to_argmax(heatmaps)
+            panel = _render_ratio_panel(
+                image=image,
+                heatmaps=heatmaps,
+                gt_centers_xy=centers_xy,
+                argmax_xy=argmax_xy.detach().cpu().numpy(),
+                peak_values=peak_values.detach().cpu().numpy(),
+                cfg=cfg,
+            )
+            panels.append(panel)
+            ratio_records.append(
+                {
+                    "sigma_ratio": sigma_ratio,
+                    "mean_peak_value": float(peak_values.mean().item()),
+                }
+            )
+
+        canvas = _compose_row(panels, ["original", *[f"ratio={ratio:.4f}" for ratio in ratios]], cfg)
+        image_path = output_dir / f"sample_{sample_index:05d}_{image_id}.png"
+        cv2.imwrite(str(image_path), cv2.cvtColor(canvas, cv2.COLOR_RGB2BGR))
+        manifest.append(
+            {
+                "sample_index": sample_index,
+                "image_id": image_id,
+                "output_image": str(image_path),
+                "ratios": ratio_records,
+            }
+        )
+
+    (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(f"Saved {len(manifest)} court heatmap preview(s) to {output_dir}")
+    return 0
+
+
+def _resolve_sample_indices(cfg: DictConfig, dataset_size: int) -> list[int]:
+    explicit = [int(value) for value in cfg.preview.sample_indices]
+    if explicit:
+        sample_indices = explicit
+    else:
+        sample_indices = list(range(min(int(cfg.preview.max_samples), dataset_size)))
+    for sample_index in sample_indices:
+        if sample_index < 0 or sample_index >= dataset_size:
+            raise IndexError(f"preview sample_index={sample_index} is out of range for dataset size {dataset_size}.")
+    return sample_indices
+
+
+def _load_image(data_dir: Path, image_id: str) -> np.ndarray:
+    for extension in (".png", ".jpg", ".jpeg"):
+        image_path = data_dir / "images" / f"{image_id}{extension}"
+        if image_path.exists():
+            with Image.open(image_path) as image:
+                return np.asarray(image.convert("RGB"))
+    raise FileNotFoundError(f"Image not found for image_id={image_id!r} under {data_dir / 'images'}")
+
+
+def _annotate_original(image: np.ndarray, centers_xy: np.ndarray, cfg: DictConfig) -> np.ndarray:
+    canvas = image.copy()
+    for center_xy in centers_xy:
+        _draw_point(
+            canvas,
+            tuple(float(v) for v in center_xy.tolist()),
+            radius=int(cfg.preview.draw.gt_radius),
+            color=(255, 80, 80),
+            thickness=int(cfg.preview.draw.thickness),
+        )
+    return canvas
+
+
+def _render_ratio_panel(
+    *,
+    image: np.ndarray,
+    heatmaps: np.ndarray | Any,
+    gt_centers_xy: np.ndarray,
+    argmax_xy: np.ndarray,
+    peak_values: np.ndarray,
+    cfg: DictConfig,
+) -> np.ndarray:
+    overlay = image.copy()
+    heatmaps_np = np.asarray(heatmaps.detach().cpu().numpy() if hasattr(heatmaps, "detach") else heatmaps)
+    pooled = np.clip(heatmaps_np.max(axis=0), 0.0, 1.0)
+    heatmap_cm = cv2.applyColorMap((pooled * 255).astype(np.uint8), cv2.COLORMAP_JET)
+    heatmap_cm = cv2.cvtColor(heatmap_cm, cv2.COLOR_BGR2RGB)
+    overlay = cv2.addWeighted(overlay, 0.55, heatmap_cm, 0.45, 0.0)
+
+    for center_xy in gt_centers_xy:
+        _draw_point(
+            overlay,
+            tuple(float(v) for v in center_xy.tolist()),
+            radius=int(cfg.preview.draw.gt_radius),
+            color=(255, 80, 80),
+            thickness=1,
+        )
+    for center_xy, peak_value in zip(argmax_xy, peak_values, strict=True):
+        if float(peak_value) <= 0:
+            continue
+        _draw_point(
+            overlay,
+            tuple(float(v) for v in center_xy.tolist()),
+            radius=int(cfg.preview.draw.argmax_radius),
+            color=(80, 255, 120),
+            thickness=int(cfg.preview.draw.thickness),
+        )
+    return overlay
+
+
+def _draw_point(
+    image: np.ndarray,
+    center_xy: tuple[float, float],
+    *,
+    radius: int,
+    color: tuple[int, int, int],
+    thickness: int,
+) -> None:
+    height, width = image.shape[:2]
+    x_px = int(round(center_xy[0] * max(width - 1, 0)))
+    y_px = int(round(center_xy[1] * max(height - 1, 0)))
+    cv2.circle(image, (x_px, y_px), radius, color, thickness=thickness, lineType=cv2.LINE_AA)
+
+
+def _compose_row(
+    panels: list[np.ndarray],
+    titles: list[str],
+    cfg: DictConfig,
+) -> np.ndarray:
+    tile_gap = int(cfg.preview.layout.tile_gap)
+    header_height = int(cfg.preview.layout.header_height)
+    text_scale = float(cfg.preview.layout.text_scale)
+    text_thickness = int(cfg.preview.layout.text_thickness)
+    background_rgb = tuple(int(v) for v in cfg.preview.layout.background_rgb)
+
+    height, width = panels[0].shape[:2]
+    row_width = len(panels) * width + (len(panels) - 1) * tile_gap
+    canvas = np.full((header_height + height, row_width, 3), background_rgb, dtype=np.uint8)
+
+    cursor_x = 0
+    for panel, title in zip(panels, titles, strict=True):
+        canvas[header_height:, cursor_x : cursor_x + width] = panel
+        cv2.putText(
+            canvas,
+            title,
+            (cursor_x + 6, max(header_height - 8, 12)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            text_scale,
+            (245, 245, 245),
+            text_thickness,
+            lineType=cv2.LINE_AA,
+        )
+        cursor_x += width + tile_gap
+    return canvas
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src/tasks/court_detection/training/metrics.py
+++ b/src/tasks/court_detection/training/metrics.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 from typing import Any
 
 import torch
-import torch.nn.functional as F
 from torch import Tensor
+from src.utils.data.heatmaps import heatmaps_to_argmax
 
 
 class CourtDetectionMetrics:
@@ -64,7 +64,7 @@ class CourtDetectionMetrics:
             self._union.append(union.detach().cpu())
 
     def _update_kp(self, logits: Tensor, batch: dict[str, Tensor]) -> None:
-        """Compute soft-argmax distance to ground truth keypoints."""
+        """Compute argmax distance to ground truth keypoints."""
         coords_pred = _heatmaps_to_pixel_coords(logits)  # (B, K, 2)
         coords_gt = batch["keypoints"]  # (B, K, 2)
         dist = torch.norm(coords_pred.cpu() - coords_gt.cpu(), dim=-1)  # (B, K)
@@ -120,7 +120,7 @@ class CourtDetectionMetrics:
 
 
 def _heatmaps_to_pixel_coords(heatmaps: Tensor) -> Tensor:
-    """Convert heatmaps to pixel coordinates via soft-argmax.
+    """Convert heatmaps to pixel coordinates via shared argmax decode.
 
     Parameters
     ----------
@@ -132,19 +132,15 @@ def _heatmaps_to_pixel_coords(heatmaps: Tensor) -> Tensor:
     Tensor
         ``[B, K, 2]`` pixel coordinates ``(x, y)``.
     """
-    bsz, num_kp, height, width = heatmaps.shape
-    device = heatmaps.device
-
-    flat = heatmaps.view(bsz, num_kp, -1)
-    probs = F.softmax(flat, dim=-1)
-
-    y_coords = torch.linspace(0, height - 1, height, device=device)
-    x_coords = torch.linspace(0, width - 1, width, device=device)
-    yy, xx = torch.meshgrid(y_coords, x_coords, indexing="ij")
-    xx_flat = xx.reshape(-1)
-    yy_flat = yy.reshape(-1)
-
-    x = (probs * xx_flat.view(1, 1, -1)).sum(dim=-1)
-    y = (probs * yy_flat.view(1, 1, -1)).sum(dim=-1)
-
-    return torch.stack([x, y], dim=-1)
+    height, width = heatmaps.shape[-2:]
+    coords_normalized, _ = heatmaps_to_argmax(heatmaps)
+    coords = coords_normalized.clone()
+    if width > 1:
+        coords[..., 0] = coords[..., 0] * float(width - 1)
+    else:
+        coords[..., 0] = 0.0
+    if height > 1:
+        coords[..., 1] = coords[..., 1] * float(height - 1)
+    else:
+        coords[..., 1] = 0.0
+    return coords

--- a/src/utils/data/__init__.py
+++ b/src/utils/data/__init__.py
@@ -11,6 +11,11 @@ from src.utils.data.event_utils import (
     extract_event_frames,
     extract_event_indices,
 )
+from src.utils.data.heatmaps import (
+    generate_gaussian_heatmap,
+    generate_gaussian_heatmaps,
+    heatmaps_to_argmax,
+)
 from src.utils.data.scene_batch_sampler import (
     build_scene_sampler,
     SceneBatchSampler,
@@ -33,7 +38,10 @@ __all__ = [
     "collate_padded_batch",
     "extract_event_frames",
     "extract_event_indices",
+    "generate_gaussian_heatmap",
+    "generate_gaussian_heatmaps",
     "gaussian_soft_labels",
+    "heatmaps_to_argmax",
     "random_visibility_dropout",
     "scale_uv_with_visibility",
     "SceneBatchSampler",

--- a/src/utils/data/heatmaps.py
+++ b/src/utils/data/heatmaps.py
@@ -1,0 +1,143 @@
+"""Shared spatial heatmap utilities."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def generate_gaussian_heatmaps(
+    size_hw: tuple[int, int],
+    centers_xy: Tensor | tuple[float, float] | list[float],
+    sigma_ratio: float,
+    visibility: Tensor | None = None,
+    *,
+    dtype: torch.dtype = torch.float32,
+    device: torch.device | str | None = None,
+) -> Tensor:
+    """Generate 2-D Gaussian heatmaps from normalized centers.
+
+    Args:
+        size_hw: Heatmap size as ``(height, width)``.
+        centers_xy: Normalized centers in ``(x, y)`` ordering with shape
+            ``(..., 2)``.
+        sigma_ratio: Gaussian sigma as a ratio of the heatmap diagonal.
+        visibility: Optional visibility mask broadcastable to ``centers_xy[..., 0]``.
+        dtype: Output dtype.
+        device: Output device.
+
+    Returns:
+        Heatmaps with shape ``(..., H, W)``.
+    """
+    height, width = _validate_size(size_hw)
+    if sigma_ratio <= 0:
+        raise ValueError("sigma_ratio must be positive.")
+
+    centers = torch.as_tensor(centers_xy, dtype=dtype, device=device)
+    if centers.shape == (2,):
+        centers = centers.unsqueeze(0)
+        squeeze_result = True
+    else:
+        squeeze_result = False
+    if centers.shape[-1] != 2:
+        raise ValueError(f"centers_xy must have shape (..., 2), got {tuple(centers.shape)}.")
+
+    yy = torch.linspace(0.0, 1.0, height, dtype=dtype, device=centers.device)
+    xx = torch.linspace(0.0, 1.0, width, dtype=dtype, device=centers.device)
+    grid_y, grid_x = torch.meshgrid(yy, xx, indexing="ij")
+
+    view_shape = centers.shape[:-1] + (1, 1)
+    center_x = centers[..., 0].view(view_shape)
+    center_y = centers[..., 1].view(view_shape)
+
+    sigma_norm = float(sigma_ratio) * math.sqrt(float(height * height + width * width))
+    sigma_x = sigma_norm / max(width - 1, 1)
+    sigma_y = sigma_norm / max(height - 1, 1)
+    denom_x = 2.0 * sigma_x * sigma_x
+    denom_y = 2.0 * sigma_y * sigma_y
+
+    heatmaps = torch.exp(
+        -(((grid_x - center_x) ** 2) / denom_x + ((grid_y - center_y) ** 2) / denom_y)
+    )
+
+    in_bounds = (
+        (centers[..., 0] >= 0.0)
+        & (centers[..., 0] <= 1.0)
+        & (centers[..., 1] >= 0.0)
+        & (centers[..., 1] <= 1.0)
+    )
+    if visibility is None:
+        valid = in_bounds
+    else:
+        visibility_tensor = torch.as_tensor(visibility, dtype=torch.bool, device=centers.device)
+        valid = visibility_tensor & in_bounds
+    heatmaps = heatmaps * valid.view(view_shape).to(dtype=dtype)
+
+    if squeeze_result:
+        return heatmaps.squeeze(0)
+    return heatmaps
+
+
+def generate_gaussian_heatmap(
+    size_hw: tuple[int, int],
+    center_xy: Tensor | tuple[float, float] | list[float],
+    sigma_ratio: float,
+    visible: bool = True,
+    *,
+    dtype: torch.dtype = torch.float32,
+    device: torch.device | str | None = None,
+) -> Tensor:
+    """Generate a single 2-D Gaussian heatmap from one normalized center."""
+    return generate_gaussian_heatmaps(
+        size_hw=size_hw,
+        centers_xy=center_xy,
+        sigma_ratio=sigma_ratio,
+        visibility=visible,
+        dtype=dtype,
+        device=device,
+    )
+
+
+def heatmaps_to_argmax(heatmaps: Tensor) -> tuple[Tensor, Tensor]:
+    """Convert heatmaps to sparse normalized coordinates via hard argmax.
+
+    Args:
+        heatmaps: Tensor with shape ``(..., H, W)``.
+
+    Returns:
+        Tuple of:
+            - coords: Normalized ``(..., 2)`` coordinates in ``(x, y)`` ordering.
+            - values: Peak values with shape ``(...)``.
+    """
+    if heatmaps.ndim < 2:
+        raise ValueError(f"heatmaps must have shape (..., H, W), got {tuple(heatmaps.shape)}.")
+
+    *leading_shape, height, width = heatmaps.shape
+    flat = heatmaps.reshape(*leading_shape, height * width)
+    values, indices = flat.max(dim=-1)
+
+    x = indices % width
+    y = torch.div(indices, width, rounding_mode="floor")
+
+    if width > 1:
+        x = x.to(heatmaps.dtype) / float(width - 1)
+    else:
+        x = torch.zeros_like(x, dtype=heatmaps.dtype)
+    if height > 1:
+        y = y.to(heatmaps.dtype) / float(height - 1)
+    else:
+        y = torch.zeros_like(y, dtype=heatmaps.dtype)
+
+    coords = torch.stack([x, y], dim=-1)
+    return coords, values
+
+
+def _validate_size(size_hw: tuple[int, int]) -> tuple[int, int]:
+    if len(size_hw) != 2:
+        raise ValueError(f"size_hw must be (height, width), got {size_hw!r}.")
+    height, width = int(size_hw[0]), int(size_hw[1])
+    if height <= 0 or width <= 0:
+        raise ValueError(f"size_hw must be positive, got {(height, width)}.")
+    return height, width


### PR DESCRIPTION
## Summary

- add shared spatial heatmap generation and hard-argmax decoding under `src/utils/data`
- replace ball and court heatmap call sites to use the shared normalized-coordinate API
- add Hydra preview scripts to render qualitative heatmap comparisons across sigma ratios

## Changes

- add `src/utils/data/heatmaps.py` and export the API from `src/utils/data/__init__.py`
- migrate `ball_detection` and `court_detection` datasets, metrics, and predictors to `sigma_ratio`-based heatmap generation and shared argmax decoding
- add qualitative preview scripts/configs for ball and court heatmaps and update the default `sigma_ratio` to `0.012`

## Validation

- `.venv/bin/python -m py_compile src/utils/data/heatmaps.py src/tasks/ball_detection/data/dataset.py src/tasks/ball_detection/inference/predictor.py src/tasks/ball_detection/training/lightning_module.py src/tasks/ball_detection/training/metrics.py src/tasks/ball_detection/scripts/preview_heatmaps.py src/tasks/court_detection/data/court_kp_dataset.py src/tasks/court_detection/data/datamodule.py src/tasks/court_detection/inference/predictor.py src/tasks/court_detection/training/metrics.py src/tasks/court_detection/scripts/preview_heatmaps.py`
- `.venv/bin/python -m src.tasks.ball_detection.scripts.preview_heatmaps`
- `.venv/bin/python -m src.tasks.court_detection.scripts.preview_heatmaps`

## Related Issues

- None
