### PR TITLE
fix: Generalize shared RoPE attention handling

### DIFF
--- a/src/tasks/blcs/configs/model/early_fusion.yaml
+++ b/src/tasks/blcs/configs/model/early_fusion.yaml
@@ -19,6 +19,7 @@ invisible_init_std: 0.02
 # RoPE
 rope_dim: null
 rope_theta: 10000.0
+rope_theta_time: 10000.0
 
 # Output
 predict_velocity: false

--- a/src/tasks/blcs/configs/model/multiview.yaml
+++ b/src/tasks/blcs/configs/model/multiview.yaml
@@ -15,6 +15,11 @@ cam_emb_dim: 64
 num_layers: 6      # Number of (same-time cross-attn + temporal self-attn) iterations
 num_heads: 8
 dropout: 0.1
+rope_dim: null
+rope_theta: 10000.0
+rope_theta_time: 10000.0
+rope_theta_camera: 10000.0
+rope_theta_type: 100.0
 max_seq_len: 2048
 max_views: 8
 predict_velocity: false

--- a/src/tasks/blcs/configs/model/multiview_early_fusion.yaml
+++ b/src/tasks/blcs/configs/model/multiview_early_fusion.yaml
@@ -21,6 +21,7 @@ invisible_init_std: 0.02
 # RoPE
 rope_dim: null
 rope_theta: 10000.0
+rope_theta_time: 10000.0
 
 # Output
 predict_velocity: true

--- a/src/tasks/blcs/configs/model/query.yaml
+++ b/src/tasks/blcs/configs/model/query.yaml
@@ -19,9 +19,12 @@ query_init_std: 0.02
 num_ball_layers: 4
 num_query2ball_layers: 2
 
-# RoPE (used in Stage B and Stage C)
+# RoPE axes: time, entity, type (court/ball/query)
 rope_dim: null
 rope_theta: 10000.0
+rope_theta_time: 10000.0
+rope_theta_entity: 10000.0
+rope_theta_type: 100.0
 
 # Output
 predict_velocity: false

--- a/src/tasks/blcs/configs/model/single.yaml
+++ b/src/tasks/blcs/configs/model/single.yaml
@@ -16,9 +16,11 @@ dropout: 0.1
 max_seq_len: 10240
 invisible_init_std: 0.02
 
-# RoPE (Rotary Position Embedding)
-rope_dim: null       # Defaults to head_dim (hidden_dim / num_heads)
-rope_theta: 10000.0
+# 3-axis interleaved MROPE
+rope_dim: null            # Defaults to head_dim (hidden_dim / num_heads)
+rope_theta_time: 10000.0
+rope_theta_camera: 10000.0
+rope_theta_type: 100.0
 
 
 # Output

--- a/src/tasks/blcs/models/blcs_early_fusion_model.py
+++ b/src/tasks/blcs/models/blcs_early_fusion_model.py
@@ -8,7 +8,7 @@ decoder-style Transformer and regresses 3D trajectory coordinates.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
@@ -47,7 +47,8 @@ class BLCSEarlyFusionModel(nn.Module):
         dropout: float = 0.1,
         rope_dim: int | None = None,
         rope_theta: float = 10000.0,
-        ffn_type: str = "swiglu",
+        rope_theta_time: float | None = None,
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         predict_velocity: bool = False,
         max_seq_len: int = 120,
         invisible_init_std: float = 0.02,
@@ -65,6 +66,7 @@ class BLCSEarlyFusionModel(nn.Module):
         rope_dim = head_dim if rope_dim is None else int(rope_dim)
         self.rope_dim = int(rope_dim)
         self.rope_theta = float(rope_theta)
+        self.rope_time_base = float(self.rope_theta if rope_theta_time is None else rope_theta_time)
 
         if ffn_dim is None:
             ffn_dim = int((8 * hidden_dim) / 3)
@@ -94,7 +96,7 @@ class BLCSEarlyFusionModel(nn.Module):
                         head_dim=head_dim,
                         rope_dim=self.rope_dim,
                         attn_dropout=dropout,
-                        rope_base=self.rope_theta,
+                        rope_base=self.rope_time_base,
                         ffn_type=ffn_type,
                     )
                 )
@@ -123,7 +125,7 @@ class BLCSEarlyFusionModel(nn.Module):
         freqs_cis = precompute_freqs_cis(
             dim=self.rope_dim,
             seqlen=self.max_seq_len,
-            base=self.rope_theta,
+            base=self.rope_time_base,
             device=None,
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
@@ -142,7 +144,8 @@ class BLCSEarlyFusionModel(nn.Module):
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_dim=model_cfg.get("rope_dim", None),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             predict_velocity=bool(model_cfg.get("predict_velocity", False)),
             max_seq_len=int(model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),

--- a/src/tasks/blcs/models/blcs_model.py
+++ b/src/tasks/blcs/models/blcs_model.py
@@ -15,7 +15,7 @@ Uses shared components from src.utils.models.components.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
@@ -26,9 +26,13 @@ from src.utils.models import (
     RMSNorm,
     TransformerBlock,
     TransformerBlockConfig,
-    precompute_freqs_cis,
+    precompute_freqs_cis_nd,
 )
-from src.utils.models.embeddings import BallUVEmbedding, CourtKPUVEmbedding, InvisibleTokenEmbedding
+from src.utils.models.embeddings import (
+    BallUVEmbedding,
+    CourtKPUVEmbedding,
+    InvisibleTokenEmbedding,
+)
 from src.utils.schema.court import NUM_COURT_KP
 
 if TYPE_CHECKING:
@@ -72,7 +76,10 @@ class BLCSModel(nn.Module):
         dropout: float = 0.1,
         rope_dim: int | None = None,
         rope_theta: float = 10000.0,
-        ffn_type: str = "swiglu",
+        rope_theta_time: float | None = None,
+        rope_theta_camera: float | None = None,
+        rope_theta_type: float = 100.0,
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         predict_velocity: bool = False,
         max_seq_len: int = 120,
         invisible_init_std: float = 0.02,
@@ -106,6 +113,11 @@ class BLCSModel(nn.Module):
         rope_dim = head_dim if rope_dim is None else rope_dim
         self.rope_dim = int(rope_dim)
         self.rope_theta = float(rope_theta)
+        self.rope_bases = (
+            float(self.rope_theta if rope_theta_time is None else rope_theta_time),
+            float(self.rope_theta if rope_theta_camera is None else rope_theta_camera),
+            float(rope_theta_type),
+        )
 
         if ffn_dim is None:
             ffn_dim = int((8 * hidden_dim) / 3)
@@ -124,9 +136,6 @@ class BLCSModel(nn.Module):
             dropout=dropout,
             invisible_token=self.invisible_token,
         )
-
-        # Type embedding: 0 = court, 1 = ball
-        self.type_embed = nn.Embedding(2, hidden_dim)
 
         self.blocks = nn.ModuleList(
             [
@@ -164,11 +173,10 @@ class BLCSModel(nn.Module):
                 dropout=dropout,
             )
 
-        freqs_cis = precompute_freqs_cis(
+        freqs_cis = precompute_freqs_cis_nd(
             dim=self.rope_dim,
-            seqlen=self.max_tokens,
-            base=self.rope_theta,
-            device=None,  # initialized on CPU; moved by `model.to(device)`
+            pos=self._build_rope_positions(),
+            base=self.rope_bases,
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
@@ -193,7 +201,10 @@ class BLCSModel(nn.Module):
             dropout=model_cfg.get("dropout", 0.1),
             rope_dim=model_cfg.get("rope_dim", None),
             rope_theta=model_cfg.get("rope_theta", 10000.0),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
+            rope_theta_camera=model_cfg.get("rope_theta_camera", None),
+            rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             predict_velocity=model_cfg.get("predict_velocity", False),
             max_seq_len=model_cfg.get(
                 "max_seq_len", data_cfg.get("max_seq_len", 120)
@@ -201,6 +212,29 @@ class BLCSModel(nn.Module):
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             num_court_tokens=int(data_cfg.get("num_court_kp", NUM_COURT_KP)),
         )
+
+    def _build_rope_positions(self) -> Tensor:
+        """Build 3-axis RoPE positions for `[court, ball]` tokens."""
+        court_idx = torch.arange(self.num_court_tokens, dtype=torch.long)
+        ball_time = torch.arange(self.max_seq_len, dtype=torch.long) + 1
+
+        court_pos = torch.stack(
+            [
+                torch.zeros_like(court_idx),
+                court_idx,
+                torch.zeros_like(court_idx),
+            ],
+            dim=-1,
+        )
+        ball_pos = torch.stack(
+            [
+                ball_time,
+                torch.zeros_like(ball_time),
+                torch.ones_like(ball_time),
+            ],
+            dim=-1,
+        )
+        return torch.cat([court_pos, ball_pos], dim=0)
 
     def forward(
         self,
@@ -227,27 +261,22 @@ class BLCSModel(nn.Module):
         # Tokenize court and ball
         court_tok = self.court_embed(court_kp, court_vis)  # (B, K, D)
         ball_tok = self.ball_embed(ball_uv, ball_vis)  # (B, T, D)
+        if court_tok.shape[1] != self.num_court_tokens:
+            raise ValueError(
+                f"Expected {self.num_court_tokens} court tokens, got {court_tok.shape[1]}"
+            )
 
-        # Add type embeddings
         K = court_tok.shape[1]
-        court_type = self.type_embed(
-            torch.zeros(K, device=ball_uv.device, dtype=torch.long)
-        )[None, :, :]  # (1, K, D)
-        ball_type = self.type_embed(
-            torch.ones(T, device=ball_uv.device, dtype=torch.long)
-        )[None, :, :]  # (1, T, D)
-
-        x = torch.cat(
-            [court_tok + court_type, ball_tok + ball_type], dim=1
-        )  # (B, S, D)
+        x = torch.cat([court_tok, ball_tok], dim=1)  # (B, S, D)
         S = x.shape[1]
 
-        if S > self.freqs_cis.shape[0]:
+        freqs_cis = cast(Tensor, self.freqs_cis)
+        if freqs_cis.shape[0] < S:
             raise ValueError(
-                f"Sequence length S={S} exceeds cached freqs_cis length {self.freqs_cis.shape[0]}. "
+                f"Sequence length S={S} exceeds cached freqs_cis length {freqs_cis.shape[0]}. "
                 "Increase max_seq_len."
             )
-        freqs_cis = self.freqs_cis[:S]
+        freqs_cis = freqs_cis[:S]
         if freqs_cis.device != x.device:
             freqs_cis = freqs_cis.to(x.device)
         attn_mask: Tensor | None = None

--- a/src/tasks/blcs/models/blcs_multiview_early_fusion_model.py
+++ b/src/tasks/blcs/models/blcs_multiview_early_fusion_model.py
@@ -12,7 +12,7 @@ Then:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
@@ -44,7 +44,8 @@ class BLCSMultiViewEarlyFusionModel(nn.Module):
         dropout: float = 0.1,
         rope_dim: int | None = None,
         rope_theta: float = 10000.0,
-        ffn_type: str = "swiglu",
+        rope_theta_time: float | None = None,
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         predict_velocity: bool = False,
         max_seq_len: int = 120,
         max_num_cameras: int = 8,
@@ -72,6 +73,7 @@ class BLCSMultiViewEarlyFusionModel(nn.Module):
         rope_dim = head_dim if rope_dim is None else int(rope_dim)
         self.rope_dim = int(rope_dim)
         self.rope_theta = float(rope_theta)
+        self.rope_time_base = float(self.rope_theta if rope_theta_time is None else rope_theta_time)
 
         if ffn_dim is None:
             ffn_dim = int((8 * hidden_dim) / 3)
@@ -109,7 +111,7 @@ class BLCSMultiViewEarlyFusionModel(nn.Module):
                         head_dim=head_dim,
                         rope_dim=self.rope_dim,
                         attn_dropout=dropout,
-                        rope_base=self.rope_theta,
+                        rope_base=self.rope_time_base,
                         ffn_type=ffn_type,
                     )
                 )
@@ -138,7 +140,7 @@ class BLCSMultiViewEarlyFusionModel(nn.Module):
         freqs_cis = precompute_freqs_cis(
             dim=self.rope_dim,
             seqlen=self.max_seq_len,
-            base=self.rope_theta,
+            base=self.rope_time_base,
             device=None,
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
@@ -157,7 +159,8 @@ class BLCSMultiViewEarlyFusionModel(nn.Module):
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_dim=model_cfg.get("rope_dim", None),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             predict_velocity=bool(model_cfg.get("predict_velocity", False)),
             max_seq_len=int(model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))),
             max_num_cameras=int(model_cfg.get("max_num_cameras", model_cfg.get("max_views", 8))),

--- a/src/tasks/blcs/models/blcs_multiview_model.py
+++ b/src/tasks/blcs/models/blcs_multiview_model.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 from torch import Tensor, nn
@@ -14,7 +14,7 @@ from src.utils.models import (
     RMSNorm,
     TransformerBlock,
     TransformerBlockConfig,
-    precompute_freqs_cis,
+    precompute_freqs_cis_nd,
 )
 from src.utils.models.embeddings import (
     BallUVEmbedding,
@@ -48,10 +48,13 @@ class BLCSMultiViewModel(nn.Module):
         cam_emb_dim: int = 64,
         num_heads: int = 8,
         ffn_dim: int | None = None,
-        ffn_type: str = "swiglu",
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         dropout: float = 0.1,
         rope_dim: int | None = None,
         rope_theta: float = 10000.0,
+        rope_theta_time: float | None = None,
+        rope_theta_camera: float | None = None,
+        rope_theta_type: float = 100.0,
         num_layers: int = 4,
         predict_velocity: bool = False,
         max_seq_len: int = 120,
@@ -98,6 +101,13 @@ class BLCSMultiViewModel(nn.Module):
             raise ValueError(f"rope_dim must be even, got {rope_dim}")
         if rope_dim > head_dim:
             raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
+        self.rope_dim = int(rope_dim)
+        self.rope_theta = float(rope_theta)
+        self.rope_bases = (
+            float(self.rope_theta if rope_theta_time is None else rope_theta_time),
+            float(self.rope_theta if rope_theta_camera is None else rope_theta_camera),
+            float(rope_theta_type),
+        )
 
         if ffn_dim is None:
             ffn_dim = int((8 * self.hidden_dim) / 3)
@@ -133,7 +143,7 @@ class BLCSMultiViewModel(nn.Module):
                         n_heads=num_heads,
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim,
+                        rope_dim=self.rope_dim,
                         attn_dropout=dropout,
                         ffn_type=ffn_type,
                     )
@@ -149,9 +159,9 @@ class BLCSMultiViewModel(nn.Module):
                         n_heads=num_heads,
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim,
+                        rope_dim=self.rope_dim,
                         attn_dropout=dropout,
-                        rope_base=rope_theta,
+                        rope_base=self.rope_theta,
                         ffn_type=ffn_type,
                     )
                 )
@@ -178,14 +188,6 @@ class BLCSMultiViewModel(nn.Module):
                 dropout=dropout,
             )
 
-        freqs_time_cis = precompute_freqs_cis(
-            dim=rope_dim,
-            seqlen=self.max_seq_len,
-            base=rope_theta,
-            device=None,
-        )
-        self.register_buffer("freqs_time_cis", freqs_time_cis, persistent=False)
-
     @classmethod
     def from_config(cls, config: DictConfig) -> BLCSMultiViewModel:
         """Create model from Hydra/OmegaConf config."""
@@ -198,10 +200,13 @@ class BLCSMultiViewModel(nn.Module):
             cam_emb_dim=int(model_cfg.get("cam_emb_dim", 64)),
             num_heads=int(model_cfg.get("num_heads", 8)),
             ffn_dim=model_cfg.get("ffn_dim", None),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_dim=model_cfg.get("rope_dim", None),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
+            rope_theta_camera=model_cfg.get("rope_theta_camera", None),
+            rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
             num_layers=int(model_cfg.get("num_layers", model_cfg.get("num_stage2_layers", 4))),
             predict_velocity=bool(model_cfg.get("predict_velocity", False)),
             max_seq_len=int(model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))),
@@ -209,6 +214,58 @@ class BLCSMultiViewModel(nn.Module):
             num_court_tokens=int(model_cfg.get("num_court_tokens", NUM_COURT_KP)),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             query_init_std=float(model_cfg.get("query_init_std", 0.02)),
+        )
+
+    def _build_frame_positions(
+        self,
+        *,
+        n_cams: int,
+        seq_len: int,
+        device: torch.device,
+    ) -> Tensor:
+        per_time: list[Tensor] = []
+        for time_idx in range(seq_len):
+            per_camera: list[Tensor] = []
+            for cam_idx in range(n_cams):
+                court_time = torch.full(
+                    (self.num_court_tokens,),
+                    time_idx + 1,
+                    device=device,
+                    dtype=torch.long,
+                )
+                court_camera = torch.full(
+                    (self.num_court_tokens,),
+                    cam_idx,
+                    device=device,
+                    dtype=torch.long,
+                )
+                court_type = torch.zeros(self.num_court_tokens, device=device, dtype=torch.long)
+                ball_pos = torch.tensor(
+                    [[time_idx + 1, cam_idx, 1]],
+                    device=device,
+                    dtype=torch.long,
+                )
+                per_camera.append(
+                    torch.cat(
+                        [
+                            torch.stack([court_time, court_camera, court_type], dim=-1),
+                            ball_pos,
+                        ],
+                        dim=0,
+                    )
+                )
+            per_time.append(torch.cat(per_camera, dim=0))
+        return torch.stack(per_time, dim=0)
+
+    def _build_query_positions(self, *, seq_len: int, device: torch.device) -> Tensor:
+        time_idx = torch.arange(seq_len, device=device, dtype=torch.long) + 1
+        return torch.stack(
+            [
+                time_idx,
+                torch.zeros_like(time_idx),
+                torch.full_like(time_idx, 2),
+            ],
+            dim=-1,
         )
 
     @staticmethod
@@ -394,9 +451,21 @@ class BLCSMultiViewModel(nn.Module):
         # Shape: (B, N)
         court_valid = ball_valid.any(dim=2)
 
-        freqs_time = self.freqs_time_cis[:seq_len_in]
-        if freqs_time.device != ball_uv.device:
-            freqs_time = freqs_time.to(ball_uv.device)
+        query_positions = self._build_query_positions(seq_len=seq_len_in, device=ball_uv.device)
+        freqs_time = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=query_positions,
+            base=self.rope_bases,
+        )
+        frame_freqs = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_frame_positions(
+                n_cams=n_cams,
+                seq_len=seq_len_in,
+                device=ball_uv.device,
+            ),
+            base=self.rope_bases,
+        )
 
         frame_tokens, frame_token_valid = self._build_frame_tokens(
             ball_tok=ball_tok,
@@ -422,7 +491,25 @@ class BLCSMultiViewModel(nn.Module):
             key_valid = frame_token_valid.reshape(
                 batch_size * seq_len_in, n_cams * (self.num_court_tokens + 1)
             )
-            query_bt = cross_layer(query_bt, frame_bt, key_valid=key_valid)
+            query_freqs_bt = freqs_time.unsqueeze(0).expand(batch_size, seq_len_in, self.rope_dim // 2)
+            query_freqs_bt = query_freqs_bt.reshape(batch_size * seq_len_in, 1, self.rope_dim // 2)
+            frame_freqs_bt = frame_freqs.unsqueeze(0).expand(
+                batch_size,
+                seq_len_in,
+                n_cams * (self.num_court_tokens + 1),
+                self.rope_dim // 2,
+            ).reshape(
+                batch_size * seq_len_in,
+                n_cams * (self.num_court_tokens + 1),
+                self.rope_dim // 2,
+            )
+            query_bt = cross_layer(
+                query_bt,
+                frame_bt,
+                key_valid=key_valid,
+                freqs_q_cis=query_freqs_bt,
+                freqs_k_cis=frame_freqs_bt,
+            )
             query_x = query_bt.reshape(batch_size, seq_len_in, self.hidden_dim)
 
             query_x = query_x * query_valid_fixed.unsqueeze(-1).to(dtype=query_x.dtype)

--- a/src/tasks/blcs/models/blcs_query_model.py
+++ b/src/tasks/blcs/models/blcs_query_model.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 from torch import Tensor, nn
@@ -14,7 +14,7 @@ from src.utils.models import (
     RMSNorm,
     TransformerBlock,
     TransformerBlockConfig,
-    precompute_freqs_cis,
+    precompute_freqs_cis_nd,
 )
 from src.utils.models.embeddings import (
     BallUVEmbedding,
@@ -43,9 +43,12 @@ class BLCSQueryModel(nn.Module):
         dropout: float = 0.1,
         rope_dim: int | None = None,
         rope_theta: float = 10000.0,
+        rope_theta_time: float | None = None,
+        rope_theta_entity: float | None = None,
+        rope_theta_type: float = 100.0,
         num_ball_layers: int = 4,
         num_query2ball_layers: int = 2,
-        ffn_type: str = "swiglu",
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         predict_velocity: bool = False,
         max_seq_len: int = 120,
         num_court_tokens: int = NUM_COURT_KP,
@@ -90,6 +93,13 @@ class BLCSQueryModel(nn.Module):
             raise ValueError(f"rope_dim must be even, got {rope_dim}")
         if rope_dim > head_dim:
             raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
+        self.rope_dim = int(rope_dim)
+        self.rope_theta = float(rope_theta)
+        self.rope_bases = (
+            float(self.rope_theta if rope_theta_time is None else rope_theta_time),
+            float(self.rope_theta if rope_theta_entity is None else rope_theta_entity),
+            float(rope_theta_type),
+        )
 
         if ffn_dim is None:
             ffn_dim = int((8 * hidden_dim) / 3)
@@ -122,7 +132,7 @@ class BLCSQueryModel(nn.Module):
                         n_heads=num_heads,
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim,
+                        rope_dim=self.rope_dim,
                         attn_dropout=dropout,
                         ffn_type=ffn_type,
                     )
@@ -138,9 +148,9 @@ class BLCSQueryModel(nn.Module):
                         n_heads=num_heads,
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim,
+                        rope_dim=self.rope_dim,
                         attn_dropout=dropout,
-                        rope_base=rope_theta,
+                        rope_base=self.rope_theta,
                         ffn_type=ffn_type,
                     )
                 )
@@ -155,7 +165,7 @@ class BLCSQueryModel(nn.Module):
                         n_heads=num_heads,
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim,
+                        rope_dim=self.rope_dim,
                         attn_dropout=dropout,
                         ffn_type=ffn_type,
                     )
@@ -171,9 +181,9 @@ class BLCSQueryModel(nn.Module):
                         n_heads=num_heads,
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim,
+                        rope_dim=self.rope_dim,
                         attn_dropout=dropout,
-                        rope_base=rope_theta,
+                        rope_base=self.rope_theta,
                         ffn_type=ffn_type,
                     )
                 )
@@ -199,13 +209,12 @@ class BLCSQueryModel(nn.Module):
                 dropout=dropout,
             )
 
-        freqs_cis = precompute_freqs_cis(
-            dim=rope_dim,
-            seqlen=self.max_seq_len,
-            base=rope_theta,
-            device=None,
+        court_freqs_cis = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_court_positions(),
+            base=self.rope_bases,
         )
-        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+        self.register_buffer("court_freqs_cis", court_freqs_cis, persistent=False)
 
     @classmethod
     def from_config(cls, config: DictConfig) -> BLCSQueryModel:
@@ -227,15 +236,41 @@ class BLCSQueryModel(nn.Module):
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_dim=model_cfg.get("rope_dim", None),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
+            rope_theta_entity=model_cfg.get("rope_theta_entity", None),
+            rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
             num_ball_layers=int(num_ball_layers),
             num_query2ball_layers=int(model_cfg.get("num_query2ball_layers", 2)),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             predict_velocity=bool(model_cfg.get("predict_velocity", False)),
             max_seq_len=int(model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))),
             num_court_tokens=int(model_cfg.get("num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP))),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             query_init_std=float(model_cfg.get("query_init_std", 0.02)),
         )
+
+    def _build_court_positions(self) -> Tensor:
+        court_idx = torch.arange(self.num_court_tokens, dtype=torch.long)
+        return torch.stack(
+            [
+                torch.zeros_like(court_idx),
+                court_idx,
+                torch.zeros_like(court_idx),
+            ],
+            dim=-1,
+        )
+
+    @staticmethod
+    def _build_stream_positions(
+        seq_len: int,
+        device: torch.device,
+        *,
+        token_type: int,
+    ) -> Tensor:
+        time_idx = torch.arange(seq_len, device=device, dtype=torch.long) + 1
+        entity_idx = torch.zeros(seq_len, device=device, dtype=torch.long)
+        type_idx = torch.full((seq_len,), token_type, device=device, dtype=torch.long)
+        return torch.stack([time_idx, entity_idx, type_idx], dim=-1)
 
     @staticmethod
     def _build_self_attn_mask(valid: Tensor) -> tuple[Tensor, Tensor]:
@@ -307,23 +342,39 @@ class BLCSQueryModel(nn.Module):
         court_tok = court_tok + self.court_id_embed(court_ids).unsqueeze(0)
         query_tok = self.query_base.expand(batch_size, seq_len, -1)
 
-        freqs_cis = self.freqs_cis[:seq_len]
-        if freqs_cis.device != ball_uv.device:
-            freqs_cis = freqs_cis.to(ball_uv.device)
+        ball_freqs_cis = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_stream_positions(seq_len, ball_uv.device, token_type=1),
+            base=self.rope_bases,
+        )
+        query_freqs_cis = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_stream_positions(seq_len, ball_uv.device, token_type=2),
+            base=self.rope_bases,
+        )
+        court_freqs_cis = cast(Tensor, self.court_freqs_cis)
+        if court_freqs_cis.device != ball_uv.device:
+            court_freqs_cis = court_freqs_cis.to(ball_uv.device)
 
         ball_attn_mask, ball_valid = self._build_self_attn_mask(ball_valid)
 
         # Stage 1: interleaved ball->court cross-attn and ball temporal self-attn
         ball_x = ball_tok
-        for cross_layer, self_layer in zip(self.ball_to_court_cross_layers, self.ball_temporal_layers):
+        for cross_layer, self_layer in zip(
+            self.ball_to_court_cross_layers,
+            self.ball_temporal_layers,
+            strict=True,
+        ):
             ball_x = cross_layer(
                 ball_x,
                 court_tok,
                 key_valid=court_valid,
+                freqs_q_cis=ball_freqs_cis,
+                freqs_k_cis=court_freqs_cis,
             )
             ball_x = self_layer(
                 ball_x,
-                freqs_cis=freqs_cis,
+                freqs_cis=ball_freqs_cis,
                 attn_mask=ball_attn_mask,
             )
 
@@ -331,17 +382,21 @@ class BLCSQueryModel(nn.Module):
 
         # Stage 2: interleaved query->ball cross-attn and query temporal self-attn
         query_c = query_tok
-        for cross_layer, self_layer in zip(self.query_to_ball_cross_layers, self.query_temporal_layers):
+        for cross_layer, self_layer in zip(
+            self.query_to_ball_cross_layers,
+            self.query_temporal_layers,
+            strict=True,
+        ):
             query_c = cross_layer(
                 query_c,
                 ball_b,
                 key_valid=ball_valid,
-                freqs_q_cis=freqs_cis,
-                freqs_k_cis=freqs_cis,
+                freqs_q_cis=query_freqs_cis,
+                freqs_k_cis=ball_freqs_cis,
             )
             query_c = self_layer(
                 query_c,
-                freqs_cis=freqs_cis,
+                freqs_cis=query_freqs_cis,
                 attn_mask=ball_attn_mask,
             )
 

--- a/src/tasks/event_detection/configs/model/traj3d_transformer.yaml
+++ b/src/tasks/event_detection/configs/model/traj3d_transformer.yaml
@@ -8,5 +8,6 @@ ffn_type: swiglu
 invisible_init_std: 0.02
 
 rope_theta: 10000.0
+rope_theta_time: 10000.0
 max_seq_len: 10240
 num_events: 2  # [shot, bounce]

--- a/src/tasks/event_detection/configs/model/uv_transformer.yaml
+++ b/src/tasks/event_detection/configs/model/uv_transformer.yaml
@@ -7,6 +7,9 @@ ffn_dim: null
 ffn_type: swiglu
 invisible_init_std: 0.02
 
-rope_theta: 10000.0
+# 3-axis interleaved MROPE
+rope_theta_time: 10000.0
+rope_theta_camera: 10000.0
+rope_theta_type: 100.0
 max_seq_len: 10240
 num_events: 2  # [shot, bounce]

--- a/src/tasks/event_detection/configs/model/uv_transformer_nocourt.yaml
+++ b/src/tasks/event_detection/configs/model/uv_transformer_nocourt.yaml
@@ -8,5 +8,6 @@ ffn_type: swiglu
 invisible_init_std: 0.02
 
 rope_theta: 10000.0
+rope_theta_time: 10000.0
 max_seq_len: 10240
 num_events: 2  # [shot, bounce]

--- a/src/tasks/event_detection/models/traj3d_event_model.py
+++ b/src/tasks/event_detection/models/traj3d_event_model.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 
+from src.tasks.event_detection.models.components.heads import EventLogitsHead
 from src.utils.models import (
     RMSNorm,
     TransformerBlock,
@@ -15,7 +16,6 @@ from src.utils.models import (
     precompute_freqs_cis,
 )
 from src.utils.models.embeddings import Ball3DEmbedding, InvisibleTokenEmbedding
-from src.tasks.event_detection.models.components.heads import EventLogitsHead
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -31,10 +31,11 @@ class Traj3DEventModel(nn.Module):
         num_heads: int = 8,
         dropout: float = 0.1,
         rope_theta: float = 10000.0,
+        rope_theta_time: float | None = None,
         max_seq_len: int = 256,
         num_events: int = 2,
         ffn_dim: int | None = None,
-        ffn_type: str = "swiglu",
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         invisible_init_std: float = 0.02,
     ) -> None:
         super().__init__()
@@ -46,6 +47,7 @@ class Traj3DEventModel(nn.Module):
             raise ValueError("hidden_dim must be divisible by num_heads.")
         head_dim = self.hidden_dim // int(num_heads)
         rope_dim = head_dim
+        rope_base = float(rope_theta if rope_theta_time is None else rope_theta_time)
 
         self.invisible_token = InvisibleTokenEmbedding(
             dim=self.hidden_dim, init_std=invisible_init_std
@@ -65,7 +67,7 @@ class Traj3DEventModel(nn.Module):
                         head_dim=head_dim,
                         rope_dim=rope_dim,
                         attn_dropout=dropout,
-                        rope_base=float(rope_theta),
+                        rope_base=rope_base,
                         ffn_type=ffn_type,
                     )
                 )
@@ -78,7 +80,7 @@ class Traj3DEventModel(nn.Module):
         freqs_cis = precompute_freqs_cis(
             dim=rope_dim,
             seqlen=self.max_seq_len,
-            base=float(rope_theta),
+            base=rope_base,
             device=None,
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
@@ -93,10 +95,11 @@ class Traj3DEventModel(nn.Module):
             num_heads=int(model_cfg.get("num_heads", 8)),
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
             max_seq_len=int(model_cfg.get("max_seq_len", 256)),
             num_events=int(model_cfg.get("num_events", 2)),
             ffn_dim=model_cfg.get("ffn_dim"),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
         )
 

--- a/src/tasks/event_detection/models/uv_event_model.py
+++ b/src/tasks/event_detection/models/uv_event_model.py
@@ -8,20 +8,24 @@ Architecture is aligned with src/tasks/blcs/models/blcs_model.py:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 
+from src.tasks.event_detection.models.components.heads import EventLogitsHead
 from src.utils.models import (
     RMSNorm,
     TransformerBlock,
     TransformerBlockConfig,
-    precompute_freqs_cis,
+    precompute_freqs_cis_nd,
 )
-from src.utils.models.embeddings import BallUVEmbedding, CourtKPUVEmbedding, InvisibleTokenEmbedding
-from src.tasks.event_detection.models.components.heads import EventLogitsHead
+from src.utils.models.embeddings import (
+    BallUVEmbedding,
+    CourtKPUVEmbedding,
+    InvisibleTokenEmbedding,
+)
 from src.utils.schema.court import NUM_COURT_KP
 
 if TYPE_CHECKING:
@@ -38,10 +42,13 @@ class UVEventModel(nn.Module):
         num_heads: int = 8,
         dropout: float = 0.1,
         rope_theta: float = 10000.0,
+        rope_theta_time: float | None = None,
+        rope_theta_camera: float | None = None,
+        rope_theta_type: float = 100.0,
         max_seq_len: int = 256,
         num_events: int = 2,
         ffn_dim: int | None = None,
-        ffn_type: str = "swiglu",
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         invisible_init_std: float = 0.02,
         num_court_tokens: int = NUM_COURT_KP,
     ) -> None:
@@ -55,7 +62,12 @@ class UVEventModel(nn.Module):
             raise ValueError("hidden_dim must be divisible by num_heads.")
         head_dim = self.hidden_dim // int(num_heads)
         rope_dim = head_dim
-        max_tokens = int(self.num_court_tokens + self.max_seq_len)
+        self.rope_theta = float(rope_theta)
+        self.rope_bases = (
+            float(self.rope_theta if rope_theta_time is None else rope_theta_time),
+            float(self.rope_theta if rope_theta_camera is None else rope_theta_camera),
+            float(rope_theta_type),
+        )
 
         self.invisible_token = InvisibleTokenEmbedding(
             dim=self.hidden_dim, init_std=invisible_init_std
@@ -70,7 +82,6 @@ class UVEventModel(nn.Module):
             dropout=dropout,
             invisible_token=self.invisible_token,
         )
-        self.type_embed = nn.Embedding(2, self.hidden_dim)
 
         self.blocks = nn.ModuleList(
             [
@@ -82,7 +93,7 @@ class UVEventModel(nn.Module):
                         head_dim=head_dim,
                         rope_dim=rope_dim,
                         attn_dropout=dropout,
-                        rope_base=float(rope_theta),
+                        rope_base=self.rope_theta,
                         ffn_type=ffn_type,
                     )
                 )
@@ -92,11 +103,10 @@ class UVEventModel(nn.Module):
         self.final_norm = RMSNorm(self.hidden_dim)
         self.head = EventLogitsHead(input_dim=self.hidden_dim, num_events=self.num_events, dropout=dropout)
 
-        freqs_cis = precompute_freqs_cis(
+        freqs_cis = precompute_freqs_cis_nd(
             dim=rope_dim,
-            seqlen=max_tokens,
-            base=float(rope_theta),
-            device=None,
+            pos=self._build_rope_positions(),
+            base=self.rope_bases,
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
@@ -111,13 +121,39 @@ class UVEventModel(nn.Module):
             num_heads=int(model_cfg.get("num_heads", 8)),
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
+            rope_theta_camera=model_cfg.get("rope_theta_camera", None),
+            rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
             max_seq_len=int(model_cfg.get("max_seq_len", 256)),
             num_events=int(model_cfg.get("num_events", 2)),
             ffn_dim=model_cfg.get("ffn_dim"),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             num_court_tokens=int(data_cfg.get("num_court_kp", NUM_COURT_KP)),
         )
+
+    def _build_rope_positions(self) -> Tensor:
+        """Build 3-axis RoPE positions for `[court, ball]` tokens."""
+        court_idx = torch.arange(self.num_court_tokens, dtype=torch.long)
+        ball_time = torch.arange(self.max_seq_len, dtype=torch.long) + 1
+
+        court_pos = torch.stack(
+            [
+                torch.zeros_like(court_idx),
+                court_idx,
+                torch.zeros_like(court_idx),
+            ],
+            dim=-1,
+        )
+        ball_pos = torch.stack(
+            [
+                ball_time,
+                torch.zeros_like(ball_time),
+                torch.ones_like(ball_time),
+            ],
+            dim=-1,
+        )
+        return torch.cat([court_pos, ball_pos], dim=0)
 
     def forward(
         self,
@@ -141,7 +177,7 @@ class UVEventModel(nn.Module):
             Logits (B, T, E)
         """
         B, T, _ = ball_uv.shape
-        if T > self.max_seq_len:
+        if self.max_seq_len < T:
             ball_uv = ball_uv[:, : self.max_seq_len]
             if ball_vis is not None:
                 ball_vis = ball_vis[:, : self.max_seq_len]
@@ -159,14 +195,7 @@ class UVEventModel(nn.Module):
         ball_tokens = self.ball_embed(ball_uv, ball_vis)  # (B, T, D)
 
         K = self.num_court_tokens
-        court_type = self.type_embed(
-            torch.zeros(K, device=ball_uv.device, dtype=torch.long)
-        )[None, :, :]
-        ball_type = self.type_embed(
-            torch.ones(T, device=ball_uv.device, dtype=torch.long)
-        )[None, :, :]
-
-        x = torch.cat([court_tokens + court_type, ball_tokens + ball_type], dim=1)  # (B, S, D)
+        x = torch.cat([court_tokens, ball_tokens], dim=1)  # (B, S, D)
         S = x.shape[1]
 
         key_padding_mask: Tensor | None = None
@@ -178,9 +207,10 @@ class UVEventModel(nn.Module):
             ball_valid = ball_mask > 0
             key_padding_mask = torch.cat([court_valid, ball_valid], dim=1)  # (B, S)
 
-        if S > self.freqs_cis.shape[0]:
+        freqs_cis = cast(Tensor, self.freqs_cis)
+        if freqs_cis.shape[0] < S:
             raise ValueError("Sequence length exceeds max_seq_len; increase model.max_seq_len.")
-        freqs_cis = self.freqs_cis[:S]
+        freqs_cis = freqs_cis[:S]
         if freqs_cis.device != x.device:
             freqs_cis = freqs_cis.to(x.device)
 
@@ -198,7 +228,7 @@ class UVEventModel(nn.Module):
         x = self.final_norm(x)
 
         ball_h = x[:, K:, :]
-        return self.head(ball_h)
+        return cast(Tensor, self.head(ball_h))
 
 
 if __name__ == "__main__":

--- a/src/tasks/event_detection/models/uv_event_nocourt_model.py
+++ b/src/tasks/event_detection/models/uv_event_nocourt_model.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 
+from src.tasks.event_detection.models.components.heads import EventLogitsHead
 from src.utils.models import (
     RMSNorm,
     TransformerBlock,
@@ -15,7 +16,6 @@ from src.utils.models import (
     precompute_freqs_cis,
 )
 from src.utils.models.embeddings import BallUVEmbedding, InvisibleTokenEmbedding
-from src.tasks.event_detection.models.components.heads import EventLogitsHead
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -33,10 +33,11 @@ class UVEventNoCourtModel(nn.Module):
         num_heads: int = 8,
         dropout: float = 0.1,
         rope_theta: float = 10000.0,
+        rope_theta_time: float | None = None,
         max_seq_len: int = 256,
         num_events: int = 2,
         ffn_dim: int | None = None,
-        ffn_type: str = "swiglu",
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         invisible_init_std: float = 0.02,
     ) -> None:
         super().__init__()
@@ -48,6 +49,7 @@ class UVEventNoCourtModel(nn.Module):
             raise ValueError("hidden_dim must be divisible by num_heads.")
         head_dim = self.hidden_dim // int(num_heads)
         rope_dim = head_dim
+        rope_base = float(rope_theta if rope_theta_time is None else rope_theta_time)
 
         self.invisible_token = InvisibleTokenEmbedding(
             dim=self.hidden_dim, init_std=invisible_init_std
@@ -68,7 +70,7 @@ class UVEventNoCourtModel(nn.Module):
                         head_dim=head_dim,
                         rope_dim=rope_dim,
                         attn_dropout=dropout,
-                        rope_base=float(rope_theta),
+                        rope_base=rope_base,
                         ffn_type=ffn_type,
                     )
                 )
@@ -81,7 +83,7 @@ class UVEventNoCourtModel(nn.Module):
         freqs_cis = precompute_freqs_cis(
             dim=rope_dim,
             seqlen=self.max_seq_len,
-            base=float(rope_theta),
+            base=rope_base,
             device=None,
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
@@ -96,10 +98,11 @@ class UVEventNoCourtModel(nn.Module):
             num_heads=int(model_cfg.get("num_heads", 8)),
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
             max_seq_len=int(model_cfg.get("max_seq_len", 256)),
             num_events=int(model_cfg.get("num_events", 2)),
             ffn_dim=model_cfg.get("ffn_dim"),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
         )
 
@@ -122,7 +125,7 @@ class UVEventNoCourtModel(nn.Module):
             Logits (B, T, E)
         """
         B, T, _ = ball_uv.shape
-        if T > self.max_seq_len:
+        if self.max_seq_len < T:
             ball_uv = ball_uv[:, : self.max_seq_len]
             if ball_vis is not None:
                 ball_vis = ball_vis[:, : self.max_seq_len]

--- a/src/tasks/plcs/configs/model/frame.yaml
+++ b/src/tasks/plcs/configs/model/frame.yaml
@@ -18,8 +18,10 @@ invisible_init_std: 0.02
 # Token identity / robustness settings
 num_register_tokens: 4
 use_kp_id_embedding: true
-use_rope: false
+use_rope: true
 
-# RoPE settings
-rope_dim: null       # Defaults to head_dim (hidden_dim / num_heads)
-rope_theta: 10000.0
+# 3-axis interleaved MROPE settings
+rope_dim: null           # Defaults to head_dim (hidden_dim / num_heads)
+rope_theta_time: 10000.0 # Token-order axis
+rope_theta_camera: 10000.0
+rope_theta_type: 100.0

--- a/src/tasks/plcs/configs/model/multiview.yaml
+++ b/src/tasks/plcs/configs/model/multiview.yaml
@@ -1,6 +1,6 @@
 # Multi-view PLCS model configuration
 # Per-camera tokens: court_m(20) + T * (CLS_po_{m,t}, CLS_ro_{m,t}, player_{m,t}[17])
-# Uses 2D RoPE over (time, camera) axes.
+# Uses 3-axis interleaved MROPE over (time, camera, type).
 
 name: plcs_multiview
 
@@ -21,9 +21,11 @@ invisible_init_std: 0.02
 max_views: 8
 max_seq_len: 120
 
-# 2D RoPE
-rope_dim: null       # Defaults to head_dim; must satisfy rope_dim % 4 == 0
-rope_theta: 10000.0
+# 3-axis interleaved MROPE
+rope_dim: null            # Defaults to head_dim; must be even
+rope_theta_time: 10000.0
+rope_theta_camera: 10000.0
+rope_theta_type: 100.0
 
 # Model type
 architecture: multiview

--- a/src/tasks/plcs/configs/model/sequence_query.yaml
+++ b/src/tasks/plcs/configs/model/sequence_query.yaml
@@ -22,9 +22,12 @@ max_seq_len: 2048
 num_player_layers: 4
 num_query_layers: 2
 
-# RoPE (temporal only)
+# RoPE axes: time, entity (court/joint id), type (court/player/query)
 rope_dim: null
 rope_theta: 10000.0
+rope_theta_time: 10000.0
+rope_theta_entity: 10000.0
+rope_theta_type: 100.0
 
 # Model type
 architecture: sequence

--- a/src/tasks/plcs/models/plcs_model.py
+++ b/src/tasks/plcs/models/plcs_model.py
@@ -21,24 +21,24 @@ Notes:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 
+from src.tasks.plcs.models.components.heads import PositionHead, RotationHead
 from src.utils.models import (
     RMSNorm,
     TransformerBlock,
     TransformerBlockConfig,
-    precompute_freqs_cis,
+    precompute_freqs_cis_nd,
 )
 from src.utils.models.embeddings import (
     CourtKPUVEmbedding,
     InvisibleTokenEmbedding,
     PlayerKPUVEmbedding,
 )
-from src.tasks.plcs.models.components.heads import PositionHead, RotationHead
 from src.utils.schema.court import NUM_COURT_KP
 from src.utils.schema.player import NUM_HUMAN_KP
 
@@ -82,10 +82,13 @@ class PLCSModel(nn.Module):
         dropout: float = 0.1,
         rope_dim: int | None = None,
         rope_theta: float = 10000.0,
+        rope_theta_time: float | None = None,
+        rope_theta_camera: float | None = None,
+        rope_theta_type: float = 100.0,
         num_register_tokens: int = 4,
         use_kp_id_embedding: bool = True,
-        use_rope: bool = False,
-        ffn_type: str = "swiglu",
+        use_rope: bool = True,
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         invisible_init_std: float = 0.02,
         num_court_tokens: int = NUM_COURT_KP,
     ) -> None:
@@ -118,6 +121,11 @@ class PLCSModel(nn.Module):
         rope_dim = head_dim if rope_dim is None else rope_dim
         self.rope_dim = int(rope_dim)
         self.rope_theta = float(rope_theta)
+        self.rope_bases = (
+            float(self.rope_theta if rope_theta_time is None else rope_theta_time),
+            float(self.rope_theta if rope_theta_camera is None else rope_theta_camera),
+            float(rope_theta_type),
+        )
 
         if ffn_dim is None:
             ffn_dim = int((8 * hidden_dim) / 3)
@@ -140,9 +148,6 @@ class PLCSModel(nn.Module):
             dropout=dropout,
             invisible_token=self.invisible_token,
         )
-
-        # Type embedding: 0 = court, 1 = player
-        self.type_embed = nn.Embedding(2, hidden_dim)
 
         # CLS token (no RoPE applied)
         self.cls_token = nn.Parameter(torch.zeros(1, 1, hidden_dim))
@@ -194,13 +199,12 @@ class PLCSModel(nn.Module):
         )
 
         if self.use_rope:
-            freqs_cis = precompute_freqs_cis(
+            freqs_cis = precompute_freqs_cis_nd(
                 dim=self.rope_dim,
-                seqlen=self.max_tokens,
-                base=self.rope_theta,
-                device=None,  # initialized on CPU; moved by `model.to(device)`
+                pos=self._build_body_rope_positions(),
+                base=self.rope_bases,
             )
-            self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+            self.register_buffer("freqs_cis_body", freqs_cis, persistent=False)
 
     @classmethod
     def from_config(cls, config: DictConfig) -> PLCSModel:
@@ -224,13 +228,39 @@ class PLCSModel(nn.Module):
             dropout=model_cfg.get("dropout", 0.1),
             rope_dim=model_cfg.get("rope_dim", None),
             rope_theta=model_cfg.get("rope_theta", 10000.0),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
+            rope_theta_camera=model_cfg.get("rope_theta_camera", None),
+            rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
             num_register_tokens=int(model_cfg.get("num_register_tokens", 4)),
             use_kp_id_embedding=bool(model_cfg.get("use_kp_id_embedding", True)),
-            use_rope=bool(model_cfg.get("use_rope", False)),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            use_rope=bool(model_cfg.get("use_rope", True)),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             num_court_tokens=int(data_cfg.get("num_court_kp", NUM_COURT_KP)),
         )
+
+    def _build_body_rope_positions(self) -> Tensor:
+        """Build 3-axis RoPE positions for `[court, player]` body tokens."""
+        court_idx = torch.arange(self.num_court_tokens, dtype=torch.long)
+        player_idx = torch.arange(NUM_HUMAN_KP, dtype=torch.long)
+
+        court_pos = torch.stack(
+            [
+                court_idx,
+                torch.zeros_like(court_idx),
+                torch.zeros_like(court_idx),
+            ],
+            dim=-1,
+        )
+        player_pos = torch.stack(
+            [
+                player_idx,
+                torch.zeros_like(player_idx),
+                torch.ones_like(player_idx),
+            ],
+            dim=-1,
+        )
+        return torch.cat([court_pos, player_pos], dim=0)
 
     def _build_body_tokens(
         self,
@@ -238,7 +268,7 @@ class PLCSModel(nn.Module):
         court_kp: Tensor,
         human_vis: Tensor | None = None,
         court_vis: Tensor | None = None,
-    ) -> dict[str, Tensor]:
+    ) -> Tensor:
         """Forward pass.
 
         Args:
@@ -264,20 +294,11 @@ class PLCSModel(nn.Module):
                 - rotation: (B, 2) as (cos(yaw), sin(yaw))
 
         """
-        B = human_kp.size(0)
-
         # Tokenize court and player keypoints
         court_tok = self.court_embed(court_kp, court_vis)  # (B, K, D)
         player_tok = self.player_embed(human_kp, human_vis)  # (B, 17, D)
 
         K = court_tok.shape[1]
-        # Add type embeddings
-        court_type = self.type_embed(
-            torch.zeros(K, device=human_kp.device, dtype=torch.long)
-        )[None, :, :]  # (1, K, D)
-        player_type = self.type_embed(
-            torch.ones(NUM_HUMAN_KP, device=human_kp.device, dtype=torch.long)
-        )[None, :, :]  # (1, 17, D)
 
         if self.use_kp_id_embedding:
             court_id = self.court_id_embed(
@@ -289,10 +310,7 @@ class PLCSModel(nn.Module):
             court_tok = court_tok + court_id
             player_tok = player_tok + player_id
 
-        token_body = torch.cat(
-            [court_tok + court_type, player_tok + player_type], dim=1
-        )  # (B, 37, D)
-        return token_body
+        return torch.cat([court_tok, player_tok], dim=1)  # (B, 37, D)
 
     def _add_prefix_tokens(self, token_body: Tensor) -> Tensor:
         """Add CLS/register prefix tokens to body tokens."""
@@ -309,12 +327,13 @@ class PLCSModel(nn.Module):
 
         freqs_cis: Tensor | None = None
         if self.use_rope:
-            if S_body > self.freqs_cis.shape[0]:
+            freqs_cis_body = cast(Tensor, self.freqs_cis_body)
+            if S_body > freqs_cis_body.shape[0]:
                 raise ValueError(
-                    f"Sequence length S={S_body} exceeds cached freqs_cis length {self.freqs_cis.shape[0]}. "
+                    f"Sequence length S={S_body} exceeds cached freqs_cis length {freqs_cis_body.shape[0]}. "
                     "Increase max_tokens."
                 )
-            freqs_cis_body = self.freqs_cis[:S_body]
+            freqs_cis_body = freqs_cis_body[:S_body]
             if freqs_cis_body.device != x.device:
                 freqs_cis_body = freqs_cis_body.to(x.device)
 
@@ -352,7 +371,7 @@ class PLCSModel(nn.Module):
         S_body = token_body.shape[1]
         x = self._add_prefix_tokens(token_body)
         x = self._forward_transformer(x=x, S_body=S_body)
-        player_start_idx = 1 + self.num_register_tokens + court_tok.shape[1]
+        player_start_idx = 1 + self.num_register_tokens + self.num_court_tokens
         return x, player_start_idx
 
     def forward(

--- a/src/tasks/plcs/models/plcs_multiview_model.py
+++ b/src/tasks/plcs/models/plcs_multiview_model.py
@@ -8,20 +8,24 @@ where each frame block is:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 
+from src.tasks.plcs.models.components.heads import PositionHead, RotationHead
 from src.utils.models import (
     MultiHeadSelfAttention,
     RMSNorm,
-    precompute_freqs_cis_2d,
+    precompute_freqs_cis_nd,
 )
 from src.utils.models.components.ffn_layers import MLP, SwiGLU, default_ffn_dim
-from src.utils.models.embeddings import CourtKPUVEmbedding, InvisibleTokenEmbedding, PlayerKPUVEmbedding
-from src.tasks.plcs.models.components.heads import PositionHead, RotationHead
+from src.utils.models.embeddings import (
+    CourtKPUVEmbedding,
+    InvisibleTokenEmbedding,
+    PlayerKPUVEmbedding,
+)
 from src.utils.schema.court import NUM_COURT_KP
 from src.utils.schema.player import NUM_HUMAN_KP
 
@@ -29,8 +33,8 @@ if TYPE_CHECKING:
     from omegaconf import DictConfig
 
 
-class Rope2DTransformerBlock(nn.Module):
-    """Transformer block with SDPA and 2D RoPE support."""
+class RoPETransformerBlock(nn.Module):
+    """Transformer block with SDPA and generic RoPE support."""
 
     def __init__(
         self,
@@ -65,22 +69,20 @@ class Rope2DTransformerBlock(nn.Module):
         self,
         x: Tensor,
         *,
-        rope2d: tuple[Tensor, Tensor],
-        positions_2d: Tensor,
+        freqs_cis: Tensor,
         attn_mask: Tensor | None,
     ) -> Tensor:
         x_attn = x + self.attn(
             self.attn_norm(x),
-            rope2d=rope2d,
-            positions_2d=positions_2d,
+            freqs_cis=freqs_cis,
             attn_mask=attn_mask,
         )
-        x_fnn = x_attn + self.ffn(self.ffn_norm(x_attn))
+        x_fnn = x_attn + cast(Tensor, self.ffn(self.ffn_norm(x_attn)))
         return x_fnn
 
 
 class PLCSMultiViewModel(nn.Module):
-    """Multi-view PLCS model using camera-time 2D RoPE."""
+    """Multi-view PLCS model using 3-axis interleaved MROPE."""
 
     def __init__(
         self,
@@ -91,6 +93,9 @@ class PLCSMultiViewModel(nn.Module):
         dropout: float = 0.1,
         rope_dim: int | None = None,
         rope_theta: float = 10000.0,
+        rope_theta_time: float | None = None,
+        rope_theta_camera: float | None = None,
+        rope_theta_type: float = 100.0,
         ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         max_views: int = 8,
         max_seq_len: int = 120,
@@ -110,9 +115,14 @@ class PLCSMultiViewModel(nn.Module):
         rope_dim = head_dim if rope_dim is None else rope_dim
         self.rope_dim = int(rope_dim)
         self.rope_theta = float(rope_theta)
+        self.rope_bases = (
+            float(self.rope_theta if rope_theta_time is None else rope_theta_time),
+            float(self.rope_theta if rope_theta_camera is None else rope_theta_camera),
+            float(rope_theta_type),
+        )
 
-        if self.rope_dim % 4 != 0:
-            raise ValueError(f"2D RoPE requires rope_dim % 4 == 0, got {self.rope_dim}")
+        if self.rope_dim % 2 != 0:
+            raise ValueError(f"RoPE requires an even rope_dim, got {self.rope_dim}")
 
         if ffn_dim is None:
             ffn_dim = default_ffn_dim(hidden_dim)
@@ -136,7 +146,7 @@ class PLCSMultiViewModel(nn.Module):
 
         self.blocks = nn.ModuleList(
             [
-                Rope2DTransformerBlock(
+                RoPETransformerBlock(
                     dim=hidden_dim,
                     n_heads=num_heads,
                     ffn_dim=ffn_dim,
@@ -164,16 +174,6 @@ class PLCSMultiViewModel(nn.Module):
             dropout=dropout,
         )
 
-        freqs_y, freqs_x = precompute_freqs_cis_2d(
-            dim=self.rope_dim,
-            height=self.max_seq_len + 1,
-            width=self.max_views,
-            base=self.rope_theta,
-            device=None,
-        )
-        self.register_buffer("freqs_cis_y", freqs_y, persistent=False)
-        self.register_buffer("freqs_cis_x", freqs_x, persistent=False)
-
     @classmethod
     def from_config(cls, config: DictConfig) -> PLCSMultiViewModel:
         """Create model from hydra config."""
@@ -188,27 +188,30 @@ class PLCSMultiViewModel(nn.Module):
             dropout=model_cfg.get("dropout", 0.1),
             rope_dim=model_cfg.get("rope_dim", None),
             rope_theta=model_cfg.get("rope_theta", 10000.0),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
+            rope_theta_camera=model_cfg.get("rope_theta_camera", None),
+            rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             max_views=model_cfg.get("max_views", 8),
             max_seq_len=model_cfg.get("max_seq_len", 120),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             num_court_tokens=int(data_cfg.get("num_court_kp", NUM_COURT_KP)),
         )
 
-    def _build_positions_2d(
+    def _build_positions_3d(
         self,
         *,
-        batch_size: int,
         n_cameras: int,
         seq_len: int,
         device: torch.device,
     ) -> Tensor:
-        """Build (B, S, 2) coordinates with axes: (time, camera)."""
+        """Build `(S, 3)` coordinates with axes: (time, camera, type)."""
         per_cam: list[Tensor] = []
         for cam_idx in range(n_cameras):
             court_time = torch.zeros(self.num_court_tokens, device=device, dtype=torch.long)
             court_cam = torch.full((self.num_court_tokens,), cam_idx, device=device, dtype=torch.long)
-            court_pos = torch.stack([court_time, court_cam], dim=-1)
+            court_type = torch.zeros(self.num_court_tokens, device=device, dtype=torch.long)
+            court_pos = torch.stack([court_time, court_cam, court_type], dim=-1)
 
             frame_time = torch.arange(seq_len, device=device, dtype=torch.long).repeat_interleave(
                 self.frame_block_tokens
@@ -219,11 +222,11 @@ class PLCSMultiViewModel(nn.Module):
                 device=device,
                 dtype=torch.long,
             )
-            frame_pos = torch.stack([frame_time, frame_cam], dim=-1)
+            frame_type = torch.ones(seq_len * self.frame_block_tokens, device=device, dtype=torch.long)
+            frame_pos = torch.stack([frame_time, frame_cam, frame_type], dim=-1)
             per_cam.append(torch.cat([court_pos, frame_pos], dim=0))
 
-        positions = torch.cat(per_cam, dim=0)
-        return positions.unsqueeze(0).expand(batch_size, -1, -1)
+        return torch.cat(per_cam, dim=0)
 
     def forward(
         self,
@@ -290,9 +293,9 @@ class PLCSMultiViewModel(nn.Module):
         B, N, T = human_kp.shape[:3]
         device = human_kp.device
 
-        if N > self.max_views:
+        if self.max_views < N:
             raise ValueError(f"Number of views N={N} exceeds max_views={self.max_views}.")
-        if T > self.max_seq_len:
+        if self.max_seq_len < T:
             raise ValueError(f"Sequence length T={T} exceeds max_seq_len={self.max_seq_len}.")
 
         if human_mask is not None:
@@ -311,6 +314,8 @@ class PLCSMultiViewModel(nn.Module):
         # court is camera-level (use first frame per camera)
         court_scene = court_kp[:, :, 0, :, :]  # (B,N,K,2)
         K = court_scene.shape[2]
+        if self.num_court_tokens != K:
+            raise ValueError(f"Expected {self.num_court_tokens} court tokens, got {K}.")
         court_scene_flat = court_scene.reshape(B * N, K, 2)
 
         court_vis_scene: Tensor | None = None
@@ -360,26 +365,21 @@ class PLCSMultiViewModel(nn.Module):
         eye = torch.eye(S, device=device, dtype=torch.bool).unsqueeze(0)
         attn_mask = attn_keep | eye
 
-        positions_2d = self._build_positions_2d(
-            batch_size=B,
+        positions_3d = self._build_positions_3d(
             n_cameras=N,
             seq_len=T,
             device=device,
         )
-
-        freqs_y = self.freqs_cis_y[: T + 1]
-        freqs_x = self.freqs_cis_x[:N]
-        if freqs_y.device != device:
-            freqs_y = freqs_y.to(device)
-        if freqs_x.device != device:
-            freqs_x = freqs_x.to(device)
-        rope2d = (freqs_y, freqs_x)
+        freqs_cis = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=positions_3d,
+            base=self.rope_bases,
+        )
 
         for blk in self.blocks:
             x = blk(
                 x,
-                rope2d=rope2d,
-                positions_2d=positions_2d,
+                freqs_cis=freqs_cis,
                 attn_mask=attn_mask,
             )
             x = x * token_valid.unsqueeze(-1).to(dtype=x.dtype)

--- a/src/tasks/plcs/models/plcs_query_sequence_model.py
+++ b/src/tasks/plcs/models/plcs_query_sequence_model.py
@@ -2,26 +2,26 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 
+from src.tasks.plcs.models.components.heads import PositionHead, RotationHead
 from src.utils.models import (
     CrossAttnBlock,
     CrossAttnBlockConfig,
     RMSNorm,
     TransformerBlock,
     TransformerBlockConfig,
-    precompute_freqs_cis,
+    precompute_freqs_cis_nd,
 )
 from src.utils.models.embeddings import (
     CourtKPUVEmbedding,
     InvisibleTokenEmbedding,
     PlayerKPUVEmbedding,
 )
-from src.tasks.plcs.models.components.heads import PositionHead, RotationHead
 from src.utils.schema.court import NUM_COURT_KP
 from src.utils.schema.player import NUM_HUMAN_KP
 
@@ -47,9 +47,12 @@ class PLCSQuerySequenceModel(nn.Module):
         dropout: float = 0.1,
         rope_dim: int | None = None,
         rope_theta: float = 10000.0,
+        rope_theta_time: float | None = None,
+        rope_theta_entity: float | None = None,
+        rope_theta_type: float = 100.0,
         num_player_layers: int = 4,
         num_query_layers: int = 2,
-        ffn_type: str = "swiglu",
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         max_seq_len: int = 120,
         invisible_init_std: float = 0.02,
         query_init_std: float = 0.02,
@@ -72,6 +75,7 @@ class PLCSQuerySequenceModel(nn.Module):
         self.max_seq_len = int(max_seq_len)
         self.num_court_tokens = int(num_court_tokens)
         self.num_joints = int(NUM_HUMAN_KP)
+        self.num_query_tokens = 2
 
         head_dim = hidden_dim // num_heads
         rope_dim = head_dim if rope_dim is None else int(rope_dim)
@@ -79,6 +83,13 @@ class PLCSQuerySequenceModel(nn.Module):
             raise ValueError(f"rope_dim must be even, got {rope_dim}")
         if rope_dim > head_dim:
             raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
+        self.rope_dim = int(rope_dim)
+        self.rope_theta = float(rope_theta)
+        self.rope_bases = (
+            float(self.rope_theta if rope_theta_time is None else rope_theta_time),
+            float(self.rope_theta if rope_theta_entity is None else rope_theta_entity),
+            float(rope_theta_type),
+        )
 
         if ffn_dim is None:
             ffn_dim = int((8 * hidden_dim) / 3)
@@ -109,7 +120,7 @@ class PLCSQuerySequenceModel(nn.Module):
                         n_heads=num_heads,
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim,
+                        rope_dim=self.rope_dim,
                         attn_dropout=dropout,
                         ffn_type=ffn_type,
                     )
@@ -125,9 +136,9 @@ class PLCSQuerySequenceModel(nn.Module):
                         n_heads=num_heads,
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim,
+                        rope_dim=self.rope_dim,
                         attn_dropout=dropout,
-                        rope_base=rope_theta,
+                        rope_base=self.rope_theta,
                         ffn_type=ffn_type,
                     )
                 )
@@ -143,7 +154,7 @@ class PLCSQuerySequenceModel(nn.Module):
                         n_heads=num_heads,
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim,
+                        rope_dim=self.rope_dim,
                         attn_dropout=dropout,
                         ffn_type=ffn_type,
                     )
@@ -159,9 +170,9 @@ class PLCSQuerySequenceModel(nn.Module):
                         n_heads=num_heads,
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim,
+                        rope_dim=self.rope_dim,
                         attn_dropout=dropout,
-                        rope_base=rope_theta,
+                        rope_base=self.rope_theta,
                         ffn_type=ffn_type,
                     )
                 )
@@ -185,13 +196,13 @@ class PLCSQuerySequenceModel(nn.Module):
             dropout=dropout,
         )
 
-        freqs_cis = precompute_freqs_cis(
-            dim=rope_dim,
-            seqlen=self.max_seq_len,
-            base=rope_theta,
-            device=None,
+        court_positions = self._build_court_positions()
+        court_freqs_cis = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=court_positions,
+            base=self.rope_bases,
         )
-        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+        self.register_buffer("court_freqs_cis", court_freqs_cis, persistent=False)
 
     @classmethod
     def from_config(cls, config: DictConfig) -> PLCSQuerySequenceModel:
@@ -206,13 +217,99 @@ class PLCSQuerySequenceModel(nn.Module):
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_dim=model_cfg.get("rope_dim", None),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
+            rope_theta_entity=model_cfg.get("rope_theta_entity", None),
+            rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
             num_player_layers=int(model_cfg.get("num_player_layers", 4)),
             num_query_layers=int(model_cfg.get("num_query_layers", 2)),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             max_seq_len=int(model_cfg.get("max_seq_len", 120)),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             query_init_std=float(model_cfg.get("query_init_std", 0.02)),
             num_court_tokens=int(data_cfg.get("num_court_kp", NUM_COURT_KP)),
+        )
+
+    def _build_court_positions(self) -> Tensor:
+        court_idx = torch.arange(self.num_court_tokens, dtype=torch.long)
+        return torch.stack(
+            [
+                torch.zeros_like(court_idx),
+                court_idx,
+                torch.zeros_like(court_idx),
+            ],
+            dim=-1,
+        )
+
+    def _build_player_cross_positions(self, seq_len: int, device: torch.device) -> Tensor:
+        time_idx = torch.arange(seq_len, device=device, dtype=torch.long).repeat_interleave(
+            self.num_joints
+        ) + 1
+        joint_idx = torch.arange(self.num_joints, device=device, dtype=torch.long).repeat(seq_len)
+        token_type = torch.ones(seq_len * self.num_joints, device=device, dtype=torch.long)
+        return torch.stack([time_idx, joint_idx, token_type], dim=-1)
+
+    def _build_player_temporal_positions(self, seq_len: int, device: torch.device) -> Tensor:
+        time_idx = torch.arange(seq_len, device=device, dtype=torch.long).view(1, seq_len)
+        joint_idx = torch.arange(self.num_joints, device=device, dtype=torch.long).view(
+            self.num_joints, 1
+        )
+        token_type = torch.ones((self.num_joints, seq_len), device=device, dtype=torch.long)
+        return torch.stack(
+            [
+                time_idx.expand(self.num_joints, seq_len) + 1,
+                joint_idx.expand(self.num_joints, seq_len),
+                token_type,
+            ],
+            dim=-1,
+        )
+
+    def _build_query_frame_positions(self, seq_len: int, device: torch.device) -> Tensor:
+        time_idx = torch.arange(seq_len, device=device, dtype=torch.long).view(seq_len, 1) + 1
+        entity_idx = torch.zeros((seq_len, self.num_query_tokens), device=device, dtype=torch.long)
+        query_type = torch.arange(
+            2,
+            2 + self.num_query_tokens,
+            device=device,
+            dtype=torch.long,
+        ).view(1, self.num_query_tokens)
+        return torch.stack(
+            [
+                time_idx.expand(seq_len, self.num_query_tokens),
+                entity_idx,
+                query_type.expand(seq_len, self.num_query_tokens),
+            ],
+            dim=-1,
+        )
+
+    def _build_player_key_positions(self, seq_len: int, device: torch.device) -> Tensor:
+        time_idx = torch.arange(seq_len, device=device, dtype=torch.long).view(seq_len, 1) + 1
+        joint_idx = torch.arange(self.num_joints, device=device, dtype=torch.long).view(1, self.num_joints)
+        token_type = torch.ones((seq_len, self.num_joints), device=device, dtype=torch.long)
+        return torch.stack(
+            [
+                time_idx.expand(seq_len, self.num_joints),
+                joint_idx.expand(seq_len, self.num_joints),
+                token_type,
+            ],
+            dim=-1,
+        )
+
+    def _build_query_temporal_positions(self, seq_len: int, device: torch.device) -> Tensor:
+        time_idx = torch.arange(seq_len, device=device, dtype=torch.long).view(1, seq_len)
+        query_type = torch.arange(
+            2,
+            2 + self.num_query_tokens,
+            device=device,
+            dtype=torch.long,
+        ).view(self.num_query_tokens, 1)
+        entity_idx = torch.zeros((self.num_query_tokens, seq_len), device=device, dtype=torch.long)
+        return torch.stack(
+            [
+                time_idx.expand(self.num_query_tokens, seq_len) + 1,
+                entity_idx,
+                query_type.expand(self.num_query_tokens, seq_len),
+            ],
+            dim=-1,
         )
 
     def _normalize_court_inputs(
@@ -394,9 +491,34 @@ class PLCSQuerySequenceModel(nn.Module):
         joint_ids = torch.arange(self.num_joints, device=human_kp.device, dtype=torch.long)
         player_tok = player_tok + self.joint_id_embed(joint_ids).view(1, 1, self.num_joints, -1)
 
-        freqs_cis = self.freqs_cis[:seq_len]
-        if freqs_cis.device != human_kp.device:
-            freqs_cis = freqs_cis.to(human_kp.device)
+        player_cross_freqs = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_player_cross_positions(seq_len, human_kp.device),
+            base=self.rope_bases,
+        )
+        player_temporal_freqs = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_player_temporal_positions(seq_len, human_kp.device),
+            base=self.rope_bases,
+        )
+        query_frame_freqs = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_query_frame_positions(seq_len, human_kp.device),
+            base=self.rope_bases,
+        )
+        player_key_freqs = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_player_key_positions(seq_len, human_kp.device),
+            base=self.rope_bases,
+        )
+        query_temporal_freqs = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_query_temporal_positions(seq_len, human_kp.device),
+            base=self.rope_bases,
+        )
+        court_freqs_cis = cast(Tensor, self.court_freqs_cis)
+        if court_freqs_cis.device != human_kp.device:
+            court_freqs_cis = court_freqs_cis.to(human_kp.device)
 
         court_valid = torch.ones(
             batch_size,
@@ -413,12 +535,18 @@ class PLCSQuerySequenceModel(nn.Module):
         )
 
         player_x = player_tok
-        for cross_layer, self_layer in zip(self.player_cross_layers, self.player_self_layers):
+        for cross_layer, self_layer in zip(
+            self.player_cross_layers,
+            self.player_self_layers,
+            strict=True,
+        ):
             player_flat = player_x.reshape(batch_size, seq_len * self.num_joints, self.hidden_dim)
             player_flat = cross_layer(
                 player_flat,
                 court_tok,
                 key_valid=court_valid,
+                freqs_q_cis=player_cross_freqs,
+                freqs_k_cis=court_freqs_cis,
             )
             player_x = player_flat.view(batch_size, seq_len, self.num_joints, self.hidden_dim)
 
@@ -437,9 +565,16 @@ class PLCSQuerySequenceModel(nn.Module):
                 joint_attn_mask = joint_attn_mask.clone()
                 joint_attn_mask[empty_joint, :, 0] = True
 
+            player_joint_freqs = player_temporal_freqs.unsqueeze(0).expand(
+                batch_size,
+                self.num_joints,
+                seq_len,
+                self.rope_dim // 2,
+            ).reshape(batch_size * self.num_joints, seq_len, self.rope_dim // 2)
+
             player_btjd = self_layer(
                 player_btjd,
-                freqs_cis=freqs_cis,
+                freqs_cis=player_joint_freqs,
                 attn_mask=joint_attn_mask,
             )
             player_x = player_btjd.reshape(batch_size, self.num_joints, seq_len, self.hidden_dim)
@@ -460,23 +595,48 @@ class PLCSQuerySequenceModel(nn.Module):
             key_valid_btj = key_valid_btj.clone()
             key_valid_btj[empty_bt, 0] = True
 
+        query_frame_freqs_bt = query_frame_freqs.unsqueeze(0).expand(
+            batch_size,
+            seq_len,
+            self.num_query_tokens,
+            self.rope_dim // 2,
+        ).reshape(batch_size * seq_len, self.num_query_tokens, self.rope_dim // 2)
+        player_key_freqs_bt = player_key_freqs.unsqueeze(0).expand(
+            batch_size,
+            seq_len,
+            self.num_joints,
+            self.rope_dim // 2,
+        ).reshape(batch_size * seq_len, self.num_joints, self.rope_dim // 2)
+
         frame_attn_mask_b2 = frame_attn_mask.repeat_interleave(2, dim=0)
 
-        for cross_layer, self_layer in zip(self.query_cross_layers, self.query_self_layers):
+        for cross_layer, self_layer in zip(
+            self.query_cross_layers,
+            self.query_self_layers,
+            strict=True,
+        ):
             # Per-timestep readout: (B,T,2,D) -> (B*T,2,D), keys (B*T,J,D)
             query_bt2 = query.reshape(batch_size * seq_len, 2, self.hidden_dim)
             query_bt2 = cross_layer(
                 query_bt2,
                 player_keys,
                 key_valid=key_valid_btj,
+                freqs_q_cis=query_frame_freqs_bt,
+                freqs_k_cis=player_key_freqs_bt,
             )
             query = query_bt2.reshape(batch_size, seq_len, 2, self.hidden_dim)
 
             # Temporal self-attn with shared layers over query types.
             query_b2t = query.permute(0, 2, 1, 3).reshape(batch_size * 2, seq_len, self.hidden_dim)
+            query_temporal_freqs_batched = query_temporal_freqs.unsqueeze(0).expand(
+                batch_size,
+                self.num_query_tokens,
+                seq_len,
+                self.rope_dim // 2,
+            ).reshape(batch_size * self.num_query_tokens, seq_len, self.rope_dim // 2)
             query_b2t = self_layer(
                 query_b2t,
-                freqs_cis=freqs_cis,
+                freqs_cis=query_temporal_freqs_batched,
                 attn_mask=frame_attn_mask_b2,
             )
             query = query_b2t.reshape(batch_size, 2, seq_len, self.hidden_dim).permute(0, 2, 1, 3)

--- a/src/tasks/trajectory_completion/configs/model/uv_transformer.yaml
+++ b/src/tasks/trajectory_completion/configs/model/uv_transformer.yaml
@@ -10,4 +10,7 @@ ffn_type: swiglu
 invisible_init_std: 0.02
 
 rope_theta: 10000.0
+rope_theta_time: 10000.0
+rope_theta_entity: 10000.0
+rope_theta_type: 100.0
 max_seq_len: 10240

--- a/src/tasks/trajectory_completion/configs/model/uv_transformer_nocourt.yaml
+++ b/src/tasks/trajectory_completion/configs/model/uv_transformer_nocourt.yaml
@@ -10,4 +10,5 @@ ffn_type: swiglu
 invisible_init_std: 0.02
 
 rope_theta: 10000.0
+rope_theta_time: 10000.0
 max_seq_len: 10240

--- a/src/tasks/trajectory_completion/models/uv_completion_model.py
+++ b/src/tasks/trajectory_completion/models/uv_completion_model.py
@@ -10,7 +10,7 @@ Forward I/F is kept unchanged.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
@@ -22,9 +22,13 @@ from src.utils.models import (
     RMSNorm,
     TransformerBlock,
     TransformerBlockConfig,
-    precompute_freqs_cis,
+    precompute_freqs_cis_nd,
 )
-from src.utils.models.embeddings import BallUVEmbedding, CourtKPUVEmbedding, InvisibleTokenEmbedding
+from src.utils.models.embeddings import (
+    BallUVEmbedding,
+    CourtKPUVEmbedding,
+    InvisibleTokenEmbedding,
+)
 from src.utils.schema.court import NUM_COURT_KP
 
 if TYPE_CHECKING:
@@ -47,10 +51,13 @@ class UVTrajectoryCompletionModel(nn.Module):
         num_query_layers: int = 2,
         # Positional encoding
         rope_theta: float = 10000.0,
+        rope_theta_time: float | None = None,
+        rope_theta_entity: float | None = None,
+        rope_theta_type: float = 100.0,
         rope_dim: int | None = None,
         # FFN
         ffn_dim: int | None = None,
-        ffn_type: str = "swiglu",
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         # Embedding init
         invisible_init_std: float = 0.02,
         query_init_std: float = 0.02,
@@ -75,6 +82,13 @@ class UVTrajectoryCompletionModel(nn.Module):
             raise ValueError("rope_dim must be even.")
         if rope_dim_value > head_dim:
             raise ValueError("rope_dim must be <= head_dim.")
+        self.rope_dim = int(rope_dim_value)
+        self.rope_theta = float(rope_theta)
+        self.rope_bases = (
+            float(self.rope_theta if rope_theta_time is None else rope_theta_time),
+            float(self.rope_theta if rope_theta_entity is None else rope_theta_entity),
+            float(rope_theta_type),
+        )
 
         self.invisible_token = InvisibleTokenEmbedding(
             dim=self.hidden_dim,
@@ -118,9 +132,9 @@ class UVTrajectoryCompletionModel(nn.Module):
                         n_heads=int(num_heads),
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim_value,
+                        rope_dim=self.rope_dim,
                         attn_dropout=float(dropout),
-                        rope_base=float(rope_theta),
+                        rope_base=self.rope_theta,
                         ffn_type=ffn_type,
                     )
                 )
@@ -135,7 +149,7 @@ class UVTrajectoryCompletionModel(nn.Module):
                         n_heads=int(num_heads),
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim_value,
+                        rope_dim=self.rope_dim,
                         attn_dropout=float(dropout),
                         ffn_type=ffn_type,
                     )
@@ -151,9 +165,9 @@ class UVTrajectoryCompletionModel(nn.Module):
                         n_heads=int(num_heads),
                         ffn_dim=ffn_dim,
                         head_dim=head_dim,
-                        rope_dim=rope_dim_value,
+                        rope_dim=self.rope_dim,
                         attn_dropout=float(dropout),
-                        rope_base=float(rope_theta),
+                        rope_base=self.rope_theta,
                         ffn_type=ffn_type,
                     )
                 )
@@ -178,13 +192,12 @@ class UVTrajectoryCompletionModel(nn.Module):
             nn.Linear(self.hidden_dim, 1),
         )
 
-        freqs_cis = precompute_freqs_cis(
-            dim=rope_dim_value,
-            seqlen=self.max_seq_len,
-            base=float(rope_theta),
-            device=None,
+        court_freqs_cis = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_court_positions(),
+            base=self.rope_bases,
         )
-        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+        self.register_buffer("court_freqs_cis", court_freqs_cis, persistent=False)
 
     @classmethod
     def from_config(cls, config: DictConfig) -> UVTrajectoryCompletionModel:
@@ -204,13 +217,39 @@ class UVTrajectoryCompletionModel(nn.Module):
             num_ball_layers=int(num_ball_layers),
             num_query_layers=int(num_query_layers),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
+            rope_theta_entity=model_cfg.get("rope_theta_entity", None),
+            rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
             rope_dim=model_cfg.get("rope_dim", None),
             ffn_dim=model_cfg.get("ffn_dim"),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             query_init_std=float(model_cfg.get("query_init_std", 0.02)),
             num_court_tokens=int(model_cfg.get("num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP))),
         )
+
+    def _build_court_positions(self) -> Tensor:
+        court_idx = torch.arange(self.num_court_tokens, dtype=torch.long)
+        return torch.stack(
+            [
+                torch.zeros_like(court_idx),
+                court_idx,
+                torch.zeros_like(court_idx),
+            ],
+            dim=-1,
+        )
+
+    @staticmethod
+    def _build_stream_positions(
+        seq_len: int,
+        device: torch.device,
+        *,
+        token_type: int,
+    ) -> Tensor:
+        time_idx = torch.arange(seq_len, device=device, dtype=torch.long) + 1
+        entity_idx = torch.zeros(seq_len, device=device, dtype=torch.long)
+        type_idx = torch.full((seq_len,), token_type, device=device, dtype=torch.long)
+        return torch.stack([time_idx, entity_idx, type_idx], dim=-1)
 
     @staticmethod
     def _build_self_attn_mask(valid: Tensor) -> tuple[Tensor, Tensor]:
@@ -255,7 +294,7 @@ class UVTrajectoryCompletionModel(nn.Module):
             with shape ``(B, T)``.
         """
         B, T, _ = ball_uv.shape
-        if T > self.max_seq_len:
+        if self.max_seq_len < T:
             ball_uv = ball_uv[:, : self.max_seq_len]
             if ball_vis is not None:
                 ball_vis = ball_vis[:, : self.max_seq_len]
@@ -280,11 +319,24 @@ class UVTrajectoryCompletionModel(nn.Module):
         ball_attn_mask, ball_valid = self._build_self_attn_mask(ball_valid)
         court_valid = torch.ones(B, self.num_court_tokens, device=ball_uv.device, dtype=torch.bool)
 
-        freqs_ball_tokens = self.freqs_cis[:T]
-        if freqs_ball_tokens.device != ball_uv.device:
-            freqs_ball_tokens = freqs_ball_tokens.to(ball_uv.device)
-        freqs_ball_tok = freqs_ball_tokens
-        freqs_query = freqs_ball_tokens
+        freqs_ball_tokens = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_stream_positions(T, ball_uv.device, token_type=1),
+            base=self.rope_bases,
+        )
+        freqs_ball_raw = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_stream_positions(T, ball_uv.device, token_type=2),
+            base=self.rope_bases,
+        )
+        freqs_query = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_stream_positions(T, ball_uv.device, token_type=3),
+            base=self.rope_bases,
+        )
+        court_freqs_cis = cast(Tensor, self.court_freqs_cis)
+        if court_freqs_cis.device != ball_uv.device:
+            court_freqs_cis = court_freqs_cis.to(ball_uv.device)
 
         # Stage 1: ball tokens attend to court, then temporal self-attention.
         ball_raw = ball_tok
@@ -300,7 +352,7 @@ class UVTrajectoryCompletionModel(nn.Module):
                 court_tokens,
                 key_valid=court_valid,
                 freqs_q_cis=None,
-                freqs_k_cis=None,
+                freqs_k_cis=court_freqs_cis,
             )
             ball_tokens = self_layer(
                 ball_tokens,
@@ -315,7 +367,7 @@ class UVTrajectoryCompletionModel(nn.Module):
         ball_memory_valid = torch.cat([ball_valid, ball_valid], dim=1)
 
         # Independent RoPE streams for query and memory branches.
-        freqs_ball_memory = torch.cat([freqs_ball_tokens, freqs_ball_tok], dim=0)
+        freqs_ball_memory = torch.cat([freqs_ball_tokens, freqs_ball_raw], dim=0)
 
         # Stage 2: learned query attends to processed+raw memories, then temporal self-attention.
         query = self.query_base.expand(B, T, -1)

--- a/src/tasks/trajectory_completion/models/uv_completion_nocourt_model.py
+++ b/src/tasks/trajectory_completion/models/uv_completion_nocourt_model.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
@@ -34,9 +34,10 @@ class UVTrajectoryCompletionNoCourtModel(nn.Module):
         dropout: float = 0.1,
         max_seq_len: int = 256,
         rope_theta: float = 10000.0,
+        rope_theta_time: float | None = None,
         rope_dim: int | None = None,
         ffn_dim: int | None = None,
-        ffn_type: str = "swiglu",
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         invisible_init_std: float = 0.02,
     ) -> None:
         super().__init__()
@@ -54,6 +55,7 @@ class UVTrajectoryCompletionNoCourtModel(nn.Module):
             raise ValueError("rope_dim must be even.")
         if rope_dim_value > head_dim:
             raise ValueError("rope_dim must be <= head_dim.")
+        rope_base = float(rope_theta if rope_theta_time is None else rope_theta_time)
 
         self.invisible_token = InvisibleTokenEmbedding(
             dim=self.hidden_dim,
@@ -74,7 +76,7 @@ class UVTrajectoryCompletionNoCourtModel(nn.Module):
                         head_dim=head_dim,
                         rope_dim=rope_dim_value,
                         attn_dropout=float(dropout),
-                        rope_base=float(rope_theta),
+                        rope_base=rope_base,
                         ffn_type=ffn_type,
                     )
                 )
@@ -98,7 +100,7 @@ class UVTrajectoryCompletionNoCourtModel(nn.Module):
         freqs_cis = precompute_freqs_cis(
             dim=rope_dim_value,
             seqlen=self.max_seq_len,
-            base=float(rope_theta),
+            base=rope_base,
             device=None,
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
@@ -117,9 +119,10 @@ class UVTrajectoryCompletionNoCourtModel(nn.Module):
             dropout=float(model_cfg.get("dropout", 0.1)),
             max_seq_len=int(model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 256))),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
             rope_dim=model_cfg.get("rope_dim", None),
             ffn_dim=model_cfg.get("ffn_dim"),
-            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
+            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
         )
 
@@ -146,7 +149,7 @@ class UVTrajectoryCompletionNoCourtModel(nn.Module):
     ) -> Tensor | tuple[Tensor, list[Tensor]] | tuple[Tensor, Tensor] | tuple[Tensor, list[Tensor], Tensor]:
         """Forward pass for no-court trajectory completion."""
         _, T, _ = ball_uv.shape
-        if T > self.max_seq_len:
+        if self.max_seq_len < T:
             ball_uv = ball_uv[:, : self.max_seq_len]
             if ball_vis is not None:
                 ball_vis = ball_vis[:, : self.max_seq_len]

--- a/src/utils/models/__init__.py
+++ b/src/utils/models/__init__.py
@@ -5,22 +5,20 @@ Strategy A: treat the DeepSeek-style, pure PyTorch implementation in
 """
 
 from src.utils.models.components import (
+    MLP,
     CrossAttnBlock,
     CrossAttnBlockConfig,
-    MLP,
     LayerNorm,
     MultiHeadCrossAttention,
     MultiHeadSelfAttention,
-    PositionGetter,
     RMSNorm,
-    RotaryPositionEmbedding2D,
     SwiGLU,
     TransformerBlock,
     TransformerBlockConfig,
-    apply_rotary_emb_2d,
+    apply_rotary_emb,
     default_ffn_dim,
     precompute_freqs_cis,
-    precompute_freqs_cis_2d,
+    precompute_freqs_cis_nd,
 )
 from src.utils.models.embeddings import (
     Ball3DEmbedding,
@@ -39,10 +37,8 @@ __all__ = [
     "LayerNorm",
     # RoPE
     "precompute_freqs_cis",
-    "precompute_freqs_cis_2d",
-    "apply_rotary_emb_2d",
-    "RotaryPositionEmbedding2D",
-    "PositionGetter",
+    "precompute_freqs_cis_nd",
+    "apply_rotary_emb",
     # FFN
     "MLP",
     "SwiGLU",

--- a/src/utils/models/components/__init__.py
+++ b/src/utils/models/components/__init__.py
@@ -4,8 +4,7 @@ This package provides reusable building blocks used across tasks:
 
 - Attention: `MultiHeadSelfAttention`, `MultiHeadCrossAttention`
 - Norm: `RMSNorm`, `LayerNorm`
-- RoPE: 1D (`precompute_freqs_cis`) and 2D axial (`precompute_freqs_cis_2d`, `apply_rotary_emb_2d`)
-        plus compatibility helpers (`RotaryPositionEmbedding2D`, `PositionGetter`)
+- RoPE: 1D (`precompute_freqs_cis`) and interleaved N-D (`precompute_freqs_cis_nd`, `apply_rotary_emb`)
 - FFN: `SwiGLU`, `MLP`, `default_ffn_dim`
 - Blocks: `TransformerBlock`, `TransformerBlockConfig`, `CrossAttnBlockConfig`, `CrossAttnBlock`
 
@@ -27,11 +26,9 @@ from src.utils.models.components.block import (
 from src.utils.models.components.ffn_layers import MLP, SwiGLU, default_ffn_dim
 from src.utils.models.components.norm import LayerNorm, RMSNorm
 from src.utils.models.components.rope import (
-    PositionGetter,
-    RotaryPositionEmbedding2D,
-    apply_rotary_emb_2d,
+    apply_rotary_emb,
     precompute_freqs_cis,
-    precompute_freqs_cis_2d,
+    precompute_freqs_cis_nd,
 )
 
 __all__ = [
@@ -43,10 +40,8 @@ __all__ = [
     "LayerNorm",
     # RoPE
     "precompute_freqs_cis",
-    "precompute_freqs_cis_2d",
-    "apply_rotary_emb_2d",
-    "RotaryPositionEmbedding2D",
-    "PositionGetter",
+    "precompute_freqs_cis_nd",
+    "apply_rotary_emb",
     # FFN
     "MLP",
     "SwiGLU",

--- a/src/utils/models/components/attention.py
+++ b/src/utils/models/components/attention.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from src.utils.models.components.rope import apply_rotary_emb, apply_rotary_emb_2d
+from src.utils.models.components.rope import apply_rotary_emb
 
 
 def _normalize_attn_mask(
@@ -60,9 +60,7 @@ class MultiHeadSelfAttention(nn.Module):
     """
     Pure PyTorch Multi-Head Self-Attention using SDPA.
 
-    Supports:
-      - Optional 1D RoPE (freqs_cis) applied to first `rope_dim` of head_dim
-      - Optional 2D RoPE (rope2d + positions_2d) applied to first `rope_dim` of head_dim
+    Supports optional RoPE (freqs_cis) applied to first `rope_dim` of head_dim.
 
     Args:
         dim: model dimension
@@ -109,7 +107,7 @@ class MultiHeadSelfAttention(nn.Module):
         q, k, v = qkv.unbind(dim=2)  # each: (B, T, H, D)
         return q, k, v
 
-    def _apply_rope_1d(self, q: torch.Tensor, k: torch.Tensor, freqs_cis: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def _apply_rope(self, q: torch.Tensor, k: torch.Tensor, freqs_cis: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         if self.rope_dim == 0:
             return q, k
         q_pe, q_rest = q[..., : self.rope_dim], q[..., self.rope_dim :]
@@ -120,63 +118,18 @@ class MultiHeadSelfAttention(nn.Module):
         k = torch.cat([k_pe, k_rest], dim=-1)
         return q, k
 
-    def _apply_rope_2d(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        *,
-        rope2d: tuple[torch.Tensor, torch.Tensor],
-        positions_2d: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        if self.rope_dim == 0:
-            return q, k
-
-        if positions_2d.ndim != 3 or positions_2d.size(-1) != 2:
-            raise ValueError(f"positions_2d must be (B,T,2), got {tuple(positions_2d.shape)}")
-
-        bsz = q.size(0)
-        if positions_2d.size(0) != bsz:
-            raise ValueError(f"Batch mismatch: q.B={bsz} vs positions_2d.B={positions_2d.size(0)}")
-
-        t_total = q.size(1)
-        t_rope = positions_2d.size(1)
-        prefix = t_total - t_rope
-        if prefix < 0:
-            raise ValueError(f"positions_2d.T={t_rope} exceeds q.T={t_total}")
-
-        freqs_cis_y, freqs_cis_x = rope2d
-
-        q_pe, q_rest = q[..., : self.rope_dim], q[..., self.rope_dim :]
-        k_pe, k_rest = k[..., : self.rope_dim], k[..., self.rope_dim :]
-
-        q_prefix, q_tail = q_pe[:, :prefix], q_pe[:, prefix:]
-        k_prefix, k_tail = k_pe[:, :prefix], k_pe[:, prefix:]
-
-        q_tail = apply_rotary_emb_2d(q_tail, freqs_cis_y, freqs_cis_x, positions_2d, interleaved=True)
-        k_tail = apply_rotary_emb_2d(k_tail, freqs_cis_y, freqs_cis_x, positions_2d, interleaved=True)
-
-        q_pe = torch.cat([q_prefix, q_tail], dim=1)
-        k_pe = torch.cat([k_prefix, k_tail], dim=1)
-
-        q = torch.cat([q_pe, q_rest], dim=-1)
-        k = torch.cat([k_pe, k_rest], dim=-1)
-        return q, k
-
     def forward(
         self,
         x: torch.Tensor,
         *,
         freqs_cis: torch.Tensor | None = None,
-        rope2d: tuple[torch.Tensor, torch.Tensor] | None = None,
-        positions_2d: torch.Tensor | None = None,
         attn_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         Args:
             x: (B, T, dim)
-            freqs_cis: (T, rope_dim//2) complex cis for 1D RoPE. If None, 1D RoPE is skipped.
-            rope2d: 2D RoPE freqs tuple `(freqs_cis_y, freqs_cis_x)` (when used)
-            positions_2d: (B, T_rope, 2) y/x integer coordinates for tokens that receive 2D RoPE
+            freqs_cis: complex cis frequencies for RoPE. Supports `(T, rope_dim//2)`
+                or batched `(B, T, rope_dim//2)`.
             attn_mask: optional user mask; see module docstring
 
         Returns:
@@ -186,16 +139,8 @@ class MultiHeadSelfAttention(nn.Module):
         qkv = self.wqkv(x)
         q, k, v = self._shape_qkv(qkv)
 
-        if (freqs_cis is not None) and (rope2d is not None or positions_2d is not None):
-            raise ValueError("Use either 1D RoPE (freqs_cis) OR 2D RoPE (rope2d + positions_2d), not both.")
-
-        # Apply RoPE (optional)
         if freqs_cis is not None:
-            q, k = self._apply_rope_1d(q, k, freqs_cis)
-        if rope2d is not None:
-            if positions_2d is None:
-                raise ValueError("positions_2d must be provided when rope2d is provided.")
-            q, k = self._apply_rope_2d(q, k, rope2d=rope2d, positions_2d=positions_2d)
+            q, k = self._apply_rope(q, k, freqs_cis)
 
         k_len = q_len
 
@@ -263,16 +208,27 @@ class MultiHeadCrossAttention(nn.Module):
         bsz, seqlen, _ = x.shape
         return x.view(bsz, seqlen, self.n_heads, self.head_dim)
 
-    def _apply_rope_1d(
+    def _apply_rope(
         self,
         x: torch.Tensor,
         freqs_cis: torch.Tensor | None,
     ) -> torch.Tensor:
         if freqs_cis is None or self.rope_dim == 0:
             return x
-        if freqs_cis.size(0) != x.size(1):
+        if freqs_cis.ndim == 2:
+            if freqs_cis.size(0) != x.size(1):
+                raise ValueError(
+                    f"freqs_cis length mismatch: freqs_cis.T={freqs_cis.size(0)} vs x.T={x.size(1)}"
+                )
+        elif freqs_cis.ndim == 3:
+            if freqs_cis.shape[:2] != x.shape[:2]:
+                raise ValueError(
+                    "freqs_cis batch/length mismatch: "
+                    f"freqs={tuple(freqs_cis.shape[:2])} vs x={tuple(x.shape[:2])}"
+                )
+        else:
             raise ValueError(
-                f"freqs_cis length mismatch: freqs_cis.T={freqs_cis.size(0)} vs x.T={x.size(1)}"
+                f"freqs_cis must have rank 2 or 3, got shape {tuple(freqs_cis.shape)}"
             )
         x_pe, x_rest = x[..., : self.rope_dim], x[..., self.rope_dim :]
         x_pe = apply_rotary_emb(x_pe, freqs_cis, interleaved=True)
@@ -291,8 +247,10 @@ class MultiHeadCrossAttention(nn.Module):
         Args:
             q_in: query tokens (B, Q, D)
             kv_in: key/value tokens (B, K, D)
-            freqs_q_cis: (Q, rope_dim//2) complex cis for query RoPE
-            freqs_k_cis: (K, rope_dim//2) complex cis for key RoPE
+            freqs_q_cis: complex cis frequencies for query RoPE. Supports
+                `(Q, rope_dim//2)` or batched `(B, Q, rope_dim//2)`.
+            freqs_k_cis: complex cis frequencies for key RoPE. Supports
+                `(K, rope_dim//2)` or batched `(B, K, rope_dim//2)`.
             attn_mask: optional mask broadcastable to (B, H, Q, K)
 
         Returns:
@@ -305,8 +263,8 @@ class MultiHeadCrossAttention(nn.Module):
         k = self._shape(self.wk(kv_in))
         v = self._shape(self.wv(kv_in))
 
-        q = self._apply_rope_1d(q, freqs_q_cis)
-        k = self._apply_rope_1d(k, freqs_k_cis)
+        q = self._apply_rope(q, freqs_q_cis)
+        k = self._apply_rope(k, freqs_k_cis)
 
         q_ = q.transpose(1, 2)  # (B, H, Q, D)
         k_ = k.transpose(1, 2)  # (B, H, K, D)

--- a/src/utils/models/components/block.py
+++ b/src/utils/models/components/block.py
@@ -12,10 +12,6 @@ from src.utils.models.components.attention import (
 )
 from src.utils.models.components.ffn_layers import MLP, SwiGLU, default_ffn_dim
 from src.utils.models.components.norm import RMSNorm
-from src.utils.models.components.rope import (
-    PositionGetter,
-    precompute_freqs_cis_2d,
-)
 
 
 @dataclass

--- a/src/utils/models/components/rope.py
+++ b/src/utils/models/components/rope.py
@@ -1,399 +1,160 @@
-# ==============================================================================
-# NOTE ON ORIGIN / LICENSE
-#
-# This file is derived from (and/or inspired by) DeepSeek's inference reference:
-#   https://github.com/deepseek-ai/DeepSeek-V3.2-Exp/blob/main/inference/model.py
-#
-# MIT License
-#
-# Copyright (c) 2025 DeepSeek
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-# ==============================================================================
+"""Interleaved rotary position embedding utilities.
 
-"""Rotary position embeddings (RoPE) utilities (pure PyTorch).
-
-This module provides:
-- 1D RoPE utilities based on complex cis (DeepSeek-style).
-- 2D axial RoPE utilities (y/x split) built on the same complex cis machinery.
-
-The 2D API is offered in two layers:
-- Functional utilities: `precompute_freqs_cis_2d`, `apply_rotary_emb_2d`
-- A small wrapper module: `RotaryPositionEmbedding2D` (kept for compatibility with
-  existing attention code that expects a callable `nn.Module`).
+This module keeps the existing 1D helper API while making the core frequency
+construction generic over arbitrary coordinate ranks. Frequencies are assigned in
+an interleaved manner across axes, following the Qwen3-VL-style MROPE layout.
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import TypeAlias
+
 import torch
-from torch import nn
+
+RopeBaseLike: TypeAlias = float | Sequence[float] | torch.Tensor
 
 
-# -------------------------
-# 1D RoPE (complex cis)
-# -------------------------
+def _normalize_rope_bases(
+    base: RopeBaseLike,
+    *,
+    n_axes: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    if isinstance(base, torch.Tensor):
+        base_tensor = base.to(device=device, dtype=dtype).flatten()
+    elif isinstance(base, Sequence):
+        base_tensor = torch.tensor(list(base), device=device, dtype=dtype).flatten()
+    else:
+        base_tensor = torch.full((n_axes,), float(base), device=device, dtype=dtype)
+
+    if base_tensor.numel() == 1:
+        base_tensor = base_tensor.expand(n_axes)
+    if base_tensor.numel() != n_axes:
+        raise ValueError(f"Expected {n_axes} RoPE bases, got {base_tensor.numel()}")
+    if (base_tensor <= 0).any():
+        raise ValueError("RoPE bases must be positive.")
+    return base_tensor
+
+
 def precompute_freqs_cis(
     *,
     dim: int,
     seqlen: int,
-    base: float = 10000.0,
+    base: RopeBaseLike = 10000.0,
     device: torch.device | None = None,
 ) -> torch.Tensor:
-    """
-    Precompute complex cis tensor for 1D RoPE.
+    """Precompute complex cis frequencies for standard 1D RoPE."""
+    if seqlen < 0:
+        raise ValueError(f"seqlen must be non-negative, got {seqlen}")
+    positions = torch.arange(seqlen, device=device, dtype=torch.long).unsqueeze(-1)
+    return precompute_freqs_cis_nd(dim=dim, pos=positions, base=base)
 
-    Returns:
-        freqs_cis: (seqlen, dim//2) complex64/complex128 depending on torch defaults.
-    """
+
+def precompute_freqs_cis_nd(
+    dim: int,
+    pos: torch.Tensor,
+    base: RopeBaseLike = 10000.0,
+) -> torch.Tensor:
+    """Precompute complex cis frequencies for interleaved N-dimensional MROPE."""
     if dim % 2 != 0:
         raise ValueError(f"RoPE dim must be even, got {dim}")
 
-    inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim))
+    if pos.ndim == 0:
+        raise ValueError("pos must have at least one dimension.")
+    if pos.ndim == 1:
+        pos = pos.unsqueeze(-1)
+    if pos.size(-1) <= 0:
+        raise ValueError(f"pos must have a positive axis dimension, got shape {tuple(pos.shape)}")
 
-    t = torch.arange(seqlen, device=device, dtype=torch.float32)  # (seqlen,)
-    freqs = torch.outer(t, inv_freq)  # (seqlen, dim/2)
-    # cis = cos + i sin
-    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
-    return freqs_cis
+    device = pos.device
+    dtype = torch.float32
+    half_dim = dim // 2
+    n_axes = int(pos.size(-1))
 
+    pair_indices = torch.arange(half_dim, device=device, dtype=dtype)
+    axis_indices = torch.arange(half_dim, device=device) % n_axes
+    base_tensor = _normalize_rope_bases(base, n_axes=n_axes, device=device, dtype=dtype)
+    base_per_pair = base_tensor[axis_indices]
 
-def apply_rotary_emb(x: torch.Tensor, freqs_cis: torch.Tensor, interleaved: bool = True) -> torch.Tensor:
-    """
-    Apply 1D RoPE (complex cis) to the last dimension of `x`.
+    # Each axis receives rotary pairs cyclically across the full spectrum.
+    inv_freq = 1.0 / (base_per_pair ** ((2.0 * pair_indices) / dim))
 
-    Args:
-        x: (B, T, ..., rope_dim) where rope_dim is even and sequence axis is dim=1.
-        freqs_cis: (T, rope_dim/2) complex.
-        interleaved: matches DeepSeek's interleaving mode.
-
-    Returns:
-        Tensor with same shape/dtype as x.
-    """
-    dtype = x.dtype
-    shape = x.shape
-
-    if x.size(-1) % 2 != 0:
-        raise ValueError(f"RoPE expects even dim, got {x.size(-1)}")
-
-    # If not interleaved, convert to (.., 2, D/2) pattern used by some implementations.
-    if not interleaved:
-        x = x.view(*shape[:-1], 2, -1).transpose(-1, -2).contiguous()
-
-    x_complex = torch.view_as_complex(x.float().view(*x.shape[:-1], -1, 2))  # (..., D/2)
-    if x_complex.dim() < 2:
-        raise ValueError(f"Expected x rank>=2, got x.shape={tuple(shape)}")
-
-    T = x_complex.size(1)
-    if freqs_cis.size(0) != T:
-        raise ValueError(f"freqs_cis length mismatch: freqs_cis.T={freqs_cis.size(0)} vs x.T={T}")
-
-    freqs_cis = freqs_cis.view(1, T, *([1] * (x_complex.dim() - 3)), x_complex.size(-1))
-    y = torch.view_as_real(x_complex * freqs_cis).flatten(-2)  # back to (..., D)
-
-    if not interleaved:
-        # Undo the transpose convention
-        y = y.view(*shape[:-1], 2, -1).transpose(-1, -2).contiguous().view(*shape)
-
-    return y.to(dtype)
+    pos_interleaved = pos.to(dtype)[..., axis_indices]
+    angles = pos_interleaved * inv_freq
+    return torch.polar(torch.ones_like(angles), angles)
 
 
-# -------------------------
-# 2D RoPE (axial split, cis-based)
-# -------------------------
-class PositionGetter:
-    """Generate and cache 2D (y, x) integer positions for a patch grid.
+def _reshape_freqs_cis_for_broadcast(
+    x_complex: torch.Tensor,
+    freqs_cis: torch.Tensor,
+) -> torch.Tensor:
+    if freqs_cis.shape[-1] != x_complex.shape[-1]:
+        raise ValueError(
+            "RoPE frequency dim mismatch: "
+            f"freqs={freqs_cis.shape[-1]} vs x={x_complex.shape[-1]}"
+        )
 
-    Returns:
-        positions: (B, H*W, 2)
-    """
+    if x_complex.ndim == 3:
+        if freqs_cis.ndim == 2:
+            if freqs_cis.shape[0] != x_complex.shape[1]:
+                raise ValueError(
+                    f"RoPE length mismatch: freqs.T={freqs_cis.shape[0]} vs x.T={x_complex.shape[1]}"
+                )
+            return freqs_cis.view(1, x_complex.shape[1], x_complex.shape[2])
+        if freqs_cis.ndim == 3:
+            if freqs_cis.shape[:2] != x_complex.shape[:2]:
+                raise ValueError(
+                    "RoPE batch/length mismatch: "
+                    f"freqs={tuple(freqs_cis.shape[:2])} vs x={tuple(x_complex.shape[:2])}"
+                )
+            return freqs_cis
+    elif x_complex.ndim == 4:
+        if freqs_cis.ndim == 2:
+            if freqs_cis.shape[0] != x_complex.shape[1]:
+                raise ValueError(
+                    f"RoPE length mismatch: freqs.T={freqs_cis.shape[0]} vs x.T={x_complex.shape[1]}"
+                )
+            return freqs_cis.view(1, x_complex.shape[1], 1, x_complex.shape[3])
+        if freqs_cis.ndim == 3:
+            if freqs_cis.shape[:2] != x_complex.shape[:2]:
+                raise ValueError(
+                    "RoPE batch/length mismatch: "
+                    f"freqs={tuple(freqs_cis.shape[:2])} vs x={tuple(x_complex.shape[:2])}"
+                )
+            return freqs_cis.view(x_complex.shape[0], x_complex.shape[1], 1, x_complex.shape[3])
 
-    def __init__(self) -> None:
-        self._cache: dict[tuple[int, int, torch.device], torch.Tensor] = {}
-
-    def __call__(self, batch_size: int, height: int, width: int, device: torch.device) -> torch.Tensor:
-        key = (height, width, device)
-        if key not in self._cache:
-            y = torch.arange(height, device=device)
-            x = torch.arange(width, device=device)
-            pos = torch.cartesian_prod(y, x)  # (H*W, 2), columns: (y, x)
-            self._cache[key] = pos
-        pos = self._cache[key]
-        return pos.view(1, height * width, 2).expand(batch_size, -1, -1).clone()
+    raise ValueError(
+        "Unsupported RoPE broadcast combination: "
+        f"x_complex.shape={tuple(x_complex.shape)}, freqs_cis.shape={tuple(freqs_cis.shape)}"
+    )
 
 
-def _apply_rotary_emb_indexed_1d_canonical(
+def apply_rotary_emb(
     x: torch.Tensor,
     freqs_cis: torch.Tensor,
-    positions: torch.Tensor,
-    *,
-    interleaved: bool,
+    interleaved: bool = True,
 ) -> torch.Tensor:
-    """Apply 1D RoPE to `x` using per-token absolute positions.
-
-    Args:
-        x: (B, T, ..., D) where D is even.
-        freqs_cis: (max_pos, D/2) complex cis table.
-        positions: (B, T) integer absolute positions in [0, max_pos).
-        interleaved: whether `x` uses interleaved (even/odd) pairs.
-    """
+    """Apply rotary embeddings to `(B, T, D)` or `(B, T, H, D)` tensors."""
+    if x.ndim not in {3, 4}:
+        raise ValueError(f"Unsupported input rank for RoPE: {x.ndim}")
     if x.size(-1) % 2 != 0:
-        raise ValueError(f"RoPE expects even dim, got {x.size(-1)}")
-    if positions.ndim != 2:
-        raise ValueError(f"positions must be (B,T), got {tuple(positions.shape)}")
+        raise ValueError(f"RoPE expects an even dim, got {x.size(-1)}")
 
     dtype = x.dtype
     shape = x.shape
+    x_work = x
 
     if not interleaved:
-        x = x.view(*shape[:-1], 2, -1).transpose(-1, -2).contiguous()
+        x_work = x_work.view(*shape[:-1], 2, -1).transpose(-1, -2).contiguous()
 
-    x_complex = torch.view_as_complex(x.float().view(*x.shape[:-1], -1, 2))  # (B,T,...,D/2)
+    x_complex = torch.view_as_complex(x_work.float().view(*x_work.shape[:-1], -1, 2))
+    freqs_cis = _reshape_freqs_cis_for_broadcast(x_complex, freqs_cis.to(device=x.device))
 
-    pos = positions.to(torch.long)
-    if pos.min().item() < 0:
-        raise ValueError("positions must be non-negative.")
-
-    # Gather cis per token: (B,T,D/2)
-    gathered = freqs_cis[pos]  # complex
-    # Broadcast across extra dims (e.g., heads)
-    gathered = gathered.view(shape[0], shape[1], *([1] * (x_complex.dim() - 3)), x_complex.size(-1))
-
-    y = torch.view_as_real(x_complex * gathered).flatten(-2)  # (..., D)
+    y = torch.view_as_real(x_complex * freqs_cis).flatten(-2)
 
     if not interleaved:
         y = y.view(*shape[:-1], 2, -1).transpose(-1, -2).contiguous().view(*shape)
 
     return y.to(dtype)
-
-
-class RotaryPositionEmbedding2D(nn.Module):
-    """2D axial RoPE wrapper (kept for attention/VisionTransformer compatibility).
-
-    The core functionality is implemented by `apply_rotary_emb_2d`.
-
-    Args:
-        frequency: RoPE base (theta). For ViT-style 2D RoPE this is often 100.0.
-        scaling_factor: kept for backward-compatible configs (currently unused).
-        interleaved: whether to treat features as interleaved (even/odd) pairs.
-    """
-
-    def __init__(
-        self,
-        frequency: float = 100.0,
-        scaling_factor: float = 1.0,
-        interleaved: bool = False,
-    ) -> None:
-        super().__init__()
-        self.base_frequency = float(frequency)
-        self.scaling_factor = float(scaling_factor)
-        self.interleaved = bool(interleaved)
-        self._cache: dict[tuple[int, int, int, torch.device], tuple[torch.Tensor, torch.Tensor]] = {}
-
-    def _get_freqs(
-        self,
-        *,
-        dim: int,
-        height: int,
-        width: int,
-        device: torch.device,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        key = (dim, height, width, device)
-        if key not in self._cache:
-            freqs_y, freqs_x = precompute_freqs_cis_2d(
-                dim=dim,
-                height=height,
-                width=width,
-                base=self.base_frequency,
-                device=device,
-            )
-            self._cache[key] = (freqs_y, freqs_x)
-        return self._cache[key]
-
-    def forward(self, tokens: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
-        if positions.ndim != 3 or positions.size(-1) != 2:
-            raise ValueError(f"positions must be (B,T,2), got {tuple(positions.shape)}")
-        if positions.min().item() < 0:
-            raise ValueError("positions must be non-negative.")
-        if tokens.size(0) != positions.size(0):
-            raise ValueError(f"Batch mismatch: tokens.B={tokens.size(0)} vs positions.B={positions.size(0)}")
-
-        # Determine grid extents from the provided coordinates.
-        y_max = int(positions[..., 0].max().item())
-        x_max = int(positions[..., 1].max().item())
-        height = y_max + 1
-        width = x_max + 1
-
-        freqs_y, freqs_x = self._get_freqs(dim=tokens.size(-1), height=height, width=width, device=tokens.device)
-        return apply_rotary_emb_2d(
-            tokens,
-            freqs_y,
-            freqs_x,
-            positions,
-            interleaved=self.interleaved,
-        )
-
-
-# -------------------------
-# 2D precompute (axial split, cis-based)
-# -------------------------
-def precompute_freqs_cis_2d(
-    *,
-    dim: int,
-    height: int,
-    width: int,
-    base: float = 10000.0,
-    device: torch.device | None = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """
-    Precompute complex cis tables for 2D axial RoPE.
-
-    We split dim into y/x halves:
-        dim = rope_dim, must be divisible by 4
-        axis_dim = dim // 2  (per-axis feature dim; must be even)
-        freqs_cis_y: (height, axis_dim//2) complex
-        freqs_cis_x: (width,  axis_dim//2) complex
-
-    """
-    if dim % 4 != 0:
-        raise ValueError(f"2D axial RoPE requires dim % 4 == 0, got {dim}")
-    if height <= 0 or width <= 0:
-        raise ValueError(f"height/width must be positive, got height={height}, width={width}")
-
-    axis_dim = dim // 2  # y half and x half each has axis_dim
-
-    freqs_cis_y = precompute_freqs_cis(dim=axis_dim, seqlen=height, base=base, device=device)
-    freqs_cis_x = precompute_freqs_cis(dim=axis_dim, seqlen=width, base=base, device=device)
-    return freqs_cis_y, freqs_cis_x
-
-
-def apply_rotary_emb_2d(
-    x: torch.Tensor,
-    freqs_cis_y: torch.Tensor,
-    freqs_cis_x: torch.Tensor,
-    positions: torch.Tensor,
-    *,
-    interleaved: bool = True,
-) -> torch.Tensor:
-    """
-    Apply 2D axial RoPE using the same "complex cis" structure as 1D.
-
-    Supports x layouts:
-      - (B, n_heads, T, D)  (common)
-      - (B, T, n_heads, D)
-      - (B, T, D)
-
-    positions:
-      - (B, T, 2) where last dim is (y, x)
-
-    Requirements:
-      - D % 4 == 0  (because we split into y/x halves and each half must be even for RoPE)
-      - max(y) < freqs_cis_y.size(0)
-      - max(x) < freqs_cis_x.size(0)
-    """
-    if positions.ndim != 3 or positions.size(-1) != 2:
-        raise ValueError(f"positions must be (B,T,2), got {tuple(positions.shape)}")
-
-    D = x.size(-1)
-    if D % 4 != 0:
-        raise ValueError(f"2D axial RoPE requires last-dim % 4 == 0, got {D}")
-
-    B = positions.size(0)
-    T = positions.size(1)
-
-    # ---- Canonicalize x to (B, T, H, D) or (B, T, D)
-    layout = None
-    x_can = x
-
-    if x.dim() == 4:
-        if x.size(0) != B:
-            raise ValueError(f"Batch mismatch: x.B={x.size(0)} vs positions.B={B}")
-
-        # Detect whether x is (B, H, T, D) or (B, T, H, D)
-        if x.size(1) == T:
-            # (B, T, H, D)
-            layout = "BTHD"
-        elif x.size(2) == T:
-            # (B, H, T, D) -> (B, T, H, D)
-            layout = "BHTD"
-            x_can = x.permute(0, 2, 1, 3).contiguous()
-        else:
-            raise ValueError(f"Cannot infer token axis: x.shape={tuple(x.shape)} vs T={T}")
-
-    elif x.dim() == 3:
-        if x.size(0) != B or x.size(1) != T:
-            raise ValueError(f"x must be (B,T,D). Got x={tuple(x.shape)}, positions={tuple(positions.shape)}")
-        layout = "BTD"
-    else:
-        raise ValueError(f"Unsupported x rank={x.dim()}. Expected 3 or 4.")
-
-    axis_dim = D // 2
-    y_half = x_can[..., :axis_dim]
-    x_half = x_can[..., axis_dim:]
-
-    y_pos = positions[..., 0].to(torch.long)  # (B,T)
-    x_pos = positions[..., 1].to(torch.long)  # (B,T)
-
-    # Apply 1D RoPE (indexed) to each half
-    y_half = _apply_rotary_emb_indexed_1d_canonical(y_half, freqs_cis_y, y_pos, interleaved=interleaved)
-    x_half = _apply_rotary_emb_indexed_1d_canonical(x_half, freqs_cis_x, x_pos, interleaved=interleaved)
-
-    out = torch.cat([y_half, x_half], dim=-1)
-
-    # ---- Restore original layout
-    if layout == "BHTD":
-        out = out.permute(0, 2, 1, 3).contiguous()
-    return out
-
-
-if __name__ == "__main__":
-    torch.manual_seed(0)
-    demo_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    demo_seq_len = 4
-    demo_dim = 8
-    demo_freqs = precompute_freqs_cis(dim=demo_dim, seqlen=demo_seq_len, device=demo_device)
-    demo_input = torch.randn(1, demo_seq_len, demo_dim, device=demo_device)
-
-    with torch.no_grad():
-        demo_output = apply_rotary_emb(demo_input, demo_freqs)
-
-    print("1D RoPE output:")
-    print(demo_output)
-
-    demo_height = 2
-    demo_width = 3
-    demo_dim_2d = 8
-    demo_freqs_y, demo_freqs_x = precompute_freqs_cis_2d(
-        dim=demo_dim_2d,
-        height=demo_height,
-        width=demo_width,
-        device=demo_device,
-    )
-    demo_positions = PositionGetter()(1, demo_height, demo_width, demo_device)
-    demo_input_2d = torch.randn(1, demo_height * demo_width, demo_dim_2d, device=demo_device)
-
-    with torch.no_grad():
-        demo_output_2d = apply_rotary_emb_2d(
-            demo_input_2d,
-            freqs_cis_y=demo_freqs_y,
-            freqs_cis_x=demo_freqs_x,
-            positions=demo_positions,
-        )
-
-    print("2D RoPE output:")
-    print(demo_output_2d)


### PR DESCRIPTION
<!--
PR body template for `gh pr create --body-file`.

Suggested workflow:
1. Copy this file to a tmp file.
   BODY_FILE="$(mktemp /tmp/pr-body-XXXXXX.md)"
   cp .github/pull_request_template.md "$BODY_FILE"
2. Edit the tmp file and remove guidance comments if they are no longer needed.
3. Create the PR with:
   gh pr create --body-file "$BODY_FILE"
-->

## Summary

- Generalize shared RoPE utilities and attention handling for the issue #355 implementation.
- Update BLCS, PLCS, event detection, and trajectory completion models/configs to use interleaved multi-axis RoPE bases consistently.
- Fix shared attention imports and batched cross-attention RoPE application so the updated models run end-to-end.

## Changes

- Replace the shared RoPE component API with generic N-D frequency construction and shared rotary application.
- Thread axis-specific RoPE theta settings through affected task models and config files.
- Remove stale 2D-RoPE-specific imports in shared attention/block code and support batched RoPE tensors in cross-attention.

## Validation

- .venv/bin/python -c "import src.utils.models; import src.utils.models.components.attention; print(\"ok\")"
- .venv/bin/python -m compileall src/utils/models/components/attention.py src/utils/models/components/block.py
- .venv/bin/python smoke test covering BLCSModel, BLCSQueryModel, BLCSMultiViewModel, PLCSModel, PLCSQuerySequenceModel, PLCSMultiViewModel, UVEventModel, and UVTrajectoryCompletionModel forwards

## Related Issues

- Closes #355
