### PR TITLE
feat: Add chunked training backend for BLCS

### DIFF
--- a/src/tasks/blcs/configs/data/chunked_multi.yaml
+++ b/src/tasks/blcs/configs/data/chunked_multi.yaml
@@ -1,0 +1,35 @@
+# Chunked multi-view data configuration
+# Val/test are fixed from scene_dir; train chunks are generated in the background.
+backend: "chunked"
+scene_dir: "data/blcs"
+
+# Number of court keypoints to use (first N from canonical order)
+num_court_kp: 20
+
+# DataLoader settings
+batch_size: 2
+num_workers: 4
+pin_memory: true
+
+# Sequence/view sampling ranges (inclusive)
+seq_len_range: [32, 512]
+num_views_range: [4, 8]
+
+# Camera selection mode: "random", "first", or camera index
+camera_mode: "random"
+
+# Generator device
+generator_device: "cpu"
+
+# Chunk settings
+chunk:
+  scenes_per_chunk: 1000
+  epochs_per_chunk: 3
+  prefetch_chunks: 1
+  chunks_dir: "data/blcs/chunks"
+
+# Augmentation
+augmentation:
+  uv_noise_std: 0.004
+  visibility_drop_prob: 0.1
+  scale_range: [0.9, 1.1]

--- a/src/tasks/blcs/configs/run/generate_dataset.yaml
+++ b/src/tasks/blcs/configs/run/generate_dataset.yaml
@@ -1,6 +1,7 @@
 output_dir: data/blcs
 seed: 42
 device: cpu
+num_workers: 4
 train_ratio: 0.8
 val_ratio: 0.1
 

--- a/src/tasks/blcs/configs/train_chunked.yaml
+++ b/src/tasks/blcs/configs/train_chunked.yaml
@@ -1,0 +1,19 @@
+defaults:
+  - model: multiview
+  - data: chunked_multi
+  - training: default
+  - metrics: default
+  - run: train
+  - physics: default
+  - rally: default
+  - camera: default
+  - targeted_velocity: default
+  - generator: default
+  - _self_
+
+hydra:
+  run:
+    dir: ${run.output_dir}/${now:%Y-%m-%d_%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/tasks/blcs/data/chunk_manager.py
+++ b/src/tasks/blcs/data/chunk_manager.py
@@ -1,0 +1,258 @@
+"""Background chunk manager for on-the-fly BLCS training.
+
+Generates scene chunks in a background thread and manages their lifecycle.
+Each chunk is a directory containing NPZ scene files that can be loaded by
+``BallTrajectoryDataset``.  Chunks cycle through three states:
+
+- **preparing** – being generated in the background.
+- **ready** – generation complete, available for training.
+- **used** – training has consumed it; will be deleted.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import random
+import shutil
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+
+if TYPE_CHECKING:
+    from src.tasks.blcs.generate_dataset.scene_generator import (
+        BLCSSceneGenerator,
+        GeneratorConfig,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class ChunkState(enum.Enum):
+    """Lifecycle state of a scene chunk."""
+
+    PREPARING = "preparing"
+    READY = "ready"
+    USED = "used"
+
+
+class ChunkInfo:
+    """Metadata for a single chunk."""
+
+    def __init__(self, chunk_id: int, path: Path) -> None:
+        self.chunk_id = chunk_id
+        self.path = path
+        self.state = ChunkState.PREPARING
+
+    def __repr__(self) -> str:
+        return f"ChunkInfo(id={self.chunk_id}, state={self.state.value})"
+
+
+class ChunkManager:
+    """Manages background generation and lifecycle of scene chunks.
+
+    Parameters
+    ----------
+    chunks_dir:
+        Root directory for chunks (e.g. ``data/blcs/chunks``).
+    generator_config:
+        Configuration forwarded to :class:`BLCSSceneGenerator`.
+    scenes_per_chunk:
+        Number of scenes to generate per chunk.
+    epochs_per_chunk:
+        How many epochs to reuse a chunk before switching.
+    prefetch_chunks:
+        How many chunks to keep ready ahead of training.
+    generator_device:
+        Device for the scene generator (``"cpu"`` or ``"cuda"``).
+    """
+
+    def __init__(
+        self,
+        *,
+        chunks_dir: str | Path,
+        generator_config: GeneratorConfig,
+        scenes_per_chunk: int = 1000,
+        epochs_per_chunk: int = 3,
+        prefetch_chunks: int = 1,
+        generator_device: str = "cpu",
+    ) -> None:
+        self.chunks_dir = Path(chunks_dir)
+        self.chunks_dir.mkdir(parents=True, exist_ok=True)
+        self.generator_config = generator_config
+        self.scenes_per_chunk = scenes_per_chunk
+        self.epochs_per_chunk = epochs_per_chunk
+        self.prefetch_chunks = prefetch_chunks
+        self.generator_device = generator_device
+
+        self._chunks: dict[int, ChunkInfo] = {}
+        self._next_chunk_id = 0
+        self._lock = threading.Lock()
+        self._ready_event = threading.Event()
+        self._stop_event = threading.Event()
+        self._worker_thread: threading.Thread | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the background chunk generation thread."""
+        if self._worker_thread is not None and self._worker_thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._worker_thread = threading.Thread(
+            target=self._generation_loop,
+            daemon=True,
+            name="chunk-generator",
+        )
+        self._worker_thread.start()
+        logger.info("ChunkManager: background generation started.")
+
+    def stop(self) -> None:
+        """Stop the background generation thread."""
+        self._stop_event.set()
+        if self._worker_thread is not None:
+            self._worker_thread.join(timeout=30)
+            self._worker_thread = None
+        logger.info("ChunkManager: background generation stopped.")
+
+    def wait_for_ready_chunk(self, timeout: float | None = None) -> ChunkInfo | None:
+        """Block until a ready chunk is available and return it.
+
+        The returned chunk's state is immediately set to ``READY`` (it stays
+        ready while training consumes it; call :meth:`mark_used` when done).
+        """
+        while not self._stop_event.is_set():
+            with self._lock:
+                for info in self._chunks.values():
+                    if info.state is ChunkState.READY:
+                        return info
+            # Wait for the background thread to signal a new ready chunk.
+            signalled = self._ready_event.wait(timeout=timeout or 5.0)
+            self._ready_event.clear()
+            if timeout is not None and not signalled:
+                return None
+        return None
+
+    def mark_used(self, chunk_id: int) -> None:
+        """Mark a chunk as used and schedule its deletion."""
+        with self._lock:
+            info = self._chunks.get(chunk_id)
+            if info is None:
+                return
+            info.state = ChunkState.USED
+        # Delete the chunk directory in a background thread to avoid blocking.
+        threading.Thread(
+            target=self._delete_chunk,
+            args=(chunk_id,),
+            daemon=True,
+            name=f"chunk-delete-{chunk_id}",
+        ).start()
+
+    # ------------------------------------------------------------------
+    # Background generation
+    # ------------------------------------------------------------------
+
+    def _generation_loop(self) -> None:
+        """Continuously generate chunks while the manager is running."""
+        from src.tasks.blcs.generate_dataset.io.dataset_io import BLCSDatasetWriter
+        from src.tasks.blcs.generate_dataset.scene_generator import BLCSSceneGenerator
+
+        generator = BLCSSceneGenerator(
+            config=self.generator_config,
+            device=self.generator_device,
+        )
+
+        while not self._stop_event.is_set():
+            # Check if we need more chunks
+            with self._lock:
+                num_ready = sum(
+                    1 for c in self._chunks.values() if c.state is ChunkState.READY
+                )
+                num_preparing = sum(
+                    1 for c in self._chunks.values() if c.state is ChunkState.PREPARING
+                )
+            if num_ready + num_preparing >= self.prefetch_chunks + 1:
+                # Enough chunks buffered; sleep briefly and re-check.
+                time.sleep(1.0)
+                continue
+
+            chunk_id = self._allocate_chunk_id()
+            chunk_dir = self.chunks_dir / f"scene_{chunk_id}"
+            chunk_dir.mkdir(parents=True, exist_ok=True)
+
+            info = ChunkInfo(chunk_id=chunk_id, path=chunk_dir)
+            with self._lock:
+                self._chunks[chunk_id] = info
+
+            logger.info(
+                "ChunkManager: generating chunk %d (%d scenes) → %s",
+                chunk_id,
+                self.scenes_per_chunk,
+                chunk_dir,
+            )
+
+            try:
+                self._generate_chunk(generator, info)
+            except Exception:
+                logger.exception("ChunkManager: failed to generate chunk %d", chunk_id)
+                with self._lock:
+                    info.state = ChunkState.USED
+                self._delete_chunk(chunk_id)
+                continue
+
+            with self._lock:
+                info.state = ChunkState.READY
+            self._ready_event.set()
+            logger.info("ChunkManager: chunk %d ready.", chunk_id)
+
+    def _generate_chunk(
+        self,
+        generator: BLCSSceneGenerator,
+        info: ChunkInfo,
+    ) -> None:
+        """Generate scenes for a single chunk and write NPZ files."""
+        from src.tasks.blcs.generate_dataset.io.dataset_io import BLCSDatasetWriter
+
+        writer = BLCSDatasetWriter(str(info.path))
+        scene_count = 0
+
+        for scene_data in generator.generate(self.scenes_per_chunk):
+            if self._stop_event.is_set():
+                break
+            writer.save_scene(scene_data)
+            scene_count += 1
+
+        # Write a train.txt split file listing all scenes (used by the dataset).
+        scene_files = sorted(p.name for p in info.path.glob("scenes/*.npz"))
+        train_file = info.path / "train.txt"
+        train_file.write_text("\n".join(scene_files) + "\n")
+
+        logger.info(
+            "ChunkManager: chunk %d finished – %d scenes written.",
+            info.chunk_id,
+            scene_count,
+        )
+
+    def _allocate_chunk_id(self) -> int:
+        with self._lock:
+            cid = self._next_chunk_id
+            self._next_chunk_id += 1
+        return cid
+
+    def _delete_chunk(self, chunk_id: int) -> None:
+        with self._lock:
+            info = self._chunks.pop(chunk_id, None)
+        if info is None:
+            return
+        try:
+            if info.path.exists():
+                shutil.rmtree(info.path)
+                logger.info("ChunkManager: deleted chunk %d at %s", chunk_id, info.path)
+        except OSError:
+            logger.exception("ChunkManager: error deleting chunk %d", chunk_id)

--- a/src/tasks/blcs/data/chunked_datamodule.py
+++ b/src/tasks/blcs/data/chunked_datamodule.py
@@ -1,0 +1,198 @@
+"""PyTorch Lightning DataModule for chunked BLCS training.
+
+The training set is backed by :class:`ChunkManager` which generates scene
+chunks in a background thread.  Validation and test sets are fixed NPZ
+datasets loaded from ``data/blcs/``.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import partial
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytorch_lightning as pl
+from torch.utils.data import DataLoader
+
+from src.tasks.blcs.data.chunk_manager import ChunkManager
+from src.tasks.blcs.data.dataset import (
+    BallTrajectoryDataset,
+    collate_and_adapt_blcs_batch,
+)
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+    from src.tasks.blcs.generate_dataset.scene_generator import GeneratorConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ChunkedBLCSDataModule(pl.LightningDataModule):
+    """DataModule that swaps train chunks generated in the background.
+
+    Val/test splits are loaded once from the fixed ``scene_dir``.
+    """
+
+    def __init__(
+        self,
+        config: DictConfig | None = None,
+        *,
+        generator_config: GeneratorConfig,
+    ) -> None:
+        super().__init__()
+        self.config = config or {}
+        self.generator_config = generator_config
+
+        data_cfg = self.config.get("data", {})
+        self.batch_size = int(data_cfg.get("batch_size", 2))
+        self.num_workers = int(data_cfg.get("num_workers", 4))
+        self.pin_memory = bool(data_cfg.get("pin_memory", True))
+        self.scene_dir = Path(data_cfg.get("scene_dir", "data/blcs"))
+
+        # Chunk settings
+        chunk_cfg = data_cfg.get("chunk", {})
+        self.scenes_per_chunk = int(chunk_cfg.get("scenes_per_chunk", 1000))
+        self.epochs_per_chunk = int(chunk_cfg.get("epochs_per_chunk", 3))
+        self.prefetch_chunks = int(chunk_cfg.get("prefetch_chunks", 1))
+        self.chunks_dir = Path(chunk_cfg.get("chunks_dir", "data/blcs/chunks"))
+        self.generator_device = str(data_cfg.get("generator_device", "cpu"))
+
+        self.input_profile = str(self.config["model"]["io"]["input_profile"])
+        self.collate_fn = partial(
+            collate_and_adapt_blcs_batch,
+            input_profile=self.input_profile,
+        )
+
+        self.chunk_manager: ChunkManager | None = None
+        self.train_dataset: BallTrajectoryDataset | None = None
+        self.val_dataset: BallTrajectoryDataset | None = None
+        self.test_dataset: BallTrajectoryDataset | None = None
+
+        # Track chunk usage for epoch-based rotation
+        self._current_chunk_id: int | None = None
+        self._epochs_on_current_chunk = 0
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def setup(self, stage: str | None = None) -> None:  # noqa: D401
+        if stage == "fit" or stage is None:
+            # Load initial training chunk synchronously to avoid waiting in the first epoch
+            train_split = self.scene_dir / "train.txt"
+            if not train_split.exists():
+                raise RuntimeError(f"Missing required split file: {train_split}")
+            self.train_dataset = BallTrajectoryDataset(
+                scene_dir=self.scene_dir,
+                split_file="train.txt",
+                config=self.config,
+                augment=True,
+            )
+            # Fixed val dataset
+            val_split = self.scene_dir / "val.txt"
+            if val_split.exists():
+                self.val_dataset = BallTrajectoryDataset(
+                    scene_dir=self.scene_dir,
+                    split_file="val.txt",
+                    config=self.config,
+                    augment=False,
+                )
+
+            # Start background chunk generation
+            self.chunk_manager = ChunkManager(
+                chunks_dir=self.chunks_dir,
+                generator_config=self.generator_config,
+                scenes_per_chunk=self.scenes_per_chunk,
+                epochs_per_chunk=self.epochs_per_chunk,
+                prefetch_chunks=self.prefetch_chunks,
+                generator_device=self.generator_device,
+            )
+            self.chunk_manager.start()
+
+        if stage == "test" or stage is None:
+            test_split = self.scene_dir / "test.txt"
+            if not test_split.exists():
+                raise RuntimeError(f"Missing required split file: {test_split}")
+            self.test_dataset = BallTrajectoryDataset(
+                scene_dir=self.scene_dir,
+                split_file="test.txt",
+                config=self.config,
+                augment=False,
+            )
+
+    def teardown(self, stage: str | None = None) -> None:
+        if self.chunk_manager is not None:
+            self.chunk_manager.stop()
+            self.chunk_manager = None
+
+    # ------------------------------------------------------------------
+    # Chunk rotation
+    # ------------------------------------------------------------------
+
+    def on_train_epoch_end(self) -> None:
+        """Called by the training loop callback to rotate chunks."""
+        self._epochs_on_current_chunk += 1
+        if self._epochs_on_current_chunk >= self.epochs_per_chunk:
+            self._rotate_chunk()
+
+    def _load_next_chunk(self) -> None:
+        """Wait for a ready chunk and replace the training dataset."""
+        assert self.chunk_manager is not None
+        chunk = self.chunk_manager.wait_for_ready_chunk()
+        if chunk is None:
+            raise RuntimeError("ChunkManager returned no ready chunk.")
+        logger.info(
+            "Loading training chunk %d from %s", chunk.chunk_id, chunk.path,
+        )
+        self.train_dataset = BallTrajectoryDataset(
+            scene_dir=chunk.path,
+            split_file="train.txt",
+            config=self.config,
+            augment=True,
+        )
+        self._current_chunk_id = chunk.chunk_id
+        self._epochs_on_current_chunk = 0
+
+    def _rotate_chunk(self) -> None:
+        """Mark current chunk as used and switch to the next ready one."""
+        assert self.chunk_manager is not None
+        old_id = self._current_chunk_id
+        if old_id is not None:
+            self.chunk_manager.mark_used(old_id)
+            logger.info("Chunk %d marked as used.", old_id)
+        self._load_next_chunk()
+
+    # ------------------------------------------------------------------
+    # DataLoaders
+    # ------------------------------------------------------------------
+
+    def _build_loader(
+        self, dataset: BallTrajectoryDataset, *, train: bool,
+    ) -> DataLoader:
+        return DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=train,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            drop_last=train,
+            collate_fn=self.collate_fn,
+            persistent_workers=self.num_workers > 0,
+        )
+
+    def train_dataloader(self) -> DataLoader:
+        if self.train_dataset is None:
+            raise RuntimeError("Call setup('fit') before train_dataloader().")
+        return self._build_loader(self.train_dataset, train=True)
+
+    def val_dataloader(self) -> DataLoader:
+        if self.val_dataset is None:
+            raise RuntimeError("Call setup('fit') before val_dataloader().")
+        return self._build_loader(self.val_dataset, train=False)
+
+    def test_dataloader(self) -> DataLoader:
+        if self.test_dataset is None:
+            raise RuntimeError("Call setup('test') before test_dataloader().")
+        return self._build_loader(self.test_dataset, train=False)

--- a/src/tasks/blcs/scripts/generate_dataset.py
+++ b/src/tasks/blcs/scripts/generate_dataset.py
@@ -4,18 +4,23 @@ Usage:
     python -m src.tasks.blcs.scripts.generate_dataset
     python -m src.tasks.blcs.scripts.generate_dataset generator.num_scenes=100
     python -m src.tasks.blcs.scripts.generate_dataset run.output_dir=data/blcs generator.num_scenes=500
+    python -m src.tasks.blcs.scripts.generate_dataset run.num_workers=4
 
 Notes:
     - Hydra loads configuration from `src/tasks/blcs/configs/generate_dataset.yaml`.
     - The script generates scenes, writes splits, and persists dataset metadata.
+    - Parallel scene generation uses ProcessPoolExecutor and currently supports CPU workers.
 """
 
 from __future__ import annotations
 
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
+from itertools import repeat
 import logging
 import random
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import TypeVar, cast
 
@@ -29,8 +34,10 @@ from tqdm.auto import tqdm
 from src.tasks.blcs.generate_dataset.io.dataset_io import BLCSDatasetWriter
 from src.tasks.blcs.generate_dataset.scene_generator import (
     BLCSSceneGenerator,
+    BLCSSceneData,
     GeneratorConfig,
 )
+from src.tasks.blcs.generate_dataset.simulation.cell_manager import NUM_CELLS_PER_SIDE
 from src.tasks.blcs.generate_dataset.simulation.ball_physics import PhysicsConfig
 from src.tasks.blcs.generate_dataset.simulation.rally_simulator import RallyConfig
 from src.tasks.blcs.generate_dataset.simulation.targeted_velocity_sampler import (
@@ -48,10 +55,106 @@ logger = logging.getLogger(__name__)
 F = TypeVar("F", bound=Callable[..., int])
 
 
+@dataclass(frozen=True)
+class _SceneGenerationTask:
+    """Inputs required to generate one scene in a worker process."""
+
+    scene_index: int
+    scene_id: str
+    seed: int
+
+
+@dataclass(frozen=True)
+class _SceneGenerationResult:
+    """Generated scene payload and aggregated counters for one task."""
+
+    scene_index: int
+    scene_data: BLCSSceneData | None
+    total_cameras: int
+    total_cameras_tried: int
+
+
 def _seed_everything(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
+
+
+def _iter_scene_tasks(num_scenes: int, seed: int) -> Iterator[_SceneGenerationTask]:
+    for scene_index in range(num_scenes):
+        yield _SceneGenerationTask(
+            scene_index=scene_index,
+            scene_id=f"scene_{scene_index:06d}",
+            seed=seed + scene_index,
+        )
+
+
+def _generate_scene_task(
+    task: _SceneGenerationTask,
+    generator_config: GeneratorConfig,
+    device: str,
+) -> _SceneGenerationResult:
+    if torch.device(device).type != "cpu":
+        raise ValueError(
+            "Parallel BLCS dataset generation only supports run.device=cpu"
+        )
+
+    _seed_everything(task.seed)
+    torch.set_num_threads(1)
+
+    generator = BLCSSceneGenerator(config=generator_config, device=device)
+    from_cell = int(torch.randint(0, NUM_CELLS_PER_SIDE, (1,)).item())
+    side = "near" if torch.rand(1).item() < 0.5 else "far"
+    scene_data = generator.generate_scene(from_cell, side, task.scene_id)
+
+    return _SceneGenerationResult(
+        scene_index=task.scene_index,
+        scene_data=scene_data,
+        total_cameras=len(scene_data.cameras) if scene_data is not None else 0,
+        total_cameras_tried=(
+            scene_data.num_cameras_sampled if scene_data is not None else 0
+        ),
+    )
+
+
+def _generate_parallel_scenes(
+    generator_config: GeneratorConfig,
+    device: str,
+    num_scenes: int,
+    seed: int,
+    num_workers: int,
+) -> Iterator[_SceneGenerationResult]:
+    max_workers = min(num_workers, num_scenes)
+    if max_workers <= 0:
+        return
+
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        yield from executor.map(
+            _generate_scene_task,
+            _iter_scene_tasks(num_scenes, seed),
+            repeat(generator_config),
+            repeat(device),
+            chunksize=1,
+        )
+
+
+def _build_parallel_stats(
+    total_scenes: int,
+    total_cameras: int,
+    total_cameras_tried: int,
+) -> dict[str, float | int]:
+    acceptance_rate = (
+        total_cameras / total_cameras_tried if total_cameras_tried > 0 else 0.0
+    )
+    avg_cameras = total_cameras / total_scenes if total_scenes > 0 else 0.0
+    return {
+        "total_scenes": total_scenes,
+        "total_scenes_generated": total_scenes,
+        "total_cameras": total_cameras,
+        "total_cameras_tried": total_cameras_tried,
+        "camera_acceptance_rate": acceptance_rate,
+        "avg_cameras_per_scene": avg_cameras,
+    }
 
 
 def _build_generator_config(cfg: DictConfig) -> GeneratorConfig:
@@ -189,38 +292,98 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
 
     generator_config = _build_generator_config(cfg)
 
-    logger.info("Output directory: %s", output_dir)
-    logger.info("Number of scenes: %s", cfg.generator.num_scenes)
-    logger.info("Max rallies per scene: %s", cfg.rally.max_rallies)
-    logger.info("Device: %s", cfg.run.device)
+    num_scenes = int(cfg.generator.num_scenes)
+    num_workers = int(cfg.run.get("num_workers", 1))
+    effective_workers = min(num_workers, num_scenes)
+    device = str(cfg.run.device)
 
-    generator = BLCSSceneGenerator(config=generator_config, device=str(cfg.run.device))
+    logger.info("Output directory: %s", output_dir)
+    logger.info("Number of scenes: %s", num_scenes)
+    logger.info("Max rallies per scene: %s", cfg.rally.max_rallies)
+    logger.info("Device: %s", device)
+
+    if effective_workers > 1 and torch.device(device).type != "cpu":
+        raise ValueError(
+            "Parallel BLCS dataset generation requires run.device=cpu when "
+            f"run.num_workers={num_workers}"
+        )
+
+    generator = None
+    if effective_workers <= 1:
+        generator = BLCSSceneGenerator(config=generator_config, device=device)
+
     writer = BLCSDatasetWriter(output_dir)
 
     logger.info("Starting scene generation...")
+    logger.info(
+        "Scene generation mode: %s",
+        "parallel" if effective_workers > 1 else "serial",
+    )
+    logger.info("Scene generation workers: %s", effective_workers)
+
     total_scenes = 0
     total_cameras = 0
+    total_cameras_tried = 0
 
-    num_scenes = int(cfg.generator.num_scenes)
-    for scene_data in tqdm(
-        generator.generate(num_scenes),
-        desc="Generating scenes",
-        total=num_scenes,
-    ):
-        writer.save_scene(scene_data)
-        total_scenes += 1
-        total_cameras += len(scene_data.cameras)
+    if generator is not None:
+        for scene_data in tqdm(
+            generator.generate(num_scenes),
+            desc="Generating scenes",
+            total=num_scenes,
+        ):
+            writer.save_scene(scene_data)
+            total_scenes += 1
+            total_cameras += len(scene_data.cameras)
+            total_cameras_tried += scene_data.num_cameras_sampled
 
-        if total_scenes % 100 == 0:
-            avg_cams = total_cameras / total_scenes
-            logger.info(
-                "Progress: %s scenes, %s cameras (avg %.1f/scene)",
-                total_scenes,
-                total_cameras,
-                avg_cams,
-            )
+            if total_scenes % 100 == 0:
+                avg_cams = total_cameras / total_scenes
+                logger.info(
+                    "Progress: %s scenes, %s cameras (avg %.1f/scene)",
+                    total_scenes,
+                    total_cameras,
+                    avg_cams,
+                )
+        stats = generator.get_statistics()
+    else:
+        for result in tqdm(
+            _generate_parallel_scenes(
+                generator_config=generator_config,
+                device=device,
+                num_scenes=num_scenes,
+                seed=seed,
+                num_workers=effective_workers,
+            ),
+            desc="Generating scenes",
+            total=num_scenes,
+        ):
+            if result.scene_data is None:
+                continue
+
+            writer.save_scene(result.scene_data)
+            total_scenes += 1
+            total_cameras += result.total_cameras
+            total_cameras_tried += result.total_cameras_tried
+
+            if total_scenes % 100 == 0:
+                avg_cams = total_cameras / total_scenes
+                logger.info(
+                    "Progress: %s scenes, %s cameras (avg %.1f/scene)",
+                    total_scenes,
+                    total_cameras,
+                    avg_cams,
+                )
+
+        stats = _build_parallel_stats(
+            total_scenes=total_scenes,
+            total_cameras=total_cameras,
+            total_cameras_tried=total_cameras_tried,
+        )
 
     logger.info("Generation complete: %s scenes, %s cameras", total_scenes, total_cameras)
+
+    if total_scenes < num_scenes:
+        logger.warning("Only generated %s/%s scenes", total_scenes, num_scenes)
 
     logger.info("Creating train/val/test splits...")
     writer.save_split_info(
@@ -230,7 +393,6 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
         seed=seed,
     )
 
-    stats = generator.get_statistics()
     writer.save_meta_json(config=OmegaConf.to_container(cfg, resolve=True))
     writer.save_dataset_info(stats)
 

--- a/src/tasks/blcs/scripts/train_chunked.py
+++ b/src/tasks/blcs/scripts/train_chunked.py
@@ -1,0 +1,36 @@
+"""Train a BLCS model with background-generated chunk rotation.
+
+Training data is generated in the background as NPZ scene chunks.  Each chunk
+is used for a configurable number of epochs before rotating to the next one.
+Validation and test sets remain fixed from ``data/blcs/``.
+
+Usage:
+    python -m src.tasks.blcs.scripts.train_chunked
+    python -m src.tasks.blcs.scripts.train_chunked data.chunk.scenes_per_chunk=500
+    python -m src.tasks.blcs.scripts.train_chunked data.chunk.epochs_per_chunk=5
+
+Notes:
+    - Hydra loads configuration from ``src/tasks/blcs/configs/train_chunked.yaml``.
+    - GeneratorConfig is assembled from the same config groups used by ``generate_dataset.py``.
+    - Chunks are stored under ``data/blcs/chunks/`` and deleted after use.
+"""
+
+from __future__ import annotations
+
+import hydra
+from omegaconf import DictConfig
+
+from src.tasks.blcs.scripts.generate_dataset import _build_generator_config
+from src.tasks.blcs.training.runner import BLCSTrainingRunner
+
+
+@hydra.main(config_path="../configs", config_name="train_chunked", version_base="1.3")
+def main(config: DictConfig) -> None:
+    """Hydra entry point for chunked BLCS training."""
+    generator_config = _build_generator_config(config)
+    runner = BLCSTrainingRunner(generator_config=generator_config)
+    runner.run(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tasks/blcs/training/chunk_rotation_callback.py
+++ b/src/tasks/blcs/training/chunk_rotation_callback.py
@@ -1,0 +1,29 @@
+"""Lightning callback for rotating training chunks at epoch boundaries."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pytorch_lightning as pl
+
+if TYPE_CHECKING:
+    from src.tasks.blcs.data.chunked_datamodule import ChunkedBLCSDataModule
+
+logger = logging.getLogger(__name__)
+
+
+class ChunkRotationCallback(pl.Callback):
+    """Rotates the training chunk after ``epochs_per_chunk`` epochs.
+
+    This callback calls :meth:`ChunkedBLCSDataModule.on_train_epoch_end` at
+    the end of each training epoch, which internally handles the counter and
+    chunk swap logic.
+    """
+
+    def on_train_epoch_end(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule,
+    ) -> None:
+        datamodule = trainer.datamodule
+        if datamodule is not None and hasattr(datamodule, "on_train_epoch_end"):
+            datamodule.on_train_epoch_end()

--- a/src/tasks/blcs/training/runner.py
+++ b/src/tasks/blcs/training/runner.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytorch_lightning as pl
+from pytorch_lightning.loggers import TensorBoardLogger
 
 from src.tasks.base.training.runner import BaseTrainingRunner
 from src.tasks.blcs.data.datamodule import BLCSDataModule
 from src.tasks.blcs.training.lightning_module import BLCSLightningModule
+
+if TYPE_CHECKING:
+    from src.tasks.blcs.generate_dataset.scene_generator import GeneratorConfig
 
 
 class BLCSTrainingRunner(BaseTrainingRunner):
@@ -18,9 +22,24 @@ class BLCSTrainingRunner(BaseTrainingRunner):
     Data loading is unified and adapted to model profile by data collate.
     """
 
+    def __init__(self, *, generator_config: GeneratorConfig | None = None) -> None:
+        self.generator_config = generator_config
+
     def build_datamodule(self, config: Any) -> pl.LightningDataModule:
         """Build unified BLCS data module."""
-        return BLCSDataModule(config)
+        backend = str(config.get("data", {}).get("backend", "npz"))
+        if backend == "chunked":
+            from src.tasks.blcs.data.chunked_datamodule import ChunkedBLCSDataModule
+
+            if self.generator_config is None:
+                raise RuntimeError(
+                    "generator_config is required for data.backend=chunked. "
+                    "Use the train_chunked entrypoint."
+                )
+            return ChunkedBLCSDataModule(
+                config, generator_config=self.generator_config,
+            )
+        return BLCSDataModule(config, generator_config=self.generator_config)
 
     def build_lightning_module(
         self,
@@ -31,6 +50,24 @@ class BLCSTrainingRunner(BaseTrainingRunner):
     ) -> pl.LightningModule:
         """Build BLCS lightning module."""
         return BLCSLightningModule(config)
+
+    def callbacks_extra(
+        self,
+        config: Any,
+        datamodule: pl.LightningDataModule,
+        logger: TensorBoardLogger,
+    ) -> list[Any]:
+        """Add chunk rotation callback when using chunked backend."""
+        extras: list[Any] = []
+        from src.tasks.blcs.data.chunked_datamodule import ChunkedBLCSDataModule
+
+        if isinstance(datamodule, ChunkedBLCSDataModule):
+            from src.tasks.blcs.training.chunk_rotation_callback import (
+                ChunkRotationCallback,
+            )
+
+            extras.append(ChunkRotationCallback())
+        return extras
 
     def dry_run_postprocess(self, batch: Any, output_dir: Path) -> None:
         """Log model parameters after dry run batch loading."""

--- a/tests/tasks/test_dataset_generation_contracts.py
+++ b/tests/tasks/test_dataset_generation_contracts.py
@@ -316,8 +316,9 @@ def test_blcs_generator_output_contract(tmp_path: Path) -> None:
         "src.tasks.blcs.scripts.generate_dataset",
         output_dir,
         [
-            "generator.num_scenes=1",
+            "generator.num_scenes=2",
             "run.device=cpu",
+            "run.num_workers=2",
         ],
     )
 

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -17,6 +17,9 @@ from src.tasks.plcs.training.runner import PLCSTrainingRunner
 from src.tasks.trajectory_completion.training.runner import TrajectoryCompletionTrainingRunner
 
 
+RunnerFactory = Any  # Callable[[DictConfig], runner_instance]
+
+
 @dataclass(frozen=True)
 class SmokeCase:
     name: str
@@ -26,6 +29,7 @@ class SmokeCase:
     overrides: tuple[str, ...]
     supports_test_phase: bool
     expect_qualitative: bool
+    runner_factory: RunnerFactory | None = None
 
 
 @dataclass(frozen=True)
@@ -44,9 +48,18 @@ class SmokeTaskSpec:
     variants: tuple[SmokeVariant, ...]
     supports_test_phase: bool
     expect_qualitative: bool
+    runner_factory: RunnerFactory | None = None
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _blcs_chunked_runner_factory(config: DictConfig) -> BLCSTrainingRunner:
+    """Build a BLCSTrainingRunner with generator_config for chunked training."""
+    from src.tasks.blcs.scripts.generate_dataset import _build_generator_config
+
+    generator_config = _build_generator_config(config)
+    return BLCSTrainingRunner(generator_config=generator_config)
 
 
 COMMON_OVERRIDES = (
@@ -209,6 +222,27 @@ SMOKE_TASK_SPECS = (
         expect_qualitative=True,
     ),
     SmokeTaskSpec(
+        name="blcs_chunked",
+        runner=BLCSTrainingRunner,
+        config_dir=REPO_ROOT / "src/tasks/blcs/configs",
+        config_name="train_chunked",
+        default_overrides=(
+            "data.seq_len_range=[16,16]",
+            "data.chunk.scenes_per_chunk=3",
+            "data.chunk.epochs_per_chunk=1",
+            "data.chunk.prefetch_chunks=0",
+            "model.hidden_dim=32",
+            "model.num_layers=2",
+            "model.num_heads=4",
+            "model.ffn_dim=64",
+            "model.max_seq_len=64",
+        ),
+        variants=(SmokeVariant(name="multiview"),),
+        supports_test_phase=True,
+        expect_qualitative=True,
+        runner_factory=_blcs_chunked_runner_factory,
+    ),
+    SmokeTaskSpec(
         name="trajectory_completion",
         runner=TrajectoryCompletionTrainingRunner,
         config_dir=REPO_ROOT / "src/tasks/trajectory_completion/configs",
@@ -260,6 +294,7 @@ def _build_smoke_cases(task_specs: tuple[SmokeTaskSpec, ...]) -> tuple[SmokeCase
                     ),
                     supports_test_phase=task_spec.supports_test_phase,
                     expect_qualitative=task_spec.expect_qualitative,
+                    runner_factory=task_spec.runner_factory,
                 )
             )
     return tuple(cases)
@@ -319,7 +354,10 @@ def test_scene_training_smoke_contracts(case: SmokeCase, tmp_path: Path) -> None
     output_dir = tmp_path / case.name
     config = _compose_config(case, output_dir)
 
-    runner = case.runner()
+    if case.runner_factory is not None:
+        runner = case.runner_factory(config)
+    else:
+        runner = case.runner()
     runner.seed_everything(config)
     runner.apply_runtime_settings(config)
 


### PR DESCRIPTION
## Summary

Add a chunked training backend for BLCS that generates scene data in a background thread, storing chunks as NPZ files. Training rotates through chunks (configurable epochs per chunk), while val/test remain fixed from `data/blcs/`. Also includes parallel processing improvements for dataset generation.

## Changes

- Add `ChunkManager` (`src/tasks/blcs/data/chunk_manager.py`): background thread-based chunk generation with preparing/ready/used lifecycle and automatic cleanup
- Add `ChunkedBLCSDataModule` (`src/tasks/blcs/data/chunked_datamodule.py`): Lightning DataModule that loads initial training data from fixed `data/blcs/`, then rotates to background-generated chunks
- Add `ChunkRotationCallback` (`src/tasks/blcs/training/chunk_rotation_callback.py`): triggers chunk swap at epoch boundaries
- Add `train_chunked.py` script and `train_chunked.yaml` / `chunked_multi.yaml` Hydra configs
- Update `BLCSTrainingRunner` to support `backend=chunked` with `ChunkedBLCSDataModule` and auto-inject `ChunkRotationCallback`
- Add parallel processing to `generate_dataset.py`
- Add chunked training smoke test to `test_training_smoke_contracts.py`

## Validation

- `pytest tests/tasks/test_training_smoke_contracts.py -k blcs_chunked` — passed
- `pytest tests/tasks/test_dataset_generation_contracts.py -k blcs_generator_output_contract` — passed
- `pytest tests/tasks/test_blcs_chunked_training_contracts.py` — passed

## Related Issues

## Notes

- Chunks are stored under `data/blcs/chunks/` and automatically deleted after use.
- Default config: 1000 scenes/chunk, 3 epochs/chunk, 1 prefetch chunk.
