### PR TITLE
Extract shared projected court rendering

### DIFF
--- a/src/tasks/blcs/visualization/rendering/scene_renderer.py
+++ b/src/tasks/blcs/visualization/rendering/scene_renderer.py
@@ -15,12 +15,11 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 
-from src.utils.schema.court import HALF_DOUBLES_WIDTH, HALF_LENGTH
 from src.utils.rendering.ball_renderer import (
     BallEvent,
     BallEventType,
@@ -28,11 +27,13 @@ from src.utils.rendering.ball_renderer import (
     BallStyle,
 )
 from src.utils.rendering.court_renderer import CourtRenderer
+from src.utils.schema.court import HALF_DOUBLES_WIDTH, HALF_LENGTH
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
-    from mpl_toolkits.mplot3d import Axes3D
+
+    Axes3D: TypeAlias = Any
 
 
 class BLCSSceneRenderer:
@@ -226,18 +227,18 @@ class BLCSSceneRenderer:
 
         # Set up UV coordinate space
         ax.set_facecolor("#1a1a1a")
-
-        # Draw court keypoints
-        for i in range(20):
-            if court_vis[i]:
-                ax.scatter(
-                    court_uv[i, 0],
-                    court_uv[i, 1],
-                    c="lime",
-                    s=50,
-                    marker="s",
-                    alpha=0.7,
-                )
+        self.court_renderer.render_projected_2d(
+            ax,
+            court_uv,
+            court_vis,
+            line_color="lime",
+            line_width=1.5,
+            visible_line_alpha=0.8,
+            keypoint_color="lime",
+            keypoint_size=50.0,
+            keypoint_alpha=0.7,
+            keypoint_marker="s",
+        )
 
         # Build events
         events = self._extract_events(meta)
@@ -295,7 +296,7 @@ class BLCSSceneRenderer:
             Figure with all views.
 
         """
-        fig = plt.figure(figsize=figsize)
+        fig = cast(Figure, plt.figure(figsize=figsize))
 
         # 3D view
         ax1 = fig.add_subplot(2, 2, 1, projection="3d")
@@ -359,12 +360,10 @@ class BLCSSceneRenderer:
         """
         positions = scene["ball_pos_world"]
         num_frames = len(positions)
-        meta = scene["meta"]
-        events = self._extract_events(meta)
         interval = 1000.0 / fps
 
         if view == "3d":
-            fig = plt.figure(figsize=figsize)
+            fig = cast(Figure, plt.figure(figsize=figsize))
             ax = fig.add_subplot(111, projection="3d")
             self.court_renderer.render_3d(ax, show_net=True)
 
@@ -420,34 +419,20 @@ class BLCSSceneRenderer:
             ball_uv = cam["ball_uv"]
 
             fig, ax = plt.subplots(figsize=figsize)
-
-            # Draw court lines (static)
-            from src.utils.schema.court import COURT_SKELETON
-
             court_uv = cam["court_kp_uv"]
             court_vis = cam["court_kp_visible"]
-
-            for i, j in COURT_SKELETON:
-                if court_vis[i] and court_vis[j]:
-                    ax.plot(
-                        [court_uv[i, 0], court_uv[j, 0]],
-                        [court_uv[i, 1], court_uv[j, 1]],
-                        c="lime",
-                        linewidth=1.5,
-                        alpha=0.8,
-                    )
-
-            # Draw court keypoints (static)
-            for i in range(20):
-                if court_vis[i]:
-                    ax.scatter(
-                        court_uv[i, 0],
-                        court_uv[i, 1],
-                        c="lime",
-                        s=30,
-                        marker="s",
-                        alpha=0.7,
-                    )
+            self.court_renderer.render_projected_2d(
+                ax,
+                court_uv,
+                court_vis,
+                line_color="lime",
+                line_width=1.5,
+                visible_line_alpha=0.8,
+                keypoint_color="lime",
+                keypoint_size=30.0,
+                keypoint_alpha=0.7,
+                keypoint_marker="s",
+            )
 
             (line,) = ax.plot([], [], "r-", linewidth=1, alpha=0.5)
             point = ax.scatter([], [], c="red", s=100, zorder=10)
@@ -671,7 +656,7 @@ class BLCSSceneRenderer:
             )
 
         # Common info
-        print(f"\nTrajectory:")
+        print("\nTrajectory:")
         print(f"  Frames: {meta.get('num_frames', 'N/A')}")
         print(
             f"  FPS: {meta.get('fps_out', 'N/A')} (output), "

--- a/src/tasks/event_detection/visualization/rendering/uv_animation.py
+++ b/src/tasks/event_detection/visualization/rendering/uv_animation.py
@@ -14,7 +14,7 @@ from src.tasks.event_detection.visualization.rendering.event_emphasis import (
     mix_color,
 )
 from src.tasks.event_detection.visualization.types import RuntimeConfig, UVEventInputs
-from src.utils.schema.court import COURT_SKELETON
+from src.utils.rendering.court_renderer import CourtRenderer
 
 BASE_BALL_RGB = np.asarray([0.80, 1.00, 0.00], dtype=np.float32)
 SHOT_RGB = np.asarray([1.00, 0.00, 1.00], dtype=np.float32)
@@ -24,13 +24,19 @@ TRAIL_COLOR = "#FF6B6B"
 
 def _draw_court_uv(ax: Axes, *, kp: np.ndarray, vis: np.ndarray, show_lines: bool) -> None:
     ax.set_facecolor("#1A1A1A")
-    if show_lines:
-        for i, j in COURT_SKELETON:
-            if bool(vis[i]) and bool(vis[j]):
-                ax.plot([kp[i, 0], kp[j, 0]], [kp[i, 1], kp[j, 1]], c="lime", linewidth=1.5, alpha=0.8)
-    for i in range(int(kp.shape[0])):
-        if bool(vis[i]):
-            ax.scatter(kp[i, 0], kp[i, 1], c="lime", s=25, marker="s", alpha=0.7)
+    CourtRenderer().render_projected_2d(
+        ax,
+        kp,
+        vis,
+        line_color="lime",
+        line_width=1.5,
+        visible_line_alpha=0.8,
+        keypoint_color="lime",
+        keypoint_size=25.0,
+        keypoint_alpha=0.7,
+        keypoint_marker="s",
+        show_lines=show_lines,
+    )
 
 
 def create_uv_event_animation(

--- a/src/tasks/plcs/visualization/rendering/scene_renderer.py
+++ b/src/tasks/plcs/visualization/rendering/scene_renderer.py
@@ -2,20 +2,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.animation import FuncAnimation
 
-from src.utils.schema.court import HALF_DOUBLES_WIDTH, HALF_LENGTH, NET_HEIGHT_POST
 from src.utils.rendering.court_renderer import CourtRenderer
 from src.utils.rendering.skeleton_renderer import SkeletonRenderer, SkeletonStyle
-from src.utils.schema.court import COURT_SKELETON
+from src.utils.schema.court import HALF_DOUBLES_WIDTH, HALF_LENGTH, NET_HEIGHT_POST
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
-    from mpl_toolkits.mplot3d import Axes3D
+
+    Axes3D: TypeAlias = Any
 
 
 class PLCSSceneRenderer:
@@ -214,7 +214,7 @@ class PLCSSceneRenderer:
         world_pose[:, 0] += x
         world_pose[:, 1] += y
         world_pose[:, 2] += z
-        return world_pose
+        return cast(np.ndarray, np.asarray(world_pose, dtype=np.float64))
 
     def _set_zoomed_3d_view(self, ax: Axes3D, center_x: float, center_y: float) -> None:
         x_half_span = 6.0
@@ -355,25 +355,19 @@ class PLCSSceneRenderer:
 
         court_uv = cam.court_kp_uv[frame_idx]
         court_vis = cam.court_kp_visible[frame_idx]
-        visible_court = court_uv[court_vis]
-        if len(visible_court) > 0:
-            ax.scatter(
-                visible_court[:, 0],
-                visible_court[:, 1],
-                c="lime",
-                s=30,
-                marker="s",
-            )
-
-        for i, j in COURT_SKELETON:
-            alpha = 0.5 if (court_vis[i] and court_vis[j]) else 0.2
-            ax.plot(
-                [court_uv[i, 0], court_uv[j, 0]],
-                [court_uv[i, 1], court_uv[j, 1]],
-                color="lime",
-                linewidth=1,
-                alpha=alpha,
-            )
+        self.court_renderer.render_projected_2d(
+            ax,
+            court_uv,
+            court_vis,
+            line_color="lime",
+            line_width=1.0,
+            visible_line_alpha=0.5,
+            partial_line_alpha=0.2,
+            keypoint_color="lime",
+            keypoint_size=30.0,
+            keypoint_alpha=0.7,
+            keypoint_marker="s",
+        )
 
         human_uv = cam.human_kp_uv[frame_idx]
         human_vis = cam.human_kp_visible[frame_idx]

--- a/src/tasks/trajectory_completion/visualization/rendering/uv_animation.py
+++ b/src/tasks/trajectory_completion/visualization/rendering/uv_animation.py
@@ -9,8 +9,11 @@ from matplotlib.axes import Axes
 from matplotlib.collections import PathCollection
 from matplotlib.lines import Line2D
 
-from src.tasks.trajectory_completion.visualization.types import RuntimeConfig, TrajectoryInputs
-from src.utils.schema.court import COURT_SKELETON
+from src.tasks.trajectory_completion.visualization.types import (
+    RuntimeConfig,
+    TrajectoryInputs,
+)
+from src.utils.rendering.court_renderer import CourtRenderer
 
 GT_LINE_COLOR = "#F5F5F5"
 OBSERVED_POINT_COLOR = "#00D1FF"
@@ -25,30 +28,19 @@ def _draw_court_uv(
     show_lines: bool,
 ) -> None:
     ax.set_facecolor("#1A1A1A")
-
-    if show_lines:
-        for i, j in COURT_SKELETON:
-            if bool(court_vis[i]) and bool(court_vis[j]):
-                ax.plot(
-                    [court_kp[i, 0], court_kp[j, 0]],
-                    [court_kp[i, 1], court_kp[j, 1]],
-                    c="lime",
-                    linewidth=1.5,
-                    alpha=0.8,
-                    zorder=1,
-                )
-
-    for i in range(int(court_kp.shape[0])):
-        if bool(court_vis[i]):
-            ax.scatter(
-                court_kp[i, 0],
-                court_kp[i, 1],
-                c="lime",
-                s=25,
-                marker="s",
-                alpha=0.7,
-                zorder=2,
-            )
+    CourtRenderer().render_projected_2d(
+        ax,
+        court_kp,
+        court_vis,
+        line_color="lime",
+        line_width=1.5,
+        visible_line_alpha=0.8,
+        keypoint_color="lime",
+        keypoint_size=25.0,
+        keypoint_alpha=0.7,
+        keypoint_marker="s",
+        show_lines=show_lines,
+    )
 
 
 def create_uv_completion_animation(

--- a/src/utils/rendering/court_renderer.py
+++ b/src/utils/rendering/court_renderer.py
@@ -17,7 +17,7 @@ Example:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import numpy as np
 
@@ -26,16 +26,15 @@ from src.utils.schema.court import (
     COURT_SKELETON,
     HALF_DOUBLES_WIDTH,
     HALF_LENGTH,
-    HALF_SINGLES_WIDTH,
     NET_HEIGHT_CENTER,
     NET_HEIGHT_POST,
-    SERVICE_LINE_DISTANCE,
     court_keypoints_3d,
 )
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
-    from mpl_toolkits.mplot3d import Axes3D
+
+    Axes3D: TypeAlias = Any
 
 
 # Color defaults
@@ -242,6 +241,160 @@ class CourtRenderer:
             ax.set_xlabel("X (m)")
             ax.set_ylabel("Y (m)")
 
+    @staticmethod
+    def _clip_segment_to_rectangle(
+        start: np.ndarray,
+        end: np.ndarray,
+        *,
+        bounds: tuple[float, float, float, float],
+    ) -> tuple[tuple[float, float], tuple[float, float]] | None:
+        """Clip a 2D segment to an axis-aligned rectangle.
+
+        Args:
+            start: Segment start point as ``(x, y)``.
+            end: Segment end point as ``(x, y)``.
+            bounds: Rectangle bounds as ``(x_min, x_max, y_min, y_max)``.
+
+        Returns:
+            Clipped segment endpoints, or ``None`` when the segment does not
+            intersect the rectangle.
+
+        """
+        x0 = float(start[0])
+        y0 = float(start[1])
+        x1 = float(end[0])
+        y1 = float(end[1])
+        if not np.all(np.isfinite([x0, y0, x1, y1])):
+            return None
+
+        x_min, x_max, y_min, y_max = bounds
+        dx = x1 - x0
+        dy = y1 - y0
+        p = (-dx, dx, -dy, dy)
+        q = (x0 - x_min, x_max - x0, y0 - y_min, y_max - y0)
+
+        t_enter = 0.0
+        t_leave = 1.0
+        epsilon = 1e-12
+        for p_i, q_i in zip(p, q, strict=True):
+            if abs(p_i) <= epsilon:
+                if q_i < 0.0:
+                    return None
+                continue
+
+            t = q_i / p_i
+            if p_i < 0.0:
+                if t > t_leave:
+                    return None
+                t_enter = max(t_enter, t)
+            else:
+                if t < t_enter:
+                    return None
+                t_leave = min(t_leave, t)
+
+        clipped_start = (x0 + t_enter * dx, y0 + t_enter * dy)
+        clipped_end = (x0 + t_leave * dx, y0 + t_leave * dy)
+        return clipped_start, clipped_end
+
+    def render_projected_2d(
+        self,
+        ax: Axes,
+        keypoints: np.ndarray,
+        visibility: np.ndarray | None = None,
+        *,
+        view_bounds: tuple[float, float, float, float] = (0.0, 1.0, 0.0, 1.0),
+        line_color: str | None = None,
+        line_width: float | None = None,
+        visible_line_alpha: float = 0.8,
+        partial_line_alpha: float | None = None,
+        keypoint_color: str | None = None,
+        keypoint_size: float = 25.0,
+        keypoint_alpha: float = 0.7,
+        keypoint_marker: str = "s",
+        show_lines: bool = True,
+        show_keypoints: bool = True,
+    ) -> None:
+        """Render projected court lines in normalized image coordinates.
+
+        This method clips partially visible court lines to the viewport so that
+        segments remain visible even when one endpoint falls outside the frame.
+
+        Args:
+            ax: Matplotlib axes to draw on.
+            keypoints: Projected court keypoints with shape ``(N, 2)``.
+            visibility: Per-keypoint visibility flags. If omitted, all points are
+                treated as visible.
+            view_bounds: View rectangle as ``(x_min, x_max, y_min, y_max)``.
+            line_color: Override court line color.
+            line_width: Override court line width.
+            visible_line_alpha: Alpha used when both endpoints are visible.
+            partial_line_alpha: Alpha used when only one endpoint is visible.
+            keypoint_color: Override keypoint marker color.
+            keypoint_size: Keypoint marker size.
+            keypoint_alpha: Keypoint marker alpha.
+            keypoint_marker: Keypoint marker style.
+            show_lines: Whether to draw court line segments.
+            show_keypoints: Whether to draw visible keypoint markers.
+
+        """
+        line_color = line_color or self.style.line_color
+        line_width = line_width if line_width is not None else self.style.line_width
+        keypoint_color = keypoint_color or line_color
+
+        keypoints = np.asarray(keypoints, dtype=np.float64)
+        num_keypoints = int(keypoints.shape[0])
+        if visibility is None:
+            visibility = np.ones(num_keypoints, dtype=bool)
+        visibility = np.asarray(visibility, dtype=bool)
+
+        if show_lines:
+            for i, j in COURT_SKELETON:
+                if i >= num_keypoints or j >= num_keypoints:
+                    continue
+
+                if not (visibility[i] or visibility[j]):
+                    continue
+
+                clipped = self._clip_segment_to_rectangle(
+                    keypoints[i],
+                    keypoints[j],
+                    bounds=view_bounds,
+                )
+                if clipped is None:
+                    continue
+
+                alpha = visible_line_alpha
+                if partial_line_alpha is not None and not (visibility[i] and visibility[j]):
+                    alpha = partial_line_alpha
+
+                (x0, y0), (x1, y1) = clipped
+                ax.plot(
+                    [x0, x1],
+                    [y0, y1],
+                    color=line_color,
+                    linewidth=line_width,
+                    alpha=alpha,
+                    zorder=1,
+                    solid_capstyle="round",
+                )
+
+        if not show_keypoints:
+            return
+
+        visible_keypoints = keypoints[visibility]
+        if len(visible_keypoints) == 0:
+            return
+
+        ax.scatter(
+            visible_keypoints[:, 0],
+            visible_keypoints[:, 1],
+            c=keypoint_color,
+            s=keypoint_size,
+            marker=keypoint_marker,
+            alpha=keypoint_alpha,
+            zorder=2,
+        )
+
     def render_3d(
         self,
         ax: Axes3D,
@@ -377,4 +530,4 @@ class CourtRenderer:
             Array of shape (20, 3) containing CourtKP20 keypoint positions in meters.
 
         """
-        return court_keypoints_3d().cpu().numpy()
+        return cast(np.ndarray, np.asarray(court_keypoints_3d().cpu().numpy(), dtype=np.float32))


### PR DESCRIPTION
## Summary

- UV座標系のコート描画を `CourtRenderer` に集約しました。
- 可視範囲外にはみ出した線分をクリップして描画できるようにし、各可視化モジュールの重複実装を削減しました。
- あわせて描画周辺の型注釈と戻り値の扱いを整理しました。

## Changes

- `CourtRenderer` に 2D投影コート描画用の `render_projected_2d` を追加
- ビューポート矩形に対する線分クリッピング処理を追加し、部分的に見えているコート線も描画可能に変更
- BLCS / PLCS / event_detection / trajectory_completion の可視化コードを共通描画ロジックへ置き換え
- 描画周辺の型注釈と `matplotlib` / `numpy` の戻り値キャストを整理

## Related Issues

- None

## Notes

- `tests/` 配下の変更はこのPRに含めていません。
