### PR TITLE
[codex] Add qualitative validation logging

### DIFF
--- a/src/tasks/ball_detection/configs/training/default.yaml
+++ b/src/tasks/ball_detection/configs/training/default.yaml
@@ -40,3 +40,9 @@ early_stopping:
 lr_monitor:
   enabled: true
   interval: step
+
+# ---- Qualitative validation logging ----
+qualitative_logging:
+  enabled: true
+  every_n_epochs: 1
+  num_samples: 4

--- a/src/tasks/ball_detection/training/lightning_module.py
+++ b/src/tasks/ball_detection/training/lightning_module.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
+import cv2
+import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import Tensor
@@ -13,6 +16,7 @@ from src.tasks.ball_detection.models import build_ball_detection_model
 from src.tasks.ball_detection.training.losses import BallDetectionFocalLoss
 from src.tasks.ball_detection.training.metrics import BallDetectionMetrics
 from src.tasks.base.training.lightning_module import BaseLightningModule
+from src.tasks.base.training.qualitative_callback import save_image_to_tensorboard
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -153,3 +157,88 @@ class BallDetectionLightningModule(BaseLightningModule):
         for name, value in metrics.items():
             self.log(f"test/{name}", value)
         self.test_metrics.reset()
+
+    # ------------------------------------------------------------------
+    # Qualitative validation logging
+    # ------------------------------------------------------------------
+
+    def render_qualitative_samples(
+        self,
+        batches: list[dict[str, Any]],
+        outputs: list[dict[str, Any]],
+        artifact_dir: Path,
+        tb_writer: Any | None,
+        global_step: int,
+        epoch: int,
+    ) -> None:
+        """Render ball detection heatmap overlays for qualitative inspection."""
+        device = next(self.parameters()).device
+
+        for batch_idx, batch in enumerate(batches):
+            images = batch["images"].to(device)
+            heatmaps_gt = batch["heatmaps"]  # (B, T, Hh, Wh)
+            coords_gt = batch["coords"]  # (B, T, 2)
+            visibility = batch["visibility"]  # (B, T)
+
+            model_cfg = self.config.get("model", {})
+            model_input = to_model_input(images, model_cfg)
+
+            with torch.no_grad():
+                logits = self.model(model_input).squeeze(1)  # (B, T, Hh, Wh)
+                if logits.shape[-2:] != heatmaps_gt.shape[-2:]:
+                    b, t = logits.shape[:2]
+                    logits_flat = logits.reshape(b * t, 1, *logits.shape[-2:])
+                    logits_flat = F.interpolate(
+                        logits_flat,
+                        size=heatmaps_gt.shape[-2:],
+                        mode="bilinear",
+                        align_corners=False,
+                    )
+                    logits = logits_flat.reshape(b, t, *heatmaps_gt.shape[-2:])
+                pred_heatmaps = torch.sigmoid(logits).cpu()
+
+            # Render first sample in each batch, middle frame
+            b_idx = 0
+            t_idx = images.shape[2] // 2  # middle frame of temporal window
+
+            img = images[b_idx, :, t_idx].cpu()  # (C, H, W)
+            gt_hm = heatmaps_gt[b_idx, t_idx].numpy()  # (Hh, Wh)
+            pred_hm = pred_heatmaps[b_idx, t_idx].numpy()  # (Hh, Wh)
+
+            # Denormalize image
+            mean = np.array([0.485, 0.456, 0.406]).reshape(3, 1, 1)
+            std = np.array([0.229, 0.224, 0.225]).reshape(3, 1, 1)
+            img_np = (img.numpy() * std + mean).clip(0, 1).transpose(1, 2, 0)
+            img_bgr = (img_np * 255).astype(np.uint8)
+            img_bgr = cv2.cvtColor(img_bgr, cv2.COLOR_RGB2BGR)
+            h, w = img_bgr.shape[:2]
+
+            # Colorize heatmaps
+            gt_cm = cv2.applyColorMap(
+                cv2.resize((gt_hm * 255).astype(np.uint8), (w, h)),
+                cv2.COLORMAP_JET,
+            )
+            pred_cm = cv2.applyColorMap(
+                cv2.resize((pred_hm * 255).astype(np.uint8), (w, h)),
+                cv2.COLORMAP_JET,
+            )
+
+            # Draw GT ball position
+            if visibility[b_idx, t_idx] > 0:
+                cx = int(coords_gt[b_idx, t_idx, 0].item())
+                cy = int(coords_gt[b_idx, t_idx, 1].item())
+                cv2.circle(img_bgr, (cx, cy), 5, (0, 255, 0), 2)
+
+            panel = np.concatenate([img_bgr, gt_cm, pred_cm], axis=1)
+
+            # Save artifact
+            path = artifact_dir / f"ball_batch{batch_idx:02d}.png"
+            cv2.imwrite(str(path), panel)
+
+            # Log to TensorBoard
+            save_image_to_tensorboard(
+                tb_writer,
+                f"qualitative/ball_detection/batch{batch_idx:02d}",
+                panel,
+                global_step,
+            )

--- a/src/tasks/base/training/__init__.py
+++ b/src/tasks/base/training/__init__.py
@@ -1,6 +1,7 @@
 """Base training components."""
 
 from src.tasks.base.training.lightning_module import BaseLightningModule
+from src.tasks.base.training.qualitative_callback import QualitativeLoggingCallback
 from src.tasks.base.training.runner import BaseTrainingRunner
 
-__all__ = ["BaseLightningModule", "BaseTrainingRunner"]
+__all__ = ["BaseLightningModule", "BaseTrainingRunner", "QualitativeLoggingCallback"]

--- a/src/tasks/base/training/lightning_module.py
+++ b/src/tasks/base/training/lightning_module.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
 import pytorch_lightning as pl
 from torch.optim import AdamW
 from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR, SequentialLR
@@ -35,6 +37,33 @@ class BaseLightningModule(pl.LightningModule):
         optimizer_cfg = train_cfg.get("optimizer", {}) or {}
         betas = optimizer_cfg.get("betas")
         self.optimizer_betas = tuple(betas) if betas is not None else None
+
+    # ------------------------------------------------------------------
+    # Qualitative validation logging hook
+    # ------------------------------------------------------------------
+
+    def render_qualitative_samples(
+        self,
+        batches: list[dict[str, Any]],
+        outputs: list[dict[str, Any]],
+        artifact_dir: Path,
+        tb_writer: Any | None,
+        global_step: int,
+        epoch: int,
+    ) -> None:
+        """Render qualitative validation samples.
+
+        Override in task-specific subclasses to produce visualizations.
+        The default implementation is a no-op.
+
+        Args:
+            batches: Collected validation batch dicts (CPU tensors).
+            outputs: Corresponding validation_step outputs (CPU tensors).
+            artifact_dir: Directory to save artifact images/files.
+            tb_writer: TensorBoard SummaryWriter (may be ``None``).
+            global_step: Current global training step.
+            epoch: Current epoch number.
+        """
 
     def _estimate_total_steps(self) -> int:
         steps_per_epoch_attr = getattr(self, "steps_per_epoch", None)

--- a/src/tasks/base/training/qualitative_callback.py
+++ b/src/tasks/base/training/qualitative_callback.py
@@ -1,0 +1,235 @@
+"""Shared qualitative validation logging callback.
+
+Collects a bounded random subset of validation samples during ``validation_step``
+and delegates task-specific rendering to the LightningModule at epoch end.
+Outputs are written to both TensorBoard and versioned artifact directories.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytorch_lightning as pl
+import torch
+from pytorch_lightning.loggers import TensorBoardLogger
+
+
+class QualitativeLoggingCallback(pl.Callback):
+    """Collect validation samples and save qualitative visualizations.
+
+    The callback randomly selects ``num_samples`` batches each validation epoch,
+    then calls ``render_qualitative_samples`` on the LightningModule to produce
+    task-specific visualizations.
+
+    Args:
+        every_n_epochs: Run qualitative logging every *n* validation epochs.
+        num_samples: Number of validation batches to collect per epoch.
+        enabled: Master switch; when ``False`` the callback is a no-op.
+    """
+
+    def __init__(
+        self,
+        every_n_epochs: int = 1,
+        num_samples: int = 4,
+        enabled: bool = True,
+    ) -> None:
+        super().__init__()
+        self.every_n_epochs = max(every_n_epochs, 1)
+        self.num_samples = max(num_samples, 1)
+        self.enabled = enabled
+
+        # Populated during validation
+        self._collected_batches: list[dict[str, Any]] = []
+        self._collected_outputs: list[dict[str, Any]] = []
+        self._selected_indices: set[int] = set()
+        self._total_val_batches: int | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks
+    # ------------------------------------------------------------------
+
+    def on_validation_epoch_start(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+    ) -> None:
+        """Determine which batch indices to collect for this epoch."""
+        self._collected_batches.clear()
+        self._collected_outputs.clear()
+        self._selected_indices.clear()
+
+        if not self._should_log(trainer):
+            return
+
+        # Estimate total validation batches
+        total = self._estimate_total_batches(trainer)
+        self._total_val_batches = total
+
+        # Randomly select batch indices to collect
+        n = min(self.num_samples, total)
+        self._selected_indices = set(random.sample(range(total), n))
+
+    def on_validation_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Collect batch data if this index was selected."""
+        if not self._should_log(trainer):
+            return
+        if batch_idx not in self._selected_indices:
+            return
+
+        # Detach and move to CPU to avoid GPU memory accumulation
+        self._collected_batches.append(_detach_to_cpu(batch))
+        if outputs is not None:
+            self._collected_outputs.append(_detach_to_cpu(outputs))
+        else:
+            self._collected_outputs.append({})
+
+    def on_validation_epoch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+    ) -> None:
+        """Render and save qualitative outputs."""
+        if not self._should_log(trainer):
+            self._collected_batches.clear()
+            self._collected_outputs.clear()
+            return
+
+        if not self._collected_batches:
+            return
+
+        # Only rank-zero writes artifacts
+        if trainer.global_rank != 0:
+            self._collected_batches.clear()
+            self._collected_outputs.clear()
+            return
+
+        # Resolve output directory
+        epoch = trainer.current_epoch
+        artifact_dir = self._resolve_artifact_dir(trainer, epoch)
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+
+        # Get TensorBoard SummaryWriter
+        tb_writer = self._get_tb_writer(trainer)
+        global_step = trainer.global_step
+
+        # Delegate rendering to the task LightningModule
+        if hasattr(pl_module, "render_qualitative_samples"):
+            pl_module.render_qualitative_samples(
+                batches=self._collected_batches,
+                outputs=self._collected_outputs,
+                artifact_dir=artifact_dir,
+                tb_writer=tb_writer,
+                global_step=global_step,
+                epoch=epoch,
+            )
+
+        self._collected_batches.clear()
+        self._collected_outputs.clear()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _should_log(self, trainer: pl.Trainer) -> bool:
+        """Check if qualitative logging should run this epoch."""
+        if not self.enabled:
+            return False
+        if trainer.sanity_checking:
+            return False
+        return (trainer.current_epoch % self.every_n_epochs) == 0
+
+    def _estimate_total_batches(self, trainer: pl.Trainer) -> int:
+        """Estimate the total number of validation batches."""
+        val_dataloaders = trainer.val_dataloaders
+        if val_dataloaders is None:
+            return self.num_samples
+
+        if isinstance(val_dataloaders, list):
+            dl = val_dataloaders[0] if val_dataloaders else None
+        else:
+            dl = val_dataloaders
+
+        if dl is None:
+            return self.num_samples
+
+        try:
+            return len(dl)
+        except (TypeError, NotImplementedError):
+            return self.num_samples
+
+    def _resolve_artifact_dir(self, trainer: pl.Trainer, epoch: int) -> Path:
+        """Build ``<log_dir>/qualitative/epoch_XXXX`` path."""
+        log_dir = _get_log_dir(trainer)
+        return log_dir / "qualitative" / f"epoch_{epoch:04d}"
+
+    @staticmethod
+    def _get_tb_writer(trainer: pl.Trainer) -> Any | None:
+        """Extract the TensorBoard SummaryWriter from the trainer logger."""
+        logger = trainer.logger
+        if isinstance(logger, TensorBoardLogger):
+            return logger.experiment
+        return None
+
+
+# ------------------------------------------------------------------
+# Utility functions
+# ------------------------------------------------------------------
+
+
+def _detach_to_cpu(data: Any) -> Any:
+    """Recursively detach tensors and move to CPU."""
+    if isinstance(data, torch.Tensor):
+        return data.detach().cpu()
+    if isinstance(data, dict):
+        return {k: _detach_to_cpu(v) for k, v in data.items()}
+    if isinstance(data, (list, tuple)):
+        cls = type(data)
+        return cls(_detach_to_cpu(v) for v in data)
+    return data
+
+
+def _get_log_dir(trainer: pl.Trainer) -> Path:
+    """Get the log directory from the trainer's logger."""
+    logger = trainer.logger
+    if isinstance(logger, TensorBoardLogger):
+        return Path(logger.log_dir)
+    return Path("outputs")
+
+
+def save_image_to_tensorboard(
+    tb_writer: Any,
+    tag: str,
+    image: np.ndarray,
+    global_step: int,
+) -> None:
+    """Write a BGR/RGB numpy image to TensorBoard.
+
+    Args:
+        tb_writer: TensorBoard SummaryWriter.
+        tag: Tag name for the image.
+        image: ``(H, W, 3)`` uint8 image (BGR from cv2 — will be converted to RGB).
+        global_step: Global step for TensorBoard.
+    """
+    if tb_writer is None:
+        return
+    import cv2
+
+    if image.ndim == 3 and image.shape[2] == 3:
+        image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+    else:
+        image_rgb = image
+    # TensorBoard expects (C, H, W) for add_image
+    if image_rgb.ndim == 3:
+        image_rgb = np.transpose(image_rgb, (2, 0, 1))
+    tb_writer.add_image(tag, image_rgb, global_step)

--- a/src/tasks/base/training/runner.py
+++ b/src/tasks/base/training/runner.py
@@ -19,6 +19,8 @@ from omegaconf import OmegaConf
 from pytorch_lightning.callbacks import EarlyStopping, LearningRateMonitor, ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
 
+from src.tasks.base.training.qualitative_callback import QualitativeLoggingCallback
+
 
 class BaseTrainingRunner:
     """Base training runner with strict config-driven behavior.
@@ -173,6 +175,17 @@ class BaseTrainingRunner:
         lr_cfg = config.training.lr_monitor
         if lr_cfg.enabled:
             callbacks.append(LearningRateMonitor(logging_interval=lr_cfg.interval))
+
+        # Qualitative validation logging callback (optional)
+        qual_cfg = config.training.get("qualitative_logging", {})
+        if qual_cfg.get("enabled", False):
+            callbacks.append(
+                QualitativeLoggingCallback(
+                    every_n_epochs=int(qual_cfg.get("every_n_epochs", 1)),
+                    num_samples=int(qual_cfg.get("num_samples", 4)),
+                    enabled=True,
+                )
+            )
 
         # Add task-specific callbacks
         callbacks.extend(self.callbacks_extra(config, datamodule, logger))

--- a/src/tasks/blcs/training/lightning_module.py
+++ b/src/tasks/blcs/training/lightning_module.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
+import cv2
+import numpy as np
 import torch
 from torch import Tensor
 
 from src.tasks.base.training.lightning_module import BaseLightningModule
+from src.tasks.base.training.qualitative_callback import save_image_to_tensorboard
 from src.tasks.blcs.data.types import BLCSBatch, BLCSMultiViewBatch
 from src.tasks.blcs.models import build_blcs_model
 from src.tasks.blcs.training.losses import BLCSLoss
@@ -161,3 +165,90 @@ class BLCSLightningModule(BaseLightningModule):
         for name, value in metrics.items():
             self.log(f"test/{name}", value)
         self.test_metrics.reset()
+
+    # ------------------------------------------------------------------
+    # Qualitative validation logging
+    # ------------------------------------------------------------------
+
+    def render_qualitative_samples(
+        self,
+        batches: list[dict[str, Any]],
+        outputs: list[dict[str, Any]],
+        artifact_dir: Path,
+        tb_writer: Any | None,
+        global_step: int,
+        epoch: int,
+    ) -> None:
+        """Render GT vs predicted 3D ball trajectories in top-down (X-Y) and side (X-Z) views."""
+        device = next(self.parameters()).device
+
+        for batch_idx, batch in enumerate(batches):
+            batch_dev = {
+                k: v.to(device) if isinstance(v, Tensor) else v
+                for k, v in batch.items()
+            }
+
+            with torch.no_grad():
+                out = self._forward_from_batch(batch_dev)
+                pred_pos = out["position"].cpu().numpy()  # (B, T, 3)
+
+            gt_pos = batch["position_3d"].numpy()  # (B, T, 3)
+            mask = self._normalize_loss_mask(batch)
+            if mask is not None:
+                mask_np = mask.numpy()
+            else:
+                mask_np = np.ones(gt_pos.shape[:2], dtype=np.float32)
+
+            # Render first sample
+            b = 0
+            gt = gt_pos[b]  # (T, 3)
+            pred = pred_pos[b]  # (T, 3)
+            m = mask_np[b] > 0  # (T,)
+
+            fig_w, fig_h = 400, 400
+            # Top-down: X vs Y
+            canvas_top = np.ones((fig_h, fig_w, 3), dtype=np.uint8) * 255
+            # Side: X vs Z
+            canvas_side = np.ones((fig_h, fig_w, 3), dtype=np.uint8) * 255
+
+            def _normalize_and_draw(
+                canvas: np.ndarray, gt_2d: np.ndarray, pred_2d: np.ndarray, valid: np.ndarray
+            ) -> None:
+                all_pts = np.concatenate([gt_2d[valid], pred_2d[valid]], axis=0)
+                if len(all_pts) == 0:
+                    return
+                mn = all_pts.min(axis=0)
+                mx = all_pts.max(axis=0)
+                rng = (mx - mn).clip(1e-3)
+                margin = 30
+
+                def to_px(p: np.ndarray) -> tuple[int, int]:
+                    x = int((p[0] - mn[0]) / rng[0] * (fig_w - 2 * margin) + margin)
+                    y = int((p[1] - mn[1]) / rng[1] * (fig_h - 2 * margin) + margin)
+                    return (np.clip(x, 0, fig_w - 1), np.clip(y, 0, fig_h - 1))
+
+                for t in range(len(gt_2d)):
+                    if not valid[t]:
+                        continue
+                    cv2.circle(canvas, to_px(gt_2d[t]), 3, (0, 180, 0), -1)
+                    cv2.circle(canvas, to_px(pred_2d[t]), 3, (0, 0, 255), -1)
+
+            _normalize_and_draw(canvas_top, gt[:, :2], pred[:, :2], m)
+            cv2.putText(canvas_top, "Top-down (X-Y) Green=GT Red=Pred", (5, 15),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.35, (0, 0, 0), 1)
+
+            _normalize_and_draw(canvas_side, gt[:, [0, 2]], pred[:, [0, 2]], m)
+            cv2.putText(canvas_side, "Side (X-Z) Green=GT Red=Pred", (5, 15),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.35, (0, 0, 0), 1)
+
+            panel = np.concatenate([canvas_top, canvas_side], axis=1)
+
+            path = artifact_dir / f"blcs_batch{batch_idx:02d}.png"
+            cv2.imwrite(str(path), panel)
+
+            save_image_to_tensorboard(
+                tb_writer,
+                f"qualitative/blcs/batch{batch_idx:02d}",
+                panel,
+                global_step,
+            )

--- a/src/tasks/court_detection/configs/training/default.yaml
+++ b/src/tasks/court_detection/configs/training/default.yaml
@@ -36,3 +36,9 @@ early_stopping:
 lr_monitor:
   enabled: true
   interval: epoch
+
+# ---- Qualitative validation logging ----
+qualitative_logging:
+  enabled: true
+  every_n_epochs: 1
+  num_samples: 4

--- a/src/tasks/court_detection/training/lightning_module.py
+++ b/src/tasks/court_detection/training/lightning_module.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 
 from src.tasks.base.training.lightning_module import BaseLightningModule
+from src.tasks.base.training.qualitative_callback import save_image_to_tensorboard
 from src.tasks.court_detection.models import build_court_detection_model
 from src.tasks.court_detection.training.losses import (
     BinaryDiceLoss,
@@ -16,6 +18,11 @@ from src.tasks.court_detection.training.losses import (
     FocalBCEWithLogitsLoss,
 )
 from src.tasks.court_detection.training.metrics import CourtDetectionMetrics
+from src.tasks.court_detection.training.visualization import (
+    save_kp_vis,
+    save_line_vis,
+    save_seg_vis,
+)
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -119,3 +126,53 @@ class CourtDetectionLightningModule(BaseLightningModule):
         for name, value in metrics.items():
             self.log(f"val/{name}", value, prog_bar=(name in ("miou", "mean_dist", "dice")))
         self.val_metrics.reset()
+
+    # ------------------------------------------------------------------
+    # Qualitative validation logging
+    # ------------------------------------------------------------------
+
+    def render_qualitative_samples(
+        self,
+        batches: list[dict[str, Any]],
+        outputs: list[dict[str, Any]],
+        artifact_dir: Path,
+        tb_writer: Any | None,
+        global_step: int,
+        epoch: int,
+    ) -> None:
+        """Render court detection panels using existing visualization helpers."""
+        import cv2
+
+        device = next(self.parameters()).device
+
+        for batch_idx, batch in enumerate(batches):
+            images = batch["image"].to(device)
+
+            with torch.no_grad():
+                logits = self.model(images).cpu()  # (B, C, H, W)
+
+            # Render first sample in each batch
+            img_tensor = batch["image"][0]  # (3, H, W)
+            pred_logits_sample = logits[0]  # (C, H, W)
+
+            path = artifact_dir / f"court_batch{batch_idx:02d}.png"
+
+            if self.task == "seg":
+                gt = batch["mask"][0]  # (H, W) long
+                save_seg_vis(img_tensor, gt, pred_logits_sample, path)
+            elif self.task == "kp":
+                gt = batch["heatmap"][0]  # (K, H, W)
+                save_kp_vis(img_tensor, gt, pred_logits_sample, path)
+            elif self.task == "line":
+                gt = batch["mask"][0]  # (1, H, W)
+                save_line_vis(img_tensor, gt, pred_logits_sample, path)
+
+            # Log to TensorBoard
+            panel = cv2.imread(str(path))
+            if panel is not None:
+                save_image_to_tensorboard(
+                    tb_writer,
+                    f"qualitative/court_detection/{self.task}/batch{batch_idx:02d}",
+                    panel,
+                    global_step,
+                )

--- a/src/tasks/event_detection/configs/training/default.yaml
+++ b/src/tasks/event_detection/configs/training/default.yaml
@@ -38,3 +38,9 @@ early_stopping:
 lr_monitor:
   enabled: true
   interval: step
+
+# ---- Qualitative validation logging ----
+qualitative_logging:
+  enabled: true
+  every_n_epochs: 1
+  num_samples: 4

--- a/src/tasks/event_detection/training/lightning_module.py
+++ b/src/tasks/event_detection/training/lightning_module.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+import cv2
+import numpy as np
 import torch
 from torch import Tensor
 from torch.nn import functional as F
+
 from src.tasks.base.training.lightning_module import BaseLightningModule
+from src.tasks.base.training.qualitative_callback import save_image_to_tensorboard
 from src.tasks.event_detection.models import build_event_detection_model
 from src.tasks.event_detection.utils.peaks import extract_event_peaks
 
@@ -109,6 +115,92 @@ class EventDetectionLightningModule(BaseLightningModule):
     def validation_step(self, batch: dict[str, Tensor], batch_idx: int) -> None:
         _ = batch_idx
         self._shared_step(batch, "val")
+
+    # ------------------------------------------------------------------
+    # Qualitative validation logging
+    # ------------------------------------------------------------------
+
+    def render_qualitative_samples(
+        self,
+        batches: list[dict[str, Any]],
+        outputs: list[dict[str, Any]],
+        artifact_dir: Path,
+        tb_writer: Any | None,
+        global_step: int,
+        epoch: int,
+    ) -> None:
+        """Render event probability timelines with GT/predicted peak markers."""
+        device = next(self.parameters()).device
+
+        for batch_idx, batch in enumerate(batches):
+            batch_dev = {
+                k: v.to(device) if isinstance(v, Tensor) else v
+                for k, v in batch.items()
+            }
+
+            with torch.no_grad():
+                logits = self.forward(batch_dev).cpu()  # (B, T, E)
+
+            targets = batch["targets"]  # (B, T, E)
+            seq_len = batch.get("seq_len")  # (B,)
+            probs = torch.sigmoid(logits)
+
+            # Render first sample
+            b = 0
+            T = int(seq_len[b].item()) if seq_len is not None else probs.shape[1]
+            E = probs.shape[2]
+            event_names = [f"event_{e}" for e in range(E)]
+
+            fig_h = max(200 * E, 200)
+            fig_w = 800
+            panel = np.ones((fig_h, fig_w, 3), dtype=np.uint8) * 255
+
+            row_h = fig_h // E
+            for e in range(E):
+                y_off = e * row_h
+                prob_e = probs[b, :T, e].numpy()
+                gt_e = targets[b, :T, e].numpy()
+
+                # Draw axes
+                cv2.line(panel, (50, y_off + row_h - 30), (fig_w - 20, y_off + row_h - 30), (0, 0, 0), 1)
+                cv2.putText(panel, event_names[e], (5, y_off + 20), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 0), 1)
+
+                # Plot probability curve
+                plot_h = row_h - 50
+                for t in range(1, T):
+                    x1 = 50 + int((t - 1) / max(T - 1, 1) * (fig_w - 70))
+                    x2 = 50 + int(t / max(T - 1, 1) * (fig_w - 70))
+                    y1 = y_off + row_h - 30 - int(prob_e[t - 1] * plot_h)
+                    y2 = y_off + row_h - 30 - int(prob_e[t] * plot_h)
+                    cv2.line(panel, (x1, y1), (x2, y2), (255, 0, 0), 2)
+
+                # Draw GT peaks as green markers
+                for t in range(T):
+                    if gt_e[t] > 0.5:
+                        x = 50 + int(t / max(T - 1, 1) * (fig_w - 70))
+                        cv2.drawMarker(panel, (x, y_off + row_h - 30), (0, 180, 0), cv2.MARKER_TRIANGLE_UP, 12, 2)
+
+                # Draw predicted peaks as red markers
+                pred_peaks_list, _ = extract_event_peaks(
+                    probs[b:b + 1, :T],
+                    seq_len[b:b + 1] if seq_len is not None else None,
+                    threshold=self.peak_threshold,
+                    min_distance=max(self.match_tolerance_frames, 1),
+                    top_k=None,
+                )
+                for pk in pred_peaks_list[0][e]:
+                    x = 50 + int(pk / max(T - 1, 1) * (fig_w - 70))
+                    cv2.drawMarker(panel, (x, y_off + row_h - 45), (0, 0, 255), cv2.MARKER_TRIANGLE_DOWN, 12, 2)
+
+            path = artifact_dir / f"event_batch{batch_idx:02d}.png"
+            cv2.imwrite(str(path), panel)
+
+            save_image_to_tensorboard(
+                tb_writer,
+                f"qualitative/event_detection/batch{batch_idx:02d}",
+                panel,
+                global_step,
+            )
 
     # configure_optimizers inherited from BaseLightningModule
 

--- a/src/tasks/plcs/configs/training/default.yaml
+++ b/src/tasks/plcs/configs/training/default.yaml
@@ -34,3 +34,9 @@ early_stopping:
 lr_monitor:
   enabled: true
   interval: step
+
+# ---- Qualitative validation logging ----
+qualitative_logging:
+  enabled: true
+  every_n_epochs: 1
+  num_samples: 4

--- a/src/tasks/plcs/training/lightning_module.py
+++ b/src/tasks/plcs/training/lightning_module.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
+import cv2
+import numpy as np
+import torch
 from torch import Tensor, nn
 
 from src.tasks.base.training.lightning_module import BaseLightningModule
+from src.tasks.base.training.qualitative_callback import save_image_to_tensorboard
 from src.tasks.plcs.models import build_plcs_model
 from src.tasks.plcs.training.losses import PLCSLoss, PLCSLossConfig
 from src.tasks.plcs.training.metrics import PLCSMetrics
@@ -127,3 +132,93 @@ class PLCSLightningModule(BaseLightningModule):
         for name, value in metrics.items():
             self.log(f"test/{name}", value)
         self.test_metrics.reset()
+
+    # ------------------------------------------------------------------
+    # Qualitative validation logging
+    # ------------------------------------------------------------------
+
+    def render_qualitative_samples(
+        self,
+        batches: list[dict[str, Any]],
+        outputs: list[dict[str, Any]],
+        artifact_dir: Path,
+        tb_writer: Any | None,
+        global_step: int,
+        epoch: int,
+    ) -> None:
+        """Render GT vs predicted player positions in top-down view with orientation arrows."""
+        device = next(self.parameters()).device
+
+        for batch_idx, batch in enumerate(batches):
+            batch_dev = {
+                k: v.to(device) if isinstance(v, Tensor) else v
+                for k, v in batch.items()
+            }
+
+            with torch.no_grad():
+                out = self._forward_from_batch(batch_dev)
+                pred_pos = out["position"].cpu().numpy()  # (B, [T], 3)
+                pred_rot = out["rotation"].cpu().numpy()  # (B, [T], 2)
+
+            gt_pos = batch["position"].numpy()
+            gt_rot = batch["rotation"].numpy()
+
+            # Render first sample
+            b = 0
+            gp = gt_pos[b]  # ([T], 3) or (3,)
+            pp = pred_pos[b]
+            gr = gt_rot[b]  # ([T], 2) or (2,)
+            pr = pred_rot[b]
+
+            # Handle single-frame (no T dim) vs sequence
+            if gp.ndim == 1:
+                gp = gp[np.newaxis]
+                pp = pp[np.newaxis]
+                gr = gr[np.newaxis]
+                pr = pr[np.newaxis]
+
+            T = gp.shape[0]
+            fig_w, fig_h = 500, 500
+            canvas = np.ones((fig_h, fig_w, 3), dtype=np.uint8) * 255
+
+            # Use X-Y as top-down
+            all_xy = np.concatenate([gp[:, :2], pp[:, :2]], axis=0)
+            mn = all_xy.min(axis=0)
+            mx = all_xy.max(axis=0)
+            rng = (mx - mn).clip(1e-3)
+            margin = 40
+
+            def to_px(p: np.ndarray) -> tuple[int, int]:
+                x = int((p[0] - mn[0]) / rng[0] * (fig_w - 2 * margin) + margin)
+                y = int((p[1] - mn[1]) / rng[1] * (fig_h - 2 * margin) + margin)
+                return (np.clip(x, 0, fig_w - 1), np.clip(y, 0, fig_h - 1))
+
+            arrow_len = 20
+
+            for t in range(T):
+                # GT: green
+                pt_gt = to_px(gp[t, :2])
+                cv2.circle(canvas, pt_gt, 4, (0, 180, 0), -1)
+                dx_gt = int(arrow_len * float(gr[t, 0]))
+                dy_gt = int(arrow_len * float(gr[t, 1]))
+                cv2.arrowedLine(canvas, pt_gt, (pt_gt[0] + dx_gt, pt_gt[1] + dy_gt), (0, 180, 0), 2)
+
+                # Pred: red
+                pt_pred = to_px(pp[t, :2])
+                cv2.circle(canvas, pt_pred, 4, (0, 0, 255), -1)
+                dx_pr = int(arrow_len * float(pr[t, 0]))
+                dy_pr = int(arrow_len * float(pr[t, 1]))
+                cv2.arrowedLine(canvas, pt_pred, (pt_pred[0] + dx_pr, pt_pred[1] + dy_pr), (0, 0, 255), 2)
+
+            cv2.putText(canvas, "Top-down: Green=GT, Red=Pred (arrows=orientation)", (5, fig_h - 10),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.35, (0, 0, 0), 1)
+
+            path = artifact_dir / f"plcs_batch{batch_idx:02d}.png"
+            cv2.imwrite(str(path), canvas)
+
+            save_image_to_tensorboard(
+                tb_writer,
+                f"qualitative/plcs/batch{batch_idx:02d}",
+                canvas,
+                global_step,
+            )

--- a/src/tasks/trajectory_completion/configs/training/default.yaml
+++ b/src/tasks/trajectory_completion/configs/training/default.yaml
@@ -53,3 +53,9 @@ early_stopping:
 lr_monitor:
   enabled: true
   interval: step
+
+# ---- Qualitative validation logging ----
+qualitative_logging:
+  enabled: true
+  every_n_epochs: 1
+  num_samples: 4

--- a/src/tasks/trajectory_completion/training/lightning_module.py
+++ b/src/tasks/trajectory_completion/training/lightning_module.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+import cv2
+import numpy as np
 import torch
 from torch import Tensor
 from torch import nn
 from torch.nn import functional as F
 
 from src.tasks.base.training.lightning_module import BaseLightningModule
+from src.tasks.base.training.qualitative_callback import save_image_to_tensorboard
 from src.tasks.trajectory_completion.models import build_trajectory_completion_model
 
 if TYPE_CHECKING:
@@ -393,6 +396,107 @@ class TrajectoryCompletionLightningModule(BaseLightningModule):
         }
         logs.update(aux_logs)
         return loss, logs
+
+    # ------------------------------------------------------------------
+    # Qualitative validation logging
+    # ------------------------------------------------------------------
+
+    def render_qualitative_samples(
+        self,
+        batches: list[dict[str, Any]],
+        outputs: list[dict[str, Any]],
+        artifact_dir: Path,
+        tb_writer: Any | None,
+        global_step: int,
+        epoch: int,
+    ) -> None:
+        """Render observed vs GT-hidden vs predicted UV trajectories."""
+        device = next(self.parameters()).device
+
+        for batch_idx, batch in enumerate(batches):
+            batch_dev = {
+                k: v.to(device) if isinstance(v, Tensor) else v
+                for k, v in batch.items()
+            }
+
+            with torch.no_grad():
+                pred, _, in_frame_logits = self._forward_with_auxiliary(batch_dev)
+                pred = pred.cpu()
+                in_frame_probs = torch.sigmoid(in_frame_logits).cpu()
+
+            # First sample
+            b = 0
+            ball_uv_gt = batch["ball_uv_gt"][b].numpy()  # (T, 2)
+            ball_vis = batch["ball_vis"][b].numpy()  # (T,)
+            ball_gt_vis = batch["ball_gt_vis"][b].numpy()  # (T,)
+            ball_mask = batch["ball_mask"][b].numpy()  # (T,)
+            pred_uv = pred[b].numpy()  # (T, 2)
+            in_frame_gt = batch.get("ball_in_frame_gt", batch["ball_gt_vis"])[b].numpy()
+            in_frame_pred = (in_frame_probs[b].numpy() >= self.in_frame_threshold).astype(float)
+
+            T = ball_uv_gt.shape[0]
+
+            # --- Panel 1: UV trajectory plot ---
+            fig_w, fig_h = 600, 400
+            canvas = np.ones((fig_h, fig_w, 3), dtype=np.uint8) * 255
+
+            def _uv_to_px(uv: np.ndarray) -> tuple[int, int]:
+                x = int(uv[0] * (fig_w - 40) + 20)
+                y = int(uv[1] * (fig_h - 40) + 20)
+                return (np.clip(x, 0, fig_w - 1), np.clip(y, 0, fig_h - 1))
+
+            # Draw GT trajectory (green for observed, yellow for hidden)
+            for t in range(T):
+                if ball_mask[t] <= 0 or ball_gt_vis[t] <= 0:
+                    continue
+                pt = _uv_to_px(ball_uv_gt[t])
+                if ball_vis[t] > 0:
+                    cv2.circle(canvas, pt, 3, (0, 180, 0), -1)  # observed: green
+                else:
+                    cv2.circle(canvas, pt, 3, (0, 200, 200), -1)  # hidden: yellow
+
+            # Draw predicted trajectory (red/blue)
+            for t in range(T):
+                if ball_mask[t] <= 0:
+                    continue
+                pt = _uv_to_px(pred_uv[t])
+                if ball_vis[t] > 0:
+                    cv2.circle(canvas, pt, 2, (200, 100, 100), -1)  # observed pred: light blue
+                else:
+                    cv2.circle(canvas, pt, 3, (0, 0, 255), -1)  # masked pred: red
+
+            cv2.putText(canvas, "Green=GT obs, Yellow=GT hidden, Red=Pred masked", (5, fig_h - 10),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.35, (0, 0, 0), 1)
+
+            # --- Panel 2: In-frame probability timeline ---
+            timeline_h = 150
+            timeline = np.ones((timeline_h, fig_w, 3), dtype=np.uint8) * 255
+            plot_area_h = timeline_h - 40
+            for t in range(1, T):
+                x1 = 30 + int((t - 1) / max(T - 1, 1) * (fig_w - 50))
+                x2 = 30 + int(t / max(T - 1, 1) * (fig_w - 50))
+                # GT in-frame
+                y1_gt = timeline_h - 25 - int(in_frame_gt[t - 1] * plot_area_h)
+                y2_gt = timeline_h - 25 - int(in_frame_gt[t] * plot_area_h)
+                cv2.line(timeline, (x1, y1_gt), (x2, y2_gt), (0, 180, 0), 2)
+                # Pred in-frame
+                y1_p = timeline_h - 25 - int(in_frame_probs[b, t - 1].item() * plot_area_h)
+                y2_p = timeline_h - 25 - int(in_frame_probs[b, t].item() * plot_area_h)
+                cv2.line(timeline, (x1, y1_p), (x2, y2_p), (0, 0, 255), 1)
+            cv2.putText(timeline, "In-frame: Green=GT, Red=Pred", (5, 15),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.35, (0, 0, 0), 1)
+
+            panel = np.concatenate([canvas, timeline], axis=0)
+
+            path = artifact_dir / f"traj_batch{batch_idx:02d}.png"
+            cv2.imwrite(str(path), panel)
+
+            save_image_to_tensorboard(
+                tb_writer,
+                f"qualitative/trajectory_completion/batch{batch_idx:02d}",
+                panel,
+                global_step,
+            )
 
     # configure_optimizers inherited from BaseLightningModule
 


### PR DESCRIPTION
## Summary

- Add a shared qualitative validation logging callback for training runs.
- Enable per-task visual rendering hooks and default qualitative logging settings across core training tasks.
- Save generated panels to both artifact directories and TensorBoard for faster validation inspection.

## Changes

- Add `QualitativeLoggingCallback` to collect sampled validation batches and delegate rendering at validation epoch end.
- Extend `BaseLightningModule` and `BaseTrainingRunner` to expose task-specific qualitative rendering and wire the callback from config.
- Implement qualitative visualization rendering for ball detection, court detection, event detection, PLCS, BLCS, and trajectory completion, and enable the config block in each default training config.

## Validation

- `./.venv/bin/python -m compileall src/tasks/base/training src/tasks/ball_detection/training src/tasks/blcs/training src/tasks/court_detection/training src/tasks/event_detection/training src/tasks/plcs/training src/tasks/trajectory_completion/training`
- `./.agents/skills/git-commit/scripts/preflight.sh "feat: Add qualitative validation logging"`
- `git diff --check`

## Related Issues

- References #

## Notes

- Created as a draft PR because the change spans multiple training tasks and only syntax-level validation was run locally.