### PR TITLE
refactor: Streamline scene dataset generation workflow

### DIFF
--- a/src/tasks/base/data/dataset_writer.py
+++ b/src/tasks/base/data/dataset_writer.py
@@ -158,25 +158,3 @@ class BaseDatasetWriter(ABC):
             len(self.scene_records),
             total_cameras,
         )
-
-    def save_dataset_info(self, stats: dict) -> None:
-        """Save dataset statistics and metadata.
-
-        Args:
-            stats: Statistics from generator (module-specific).
-
-        """
-        # Build base info
-        info = {
-            "total_scenes": len(self.scene_records),
-            "total_cameras": stats.get("total_cameras", 0),
-            "avg_cameras_per_scene": stats.get("avg_cameras_per_scene", 0),
-        }
-
-        # Add all additional stats from the generator
-        info.update(stats)
-
-        with open(self.output_dir / "dataset_info.json", "w") as f:
-            json.dump(info, f, indent=2)
-
-        logger.info("Dataset info saved: %s scenes", len(self.scene_records))

--- a/src/tasks/blcs/configs/data/chunked_multi.yaml
+++ b/src/tasks/blcs/configs/data/chunked_multi.yaml
@@ -27,6 +27,7 @@ chunk:
   epochs_per_chunk: 3
   prefetch_chunks: 1
   chunks_dir: "data/blcs/chunks"
+  generation_workers: 0  # parallel scene generation workers (0 = sequential)
 
 # Augmentation
 augmentation:

--- a/src/tasks/blcs/configs/data/multiview.yaml
+++ b/src/tasks/blcs/configs/data/multiview.yaml
@@ -1,4 +1,5 @@
 # Multi-view BLCS data configuration
+backend: "default"
 scene_dir: "data/blcs"
 
 # Number of court keypoints to use (first N from canonical order)

--- a/src/tasks/blcs/configs/data/single.yaml
+++ b/src/tasks/blcs/configs/data/single.yaml
@@ -1,4 +1,5 @@
 # Scene data directory (matches dataset generation default)
+backend: "default"
 scene_dir: "data/blcs"
 
 # Number of court keypoints to use (first N from canonical order)

--- a/src/tasks/blcs/data/chunk_manager.py
+++ b/src/tasks/blcs/data/chunk_manager.py
@@ -69,6 +69,10 @@ class ChunkManager:
         How many chunks to keep ready ahead of training.
     generator_device:
         Device for the scene generator (``"cpu"`` or ``"cuda"``).
+    generation_workers:
+        Number of parallel worker processes for scene generation.
+        ``0`` (default) uses sequential generation in the background thread.
+        This is independent of the DataLoader ``num_workers``.
     """
 
     def __init__(
@@ -80,6 +84,7 @@ class ChunkManager:
         epochs_per_chunk: int = 3,
         prefetch_chunks: int = 1,
         generator_device: str = "cpu",
+        generation_workers: int = 0,
     ) -> None:
         self.chunks_dir = Path(chunks_dir)
         self.chunks_dir.mkdir(parents=True, exist_ok=True)
@@ -88,6 +93,7 @@ class ChunkManager:
         self.epochs_per_chunk = epochs_per_chunk
         self.prefetch_chunks = prefetch_chunks
         self.generator_device = generator_device
+        self.generation_workers = generation_workers
 
         self._chunks: dict[int, ChunkInfo] = {}
         self._next_chunk_id = 0
@@ -222,11 +228,27 @@ class ChunkManager:
         writer = BLCSDatasetWriter(str(info.path))
         scene_count = 0
 
-        for scene_data in generator.generate(self.scenes_per_chunk):
-            if self._stop_event.is_set():
-                break
-            writer.save_scene(scene_data)
-            scene_count += 1
+        if self.generation_workers > 0:
+            from src.tasks.blcs.generate_dataset.utils.parallel_runner import (
+                generate_parallel_scenes,
+            )
+
+            for scene_data in generate_parallel_scenes(
+                generator_config=self.generator_config,
+                device=self.generator_device,
+                num_scenes=self.scenes_per_chunk,
+                num_workers=self.generation_workers,
+            ):
+                if self._stop_event.is_set():
+                    break
+                writer.save_scene(scene_data)
+                scene_count += 1
+        else:
+            for scene_data in generator.generate(self.scenes_per_chunk):
+                if self._stop_event.is_set():
+                    break
+                writer.save_scene(scene_data)
+                scene_count += 1
 
         # Write a train.txt split file listing all scenes (used by the dataset).
         scene_files = sorted(p.name for p in info.path.glob("scenes/*.npz"))

--- a/src/tasks/blcs/data/chunked_datamodule.py
+++ b/src/tasks/blcs/data/chunked_datamodule.py
@@ -57,6 +57,7 @@ class ChunkedBLCSDataModule(pl.LightningDataModule):
         self.epochs_per_chunk = int(chunk_cfg.get("epochs_per_chunk", 3))
         self.prefetch_chunks = int(chunk_cfg.get("prefetch_chunks", 1))
         self.chunks_dir = Path(chunk_cfg.get("chunks_dir", "data/blcs/chunks"))
+        self.generation_workers = int(chunk_cfg.get("generation_workers", 0))
         self.generator_device = str(data_cfg.get("generator_device", "cpu"))
 
         self.input_profile = str(self.config["model"]["io"]["input_profile"])
@@ -108,6 +109,7 @@ class ChunkedBLCSDataModule(pl.LightningDataModule):
                 epochs_per_chunk=self.epochs_per_chunk,
                 prefetch_chunks=self.prefetch_chunks,
                 generator_device=self.generator_device,
+                generation_workers=self.generation_workers,
             )
             self.chunk_manager.start()
 

--- a/src/tasks/blcs/generate_dataset/scene_generator.py
+++ b/src/tasks/blcs/generate_dataset/scene_generator.py
@@ -122,6 +122,14 @@ class BLCSSceneGenerator:
         """Sample stochastic court geometry for one scene."""
         return self.config.court.sample()
 
+    def sample_from_cell(self) -> int:
+        """Sample an initial launch cell index."""
+        return int(torch.randint(0, NUM_CELLS_PER_SIDE, (1,)).item())
+
+    def sample_side(self) -> str:
+        """Sample an initial player side."""
+        return "near" if torch.rand(1).item() < 0.5 else "far"
+
     def _build_rally_simulator(
         self,
         physics_config: PhysicsConfig,
@@ -261,8 +269,8 @@ class BLCSSceneGenerator:
 
         scene_counter = 0
         for _ in range(num_scenes):
-            from_cell = int(torch.randint(0, NUM_CELLS_PER_SIDE, (1,)).item())
-            side = "near" if torch.rand(1).item() < 0.5 else "far"
+            from_cell = self.sample_from_cell()
+            side = self.sample_side()
 
             scene_id = f"scene_{scene_counter:06d}"
             scene = self.generate_scene(from_cell, side, scene_id)

--- a/src/tasks/blcs/generate_dataset/utils/parallel_runner.py
+++ b/src/tasks/blcs/generate_dataset/utils/parallel_runner.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from concurrent.futures import ProcessPoolExecutor
+from itertools import repeat
+from collections.abc import Iterator
+
+import torch
+
+from src.tasks.blcs.generate_dataset.scene_generator import (
+    BLCSSceneGenerator,
+    BLCSSceneData,
+    GeneratorConfig,
+)
+
+
+def _generate_scene_task(
+    scene_index: int,
+    generator_config: GeneratorConfig,
+    device: str,
+) -> BLCSSceneData:
+    if torch.device(device).type != "cpu":
+        raise ValueError(
+            "Parallel BLCS dataset generation only supports run.device=cpu"
+        )
+    torch.set_num_threads(1)
+
+    generator = BLCSSceneGenerator(config=generator_config, device=device)
+    from_cell = generator.sample_from_cell()
+    side = generator.sample_side()
+    scene_data = generator.generate_scene(from_cell, side, f"scene_{scene_index:06d}")
+
+    return scene_data
+
+
+def generate_parallel_scenes(
+    generator_config: GeneratorConfig,
+    device: str,
+    num_scenes: int,
+    num_workers: int,
+) -> Iterator[BLCSSceneData]:
+    max_workers = min(num_workers, num_scenes)
+    if max_workers <= 0:
+        return
+
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        yield from executor.map(
+            _generate_scene_task,
+            range(num_scenes),
+            repeat(generator_config),
+            repeat(device),
+            chunksize=1,
+        )

--- a/src/tasks/blcs/scripts/generate_dataset.py
+++ b/src/tasks/blcs/scripts/generate_dataset.py
@@ -14,13 +14,10 @@ Notes:
 
 from __future__ import annotations
 
-from concurrent.futures import ProcessPoolExecutor
-from dataclasses import dataclass
-from itertools import repeat
 import logging
 import random
 import sys
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from pathlib import Path
 from typing import TypeVar, cast
 
@@ -33,16 +30,14 @@ from tqdm.auto import tqdm
 
 from src.tasks.blcs.generate_dataset.io.dataset_io import BLCSDatasetWriter
 from src.tasks.blcs.generate_dataset.scene_generator import (
-    BLCSSceneGenerator,
-    BLCSSceneData,
     GeneratorConfig,
 )
-from src.tasks.blcs.generate_dataset.simulation.cell_manager import NUM_CELLS_PER_SIDE
 from src.tasks.blcs.generate_dataset.simulation.ball_physics import PhysicsConfig
 from src.tasks.blcs.generate_dataset.simulation.rally_simulator import RallyConfig
 from src.tasks.blcs.generate_dataset.simulation.targeted_velocity_sampler import (
     TargetedVelocityConfig,
 )
+from src.tasks.blcs.generate_dataset.utils.parallel_runner import generate_parallel_scenes
 from src.utils.projection.camera_projector import CameraConfig
 from src.utils.schema.court import CourtConfig
 
@@ -55,109 +50,13 @@ logger = logging.getLogger(__name__)
 F = TypeVar("F", bound=Callable[..., int])
 
 
-@dataclass(frozen=True)
-class _SceneGenerationTask:
-    """Inputs required to generate one scene in a worker process."""
-
-    scene_index: int
-    scene_id: str
-    seed: int
-
-
-@dataclass(frozen=True)
-class _SceneGenerationResult:
-    """Generated scene payload and aggregated counters for one task."""
-
-    scene_index: int
-    scene_data: BLCSSceneData | None
-    total_cameras: int
-    total_cameras_tried: int
-
-
 def _seed_everything(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
 
 
-def _iter_scene_tasks(num_scenes: int, seed: int) -> Iterator[_SceneGenerationTask]:
-    for scene_index in range(num_scenes):
-        yield _SceneGenerationTask(
-            scene_index=scene_index,
-            scene_id=f"scene_{scene_index:06d}",
-            seed=seed + scene_index,
-        )
-
-
-def _generate_scene_task(
-    task: _SceneGenerationTask,
-    generator_config: GeneratorConfig,
-    device: str,
-) -> _SceneGenerationResult:
-    if torch.device(device).type != "cpu":
-        raise ValueError(
-            "Parallel BLCS dataset generation only supports run.device=cpu"
-        )
-
-    _seed_everything(task.seed)
-    torch.set_num_threads(1)
-
-    generator = BLCSSceneGenerator(config=generator_config, device=device)
-    from_cell = int(torch.randint(0, NUM_CELLS_PER_SIDE, (1,)).item())
-    side = "near" if torch.rand(1).item() < 0.5 else "far"
-    scene_data = generator.generate_scene(from_cell, side, task.scene_id)
-
-    return _SceneGenerationResult(
-        scene_index=task.scene_index,
-        scene_data=scene_data,
-        total_cameras=len(scene_data.cameras) if scene_data is not None else 0,
-        total_cameras_tried=(
-            scene_data.num_cameras_sampled if scene_data is not None else 0
-        ),
-    )
-
-
-def _generate_parallel_scenes(
-    generator_config: GeneratorConfig,
-    device: str,
-    num_scenes: int,
-    seed: int,
-    num_workers: int,
-) -> Iterator[_SceneGenerationResult]:
-    max_workers = min(num_workers, num_scenes)
-    if max_workers <= 0:
-        return
-
-    with ProcessPoolExecutor(max_workers=max_workers) as executor:
-        yield from executor.map(
-            _generate_scene_task,
-            _iter_scene_tasks(num_scenes, seed),
-            repeat(generator_config),
-            repeat(device),
-            chunksize=1,
-        )
-
-
-def _build_parallel_stats(
-    total_scenes: int,
-    total_cameras: int,
-    total_cameras_tried: int,
-) -> dict[str, float | int]:
-    acceptance_rate = (
-        total_cameras / total_cameras_tried if total_cameras_tried > 0 else 0.0
-    )
-    avg_cameras = total_cameras / total_scenes if total_scenes > 0 else 0.0
-    return {
-        "total_scenes": total_scenes,
-        "total_scenes_generated": total_scenes,
-        "total_cameras": total_cameras,
-        "total_cameras_tried": total_cameras_tried,
-        "camera_acceptance_rate": acceptance_rate,
-        "avg_cameras_per_scene": avg_cameras,
-    }
-
-
-def _build_generator_config(cfg: DictConfig) -> GeneratorConfig:
+def build_generator_config(cfg: DictConfig) -> GeneratorConfig:
     physics_config = PhysicsConfig(
         gravity=float(cfg.physics.gravity),
         k_drag=float(cfg.physics.k_drag),
@@ -290,7 +189,7 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
             f"Invalid split ratios: train={train_ratio}, val={val_ratio} (sum > 1.0)"
         )
 
-    generator_config = _build_generator_config(cfg)
+    generator_config = build_generator_config(cfg)
 
     num_scenes = int(cfg.generator.num_scenes)
     num_workers = int(cfg.run.get("num_workers", 1))
@@ -307,11 +206,7 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
             "Parallel BLCS dataset generation requires run.device=cpu when "
             f"run.num_workers={num_workers}"
         )
-
-    generator = None
-    if effective_workers <= 1:
-        generator = BLCSSceneGenerator(config=generator_config, device=device)
-
+    
     writer = BLCSDatasetWriter(output_dir)
 
     logger.info("Starting scene generation...")
@@ -322,65 +217,28 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
     logger.info("Scene generation workers: %s", effective_workers)
 
     total_scenes = 0
-    total_cameras = 0
-    total_cameras_tried = 0
 
-    if generator is not None:
-        for scene_data in tqdm(
-            generator.generate(num_scenes),
-            desc="Generating scenes",
-            total=num_scenes,
-        ):
-            writer.save_scene(scene_data)
-            total_scenes += 1
-            total_cameras += len(scene_data.cameras)
-            total_cameras_tried += scene_data.num_cameras_sampled
+    for scene_data in tqdm(
+        generate_parallel_scenes(
+            generator_config=generator_config,
+            device=device,
+            num_scenes=num_scenes,
+            num_workers=effective_workers,
+        ),
+        desc="Generating scenes",
+        total=num_scenes,
+    ):
+        
+        writer.save_scene(scene_data)
+        total_scenes += 1
 
-            if total_scenes % 100 == 0:
-                avg_cams = total_cameras / total_scenes
-                logger.info(
-                    "Progress: %s scenes, %s cameras (avg %.1f/scene)",
-                    total_scenes,
-                    total_cameras,
-                    avg_cams,
-                )
-        stats = generator.get_statistics()
-    else:
-        for result in tqdm(
-            _generate_parallel_scenes(
-                generator_config=generator_config,
-                device=device,
-                num_scenes=num_scenes,
-                seed=seed,
-                num_workers=effective_workers,
-            ),
-            desc="Generating scenes",
-            total=num_scenes,
-        ):
-            if result.scene_data is None:
-                continue
+        if total_scenes % 100 == 0:
+            logger.info(
+                "Progress: %s scenes",
+                total_scenes,
+            )
 
-            writer.save_scene(result.scene_data)
-            total_scenes += 1
-            total_cameras += result.total_cameras
-            total_cameras_tried += result.total_cameras_tried
-
-            if total_scenes % 100 == 0:
-                avg_cams = total_cameras / total_scenes
-                logger.info(
-                    "Progress: %s scenes, %s cameras (avg %.1f/scene)",
-                    total_scenes,
-                    total_cameras,
-                    avg_cams,
-                )
-
-        stats = _build_parallel_stats(
-            total_scenes=total_scenes,
-            total_cameras=total_cameras,
-            total_cameras_tried=total_cameras_tried,
-        )
-
-    logger.info("Generation complete: %s scenes, %s cameras", total_scenes, total_cameras)
+    logger.info("Generation complete: %s scenes", total_scenes)
 
     if total_scenes < num_scenes:
         logger.warning("Only generated %s/%s scenes", total_scenes, num_scenes)
@@ -394,15 +252,11 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
     )
 
     writer.save_meta_json(config=OmegaConf.to_container(cfg, resolve=True))
-    writer.save_dataset_info(stats)
 
     logger.info("=" * 60)
     logger.info("Dataset generation complete!")
     logger.info("Output: %s", output_dir)
     logger.info("Total scenes: %s", total_scenes)
-    logger.info("Total cameras: %s", total_cameras)
-    if total_scenes > 0:
-        logger.info("Avg cameras/scene: %.2f", total_cameras / total_scenes)
     logger.info("=" * 60)
 
     return 0

--- a/src/tasks/blcs/scripts/train_chunked.py
+++ b/src/tasks/blcs/scripts/train_chunked.py
@@ -20,14 +20,14 @@ from __future__ import annotations
 import hydra
 from omegaconf import DictConfig
 
-from src.tasks.blcs.scripts.generate_dataset import _build_generator_config
+from src.tasks.blcs.scripts.generate_dataset import build_generator_config
 from src.tasks.blcs.training.runner import BLCSTrainingRunner
 
 
 @hydra.main(config_path="../configs", config_name="train_chunked", version_base="1.3")
 def main(config: DictConfig) -> None:
     """Hydra entry point for chunked BLCS training."""
-    generator_config = _build_generator_config(config)
+    generator_config = build_generator_config(config)
     runner = BLCSTrainingRunner(generator_config=generator_config)
     runner.run(config)
 

--- a/src/tasks/blcs/training/runner.py
+++ b/src/tasks/blcs/training/runner.py
@@ -39,7 +39,12 @@ class BLCSTrainingRunner(BaseTrainingRunner):
             return ChunkedBLCSDataModule(
                 config, generator_config=self.generator_config,
             )
-        return BLCSDataModule(config, generator_config=self.generator_config)
+        elif backend == "default":
+            return BLCSDataModule(config)
+        else:
+            raise ValueError(
+                f"Unsupported data.backend='{backend}'. Supported: ['default', 'chunked']"
+            )
 
     def build_lightning_module(
         self,

--- a/src/tasks/plcs/scripts/generate_dataset.py
+++ b/src/tasks/plcs/scripts/generate_dataset.py
@@ -148,12 +148,6 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry
         json.dump(scenes_meta, f, indent=2, default=str)
 
     writer.save_meta_json(config=OmegaConf.to_container(cfg, resolve=True))
-    writer.save_dataset_info(
-        {
-            "total_cameras": total_cameras,
-            "avg_cameras_per_scene": stats["avg_cameras"],
-        }
-    )
     writer.save_split_info(
         train_ratio=float(cfg.run.get("train_ratio", 0.8)),
         val_ratio=float(cfg.run.get("val_ratio", 0.1)),

--- a/tests/tasks/test_dataset_generation_contracts.py
+++ b/tests/tasks/test_dataset_generation_contracts.py
@@ -271,7 +271,6 @@ def test_plcs_generator_output_contract(tmp_path: Path) -> None:
         output_dir,
         {
             "config.yaml",
-            "dataset_info.json",
             "meta.json",
             "scenes",
             "scenes_meta.json",
@@ -284,14 +283,12 @@ def test_plcs_generator_output_contract(tmp_path: Path) -> None:
     )
 
     meta_json = _read_json(output_dir / "meta.json")
-    dataset_info = _read_json(output_dir / "dataset_info.json")
     stats_json = _read_json(output_dir / "stats.json")
     scenes_meta = _read_json(output_dir / "scenes_meta.json")
     scene_paths = sorted((output_dir / "scenes").glob("scene_*.npz"))
     split_union, _ = _assert_split_contract(output_dir, meta_json)
 
     assert meta_json["stats"]["total_scenes"] == len(scene_paths)
-    assert dataset_info["total_scenes"] == meta_json["stats"]["total_scenes"]
     assert stats_json["successful_scenes"] == meta_json["stats"]["total_scenes"]
     assert stats_json["failed_scenes"] == 0
     assert len(scenes_meta) == meta_json["stats"]["total_scenes"]
@@ -326,7 +323,6 @@ def test_blcs_generator_output_contract(tmp_path: Path) -> None:
         output_dir,
         {
             "config.yaml",
-            "dataset_info.json",
             "meta.json",
             "scenes",
             "split_info.json",
@@ -337,12 +333,10 @@ def test_blcs_generator_output_contract(tmp_path: Path) -> None:
     )
 
     meta_json = _read_json(output_dir / "meta.json")
-    dataset_info = _read_json(output_dir / "dataset_info.json")
     scene_paths = sorted((output_dir / "scenes").glob("scene_*.npz"))
     split_union, _ = _assert_split_contract(output_dir, meta_json)
 
     assert meta_json["stats"]["total_scenes"] == len(scene_paths)
-    assert dataset_info["total_scenes"] == meta_json["stats"]["total_scenes"]
     assert {path.name for path in scene_paths} == set(split_union)
 
     for scene_record in meta_json["scenes"]:

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -56,9 +56,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 def _blcs_chunked_runner_factory(config: DictConfig) -> BLCSTrainingRunner:
     """Build a BLCSTrainingRunner with generator_config for chunked training."""
-    from src.tasks.blcs.scripts.generate_dataset import _build_generator_config
+    from src.tasks.blcs.scripts.generate_dataset import build_generator_config
 
-    generator_config = _build_generator_config(config)
+    generator_config = build_generator_config(config)
     return BLCSTrainingRunner(generator_config=generator_config)
 
 


### PR DESCRIPTION
## Summary

Refactors BLCS dataset generation flow by extracting parallel worker logic into a dedicated utility module and consolidating scene start sampling in the scene generator.
Also aligns dataset output contract changes by removing dataset_info outputs/usages and updating related contract/smoke tests.

## Changes

- Added `src/tasks/blcs/generate_dataset/utils/parallel_runner.py` and wired BLCS dataset script to use it for parallel scene generation.
- Added `sample_from_cell()` and `sample_side()` methods to `BLCSSceneGenerator` and switched internal/parallel callers to these methods.
- Removed `save_dataset_info` usage paths and updated PLCS/BLCS dataset generation contract tests and smoke contract expectations accordingly.

## Validation

- Ran: `pytest -q tests/tasks/test_dataset_generation_contracts.py tests/tasks/test_training_smoke_contracts.py`
- Result: `tests/tasks/test_dataset_generation_contracts.py` passed in this run.
- Result: `tests/tasks/test_training_smoke_contracts.py` had 8 failures; main causes were missing local dataset assets (`data/plcs/train.txt`, `data/court/data_train.json`) and BLCS smoke TypeError coverage in current smoke configuration.

## Related Issues

- References: none

## Notes

This PR intentionally includes all current working-tree changes requested by the author.
