### PR TITLE
chore: Add BLCS webui dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
     "pydantic>=2.10.0",
     "imageio>=2.37.2",
     "av>=16.1.0",
+    "uvicorn>=0.44.0",
+    "fastapi>=0.135.3",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -3500,6 +3500,7 @@ dependencies = [
     { name = "bitsandbytes" },
     { name = "deep-sort-realtime" },
     { name = "ezc3d" },
+    { name = "fastapi" },
     { name = "gdown" },
     { name = "huggingface-hub" },
     { name = "hydra-core" },
@@ -3525,6 +3526,7 @@ dependencies = [
     { name = "tqdm" },
     { name = "transformers" },
     { name = "ultralytics" },
+    { name = "uvicorn" },
     { name = "yt-dlp" },
 ]
 
@@ -3555,6 +3557,7 @@ requires-dist = [
     { name = "bitsandbytes", specifier = ">=0.48.2" },
     { name = "deep-sort-realtime", specifier = ">=1.3.2" },
     { name = "ezc3d", specifier = ">=1.6.0" },
+    { name = "fastapi", specifier = ">=0.135.3" },
     { name = "gdown", specifier = ">=5.2.0" },
     { name = "huggingface-hub", specifier = ">=0.36.0" },
     { name = "hydra-core", specifier = ">=1.3.2" },
@@ -3580,6 +3583,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformers", specifier = ">=4.57.1" },
     { name = "ultralytics", specifier = ">=8.3.223" },
+    { name = "uvicorn", specifier = ">=0.44.0" },
     { name = "yt-dlp", specifier = ">=2025.11.12" },
 ]
 


### PR DESCRIPTION
## Summary

- Add the missing runtime dependencies required to start `src/tasks/blcs/generate_dataset/webui`.
- Sync `uv.lock` with the new dependency declarations.

## Changes

- Add `fastapi` to project dependencies.
- Add `uvicorn` to project dependencies.
- Update `uv.lock` to record both packages in the resolved environment.

## Validation

- Reviewed the dependency diff and confirmed this PR only changes `pyproject.toml` and `uv.lock`.
- Did not run the web UI in this PR workflow.

## Related Issues

- References #

## Notes

- These dependency additions were made to support launching `src/tasks/blcs/generate_dataset/webui`.
