### PR TITLE
fix: Standardize camera param key as C

### DIFF
--- a/src/tasks/blcs/data/dataset.py
+++ b/src/tasks/blcs/data/dataset.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import numpy as np
 import torch
 from torch import Tensor
 
@@ -144,9 +145,8 @@ class BallTrajectoryDataset(NPZSceneDatasetBase[BLCSMultiViewSample]):
             raw = scene.data[params_key]
             cam_params = json.loads(str(raw))
             # Normalise key: generators may store centre as "C" or "center"
-            center_key = "center" if "center" in cam_params else "C"
             cam_R_list.append(torch.tensor(cam_params["R"], dtype=torch.float32))
-            cam_C_list.append(torch.tensor(cam_params[center_key], dtype=torch.float32))
+            cam_C_list.append(torch.tensor(cam_params["C"], dtype=torch.float32))
             cam_f_list.append(torch.tensor(cam_params["f"], dtype=torch.float32))
             cam_cx_list.append(torch.tensor(cam_params["cx"], dtype=torch.float32))
             cam_cy_list.append(torch.tensor(cam_params["cy"], dtype=torch.float32))

--- a/src/tasks/blcs/data/types.py
+++ b/src/tasks/blcs/data/types.py
@@ -230,7 +230,7 @@ class BLCSCameraParams:
     Identical structure to PLCS for consistency.
     """
 
-    center: list[float]  # [x, y, z] camera center in world coordinates
+    C: list[float]  # [x, y, z] camera center in world coordinates
     R: list[list[float]]  # 3x3 rotation matrix (world to camera)
     f: float  # focal length in pixels
     cx: float  # principal point x-coordinate
@@ -241,7 +241,7 @@ class BLCSCameraParams:
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
         return {
-            "center": self.center,
+            "C": self.C,
             "R": self.R,
             "f": self.f,
             "cx": self.cx,
@@ -253,8 +253,9 @@ class BLCSCameraParams:
     @classmethod
     def from_dict(cls, data: dict) -> BLCSCameraParams:
         """Create instance from dictionary loaded from JSON/NPZ."""
+        C = data["C"] if "C" in data else data["center"]
         return cls(
-            center=data["center"],
+            C=C,
             R=data["R"],
             f=data["f"],
             cx=data["cx"],

--- a/src/tasks/blcs/generate_dataset/io/dataset_io.py
+++ b/src/tasks/blcs/generate_dataset/io/dataset_io.py
@@ -25,13 +25,21 @@ from typing import Any
 import numpy as np
 
 from src.tasks.blcs.data.types import (
-    BLCSCameraParams,
     BLCSSceneMeta,
 )
 from src.tasks.blcs.generate_dataset.scene_generator import BLCSSceneData
 from src.tasks.base.data.dataset_writer import BaseDatasetWriter
 
 logger = logging.getLogger(__name__)
+
+
+def _decode_json_value(value: Any) -> Any:
+    """Decode a scalar value loaded from an NPZ JSON payload."""
+    if isinstance(value, np.ndarray) and value.shape == ():
+        value = value.item()
+    if isinstance(value, (bytes, bytearray)):
+        value = value.decode("utf-8")
+    return json.loads(value) if isinstance(value, str) else value
 
 
 class BLCSDatasetWriter(BaseDatasetWriter):
@@ -66,17 +74,6 @@ class BLCSDatasetWriter(BaseDatasetWriter):
 
         return BLCSSceneMeta(**scene_meta_dict)
 
-    def _serialize_camera_params(self, camera_params: dict[str, Any]) -> str:
-        # Normalize camera parameter keys: some generators may use "C" instead of "center"
-        normalized_params = dict(camera_params)
-        if "center" not in normalized_params and "C" in normalized_params:
-            normalized_params["center"] = normalized_params["C"]
-            # Remove the alias key to avoid potential validation errors for extra fields
-            del normalized_params["C"]
-
-        typed_params = BLCSCameraParams.from_dict(normalized_params)
-        return json.dumps(typed_params.to_dict())
-
     def _append_camera_arrays(
         self,
         save_dict: dict[str, Any],
@@ -85,7 +82,7 @@ class BLCSDatasetWriter(BaseDatasetWriter):
         camera_records: list[dict[str, float]] = []
         for i, cam in enumerate(scene.cameras):
             prefix = f"cam_{i}_"
-            save_dict[f"{prefix}params"] = self._serialize_camera_params(cam.camera_params)
+            save_dict[f"{prefix}params"] = json.dumps(cam.camera_params)
             save_dict[f"{prefix}ball_uv"] = cam.ball_uv.astype(np.float32)
             save_dict[f"{prefix}ball_visible"] = cam.ball_visible.astype(bool)
             save_dict[f"{prefix}ball_visibility_ratio"] = np.array(
@@ -160,15 +157,18 @@ def load_scene(filepath: str | Path) -> dict:
     data = np.load(filepath, allow_pickle=True)
 
     # Parse metadata
-    scene_meta = json.loads(str(data["meta"]))
+    scene_meta = _decode_json_value(data["meta"])
     num_cameras = int(data["num_cameras"])
 
     # Load camera data
     cameras = []
     for i in range(num_cameras):
         prefix = f"cam_{i}_"
+        params = _decode_json_value(data[f"{prefix}params"])
+        if "C" not in params and "center" in params:
+            params["C"] = params.pop("center")
         cam_data = {
-            "params": json.loads(str(data[f"{prefix}params"])),
+            "params": params,
             "ball_uv": data[f"{prefix}ball_uv"],
             "ball_visible": data[f"{prefix}ball_visible"],
             "ball_visibility_ratio": float(data[f"{prefix}ball_visibility_ratio"]),

--- a/src/tasks/plcs/data/types.py
+++ b/src/tasks/plcs/data/types.py
@@ -194,7 +194,7 @@ class PLCSCameraParams:
     Stored as JSON string in NPZ files under 'cam_{i}_params' keys.
     """
 
-    center: list[float]  # [x, y, z] camera center in world coordinates
+    C: list[float]  # [x, y, z] camera center in world coordinates
     R: list[list[float]]  # 3x3 rotation matrix (world to camera)
     f: float  # focal length in pixels
     cx: float  # principal point x-coordinate
@@ -205,7 +205,7 @@ class PLCSCameraParams:
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
         return {
-            "center": self.center,
+            "C": self.C,
             "R": self.R,
             "f": self.f,
             "cx": self.cx,
@@ -218,7 +218,7 @@ class PLCSCameraParams:
     def from_dict(cls, data: dict) -> PLCSCameraParams:
         """Create instance from dictionary loaded from JSON/NPZ."""
         return cls(
-            center=data["center"],
+            C=data["C"],
             R=data["R"],
             f=data["f"],
             cx=data["cx"],
@@ -303,7 +303,7 @@ class PLCSSceneMetaModel(BaseModel):
 class PLCSCameraParamsModel(BaseModel):
     """Pydantic model for camera parameters with validation."""
 
-    center: list[float] = Field(..., min_length=3, max_length=3)
+    C: list[float] = Field(..., min_length=3, max_length=3)
     R: list[list[float]] = Field(..., description="3x3 rotation matrix")
     f: float = Field(..., gt=0, description="Focal length in pixels")
     cx: float = Field(..., description="Principal point x")
@@ -322,12 +322,12 @@ class PLCSCameraParamsModel(BaseModel):
                 raise ValueError(f"R row {i} must have 3 columns, got {len(row)}")
         return v
 
-    @field_validator("center")
+    @field_validator("C")
     @classmethod
-    def validate_center(cls, v: list[float]) -> list[float]:
-        """Validate center has 3 coordinates."""
+    def validate_camera_center(cls, v: list[float]) -> list[float]:
+        """Validate camera center has 3 coordinates."""
         if len(v) != 3:
-            raise ValueError(f"Center must have 3 coordinates, got {len(v)}")
+            raise ValueError(f"C must have 3 coordinates, got {len(v)}")
         return v
 
     model_config = {"frozen": True}

--- a/src/tasks/plcs/generate_dataset/io/scene_loader.py
+++ b/src/tasks/plcs/generate_dataset/io/scene_loader.py
@@ -53,6 +53,8 @@ def load_scene(filepath: str | Path) -> dict[str, Any]:
         if isinstance(params_raw, (bytes, bytearray)):
             params_raw = params_raw.decode("utf-8")
         params = json.loads(params_raw) if isinstance(params_raw, str) else params_raw
+        if "C" not in params and "center" in params:
+            params["C"] = params.pop("center")
         cam_data = AttrDict(
             params=params,
             human_kp_uv=data[f"{prefix}human_kp_uv"],

--- a/src/tasks/plcs/generate_dataset/scene_generator.py
+++ b/src/tasks/plcs/generate_dataset/scene_generator.py
@@ -447,7 +447,7 @@ class SceneGenerator:
             # Store camera data
             cam_data = CameraData(
                 camera_params={
-                    "center": camera.C.tolist(),
+                    "C": camera.C.tolist(),
                     "R": camera.R.tolist(),
                     "f": camera.f,
                     "cx": camera.cx,
@@ -616,7 +616,7 @@ class SceneGenerator:
             cameras_data.append(
                 CameraData(
                     camera_params={
-                        "center": camera.C.tolist(),
+                        "C": camera.C.tolist(),
                         "R": camera.R.tolist(),
                         "f": camera.f,
                         "cx": camera.cx,


### PR DESCRIPTION
## Summary

- standardize serialized camera parameter dictionaries on the `C` key across BLCS and PLCS
- keep reader-side compatibility by accepting legacy `center` payloads when loading existing NPZ files

## Changes

- update PLCS scene generation to emit `camera_params["C"]` instead of `camera_params["center"]`
- align BLCS and PLCS camera parameter dataclasses and validation models with `C` as the canonical field name
- harden BLCS and PLCS NPZ loaders so JSON camera params are decoded consistently and legacy `center` keys are normalized to `C`

## Validation

- `./.venv/bin/python -m compileall src/tasks/blcs/generate_dataset/io/dataset_io.py src/tasks/blcs/data/dataset.py src/tasks/plcs/generate_dataset/scene_generator.py src/tasks/plcs/generate_dataset/io/scene_loader.py src/tasks/blcs/data/types.py src/tasks/plcs/data/types.py`

## Related Issues

- References #
