### PR TITLE
feat: Add fixed camera noise sampling

### DIFF
--- a/src/tasks/blcs/configs/camera/default.yaml
+++ b/src/tasks/blcs/configs/camera/default.yaml
@@ -7,6 +7,10 @@ image_size: [1280, 720]
 fixed_look_at: [0.0, 0.0, 0.0]
 # Additional Y-axis buffer on top of BASELINE_CLEAR.
 fixed_baseline_clear_extra: 2.0
+# Volume-uniform center perturbation radius for each fixed camera (metres).
+fixed_position_noise_radius: 0.0
+# Area-uniform look-at target radius on the z=0 court plane (metres).
+fixed_look_at_xy_radius: 0.0
 
 # Look-at perturbation (Gaussian noise on target, metres, sigma)
 look_at_noise_std: 0.5

--- a/src/tasks/blcs/scripts/generate_dataset.py
+++ b/src/tasks/blcs/scripts/generate_dataset.py
@@ -33,7 +33,9 @@ from src.tasks.blcs.generate_dataset.scene_generator import (
 )
 from src.tasks.blcs.generate_dataset.simulation.ball_physics import PhysicsConfig
 from src.tasks.blcs.generate_dataset.simulation.rally_simulator import RallyConfig
-from src.tasks.blcs.generate_dataset.simulation.targeted_velocity_sampler import TargetedVelocityConfig
+from src.tasks.blcs.generate_dataset.simulation.targeted_velocity_sampler import (
+    TargetedVelocityConfig,
+)
 from src.utils.projection.camera_projector import CameraConfig
 from src.utils.schema.court import CourtConfig
 
@@ -118,6 +120,10 @@ def _build_generator_config(cfg: DictConfig) -> GeneratorConfig:
         image_size=tuple(cfg.camera.image_size),
         fixed_look_at=tuple(cfg.camera.get("fixed_look_at", [0.0, 0.0, 0.0])),
         fixed_baseline_clear_extra=float(cfg.camera.get("fixed_baseline_clear_extra", 0.0)),
+        fixed_position_noise_radius=float(
+            cfg.camera.get("fixed_position_noise_radius", 0.0)
+        ),
+        fixed_look_at_xy_radius=float(cfg.camera.get("fixed_look_at_xy_radius", 0.0)),
         target_x_range=tuple(cfg.camera.get("target_x_range", [-2.0, 2.0])),
         target_y_range=tuple(cfg.camera.get("target_y_range", [-2.0, 2.0])),
         target_z_range=tuple(cfg.camera.get("target_z_range", [0.5, 1.5])),

--- a/src/utils/projection/camera_projector.py
+++ b/src/utils/projection/camera_projector.py
@@ -12,11 +12,11 @@ from torch import Tensor
 
 from src.utils.schema.court import (
     BASELINE_CLEAR,
-    CourtConfig,
     FENCE_HEIGHT,
     HALF_DOUBLES_WIDTH,
     HALF_LENGTH,
     SIDELINE_CLEAR,
+    CourtConfig,
     court_keypoints_3d,
 )
 
@@ -105,6 +105,8 @@ class CameraConfig:
     image_size: tuple[int, int] = (1280, 720)
     fixed_look_at: tuple[float, float, float] = (0.0, 0.0, 0.0)
     fixed_baseline_clear_extra: float = 0.0
+    fixed_position_noise_radius: float = 0.0
+    fixed_look_at_xy_radius: float = 0.0
     target_x_range: tuple[float, float] = (-2.0, 2.0)
     target_y_range: tuple[float, float] = (-2.0, 2.0)
     target_z_range: tuple[float, float] = (0.5, 1.5)
@@ -200,11 +202,36 @@ class CameraProjector:
             image_size=cfg.image_size,
         )
 
+    @staticmethod
+    def _sample_uniform_offset_in_ball(radius: float) -> tuple[float, float, float]:
+        """Sample a volume-uniform 3D offset inside a ball."""
+        if radius <= 0.0:
+            return 0.0, 0.0, 0.0
+
+        radius_sq = radius * radius
+        while True:
+            dx = random.uniform(-radius, radius)
+            dy = random.uniform(-radius, radius)
+            dz = random.uniform(-radius, radius)
+            if dx * dx + dy * dy + dz * dz <= radius_sq:
+                return dx, dy, dz
+
+    @staticmethod
+    def _sample_uniform_xy_in_disk(radius: float) -> tuple[float, float]:
+        """Sample an area-uniform XY location inside a disk."""
+        if radius <= 0.0:
+            return 0.0, 0.0
+
+        theta = random.uniform(0.0, 2.0 * math.pi)
+        r = radius * math.sqrt(random.random())
+        return r * math.cos(theta), r * math.sin(theta)
+
     def fixed_cameras(self) -> list[Camera]:
         """Build the fixed 8-camera layout (4 corners + 4 edge midpoints).
 
         Corner cameras use ``z_min``. Midpoint cameras use ``z_max``.
-        All cameras look at ``fixed_look_at``.
+        When both fixed-camera noise radii are zero, the legacy layout is
+        preserved exactly.
         """
         cfg = self.config
         fence_x, fence_y = self._fence_extents(cfg.fixed_baseline_clear_extra)
@@ -224,11 +251,28 @@ class CameraProjector:
         ]
 
         cams: list[Camera] = []
-        for center in corners + midpoints:
+        for base_center in corners + midpoints:
+            dx, dy, dz = self._sample_uniform_offset_in_ball(
+                cfg.fixed_position_noise_radius
+            )
+            center = (
+                base_center[0] + dx,
+                base_center[1] + dy,
+                base_center[2] + dz,
+            )
+
+            if cfg.fixed_look_at_xy_radius > 0.0:
+                target_x, target_y = self._sample_uniform_xy_in_disk(
+                    cfg.fixed_look_at_xy_radius
+                )
+                look_at_target = (target_x, target_y, 0.0)
+            else:
+                look_at_target = look_at
+
             cams.append(
                 make_look_at_camera(
                     center=center,
-                    look_at=look_at,
+                    look_at=look_at_target,
                     hfov_deg=cfg.hfov_deg,
                     image_size=cfg.image_size,
                 )


### PR DESCRIPTION
## Summary

- Add configurable noise radii for fixed_8 BLCS cameras.
- Sample camera centers within a sphere around each fixed base position.
- Sample look-at targets from an xy-plane disk around the origin.

## Changes

- Extend CameraConfig and Hydra wiring with fixed_position_noise_radius and fixed_look_at_xy_radius.
- Update fixed camera generation to perturb position and look-at target while preserving the zero-noise layout.
- Add defaults for the new camera config knobs.

## Validation

- `.venv/bin/python -m ruff check src/utils/projection/camera_projector.py src/tasks/blcs/scripts/generate_dataset.py`
