### PR TITLE
Add BLCS GAN training workflow

### DIFF
--- a/src/tasks/base/training/runner.py
+++ b/src/tasks/base/training/runner.py
@@ -34,6 +34,7 @@ class BaseTrainingRunner:
 
     def run(self, config: Any) -> None:
         """Run training with the provided config."""
+        self.prepare_config(config)
         self.seed_everything(config)
         self.apply_runtime_settings(config)
 
@@ -88,6 +89,10 @@ class BaseTrainingRunner:
         """Prepare output directory path."""
         return Path(self._ensure_absolute(str(config.run.output_dir)))
 
+    def prepare_config(self, config: Any) -> None:
+        """Apply task-specific config mutations before the run starts."""
+        return None
+
     def resolve_resume(self, config: Any, output_dir: Path) -> str | None:
         """Resolve resume checkpoint path."""
         resume = config.run.resume
@@ -132,6 +137,9 @@ class BaseTrainingRunner:
 
     def save_config(self, config: Any, output_dir: Path) -> None:
         """Save resolved config to output directory."""
+        # Some callers invoke runner methods directly without going through run(),
+        # so prepare task-specific runtime config here as well before persisting it.
+        self.prepare_config(config)
         OmegaConf.save(config, output_dir / "config.yaml")
 
     def build_logger(self, config: Any, output_dir: Path) -> TensorBoardLogger:

--- a/src/tasks/blcs/configs/train_chunked.yaml
+++ b/src/tasks/blcs/configs/train_chunked.yaml
@@ -1,7 +1,7 @@
 defaults:
   - model: multiview
   - data: chunked_multi
-  - training: default
+  - training: chunked
   - metrics: default
   - run: train
   - physics: default

--- a/src/tasks/blcs/configs/training/chunked.yaml
+++ b/src/tasks/blcs/configs/training/chunked.yaml
@@ -1,3 +1,7 @@
+defaults:
+  - _self_
+  - optional gan: null
+
 # ---- Trainer (Lightning Trainer settings) ----
 trainer:
   max_epochs: 200

--- a/src/tasks/blcs/configs/training/default.yaml
+++ b/src/tasks/blcs/configs/training/default.yaml
@@ -1,3 +1,7 @@
+defaults:
+  - _self_
+  - optional gan: null
+
 # ---- Trainer (Lightning Trainer settings) ----
 trainer:
   max_epochs: 50

--- a/src/tasks/blcs/configs/training/gan/lsgan.yaml
+++ b/src/tasks/blcs/configs/training/gan/lsgan.yaml
@@ -1,0 +1,26 @@
+enabled: true
+target_weight: 0.1
+warmup_epochs: 5
+generator_gradient_clip_val: 1.0
+discriminator_gradient_clip_val: 1.0
+
+transition:
+  monitor: val/pos_error_m
+  mode: min
+  patience: 3
+  min_delta: 1.0e-3
+  min_supervised_epochs: 1
+
+discriminator:
+  name: trajectory_transformer
+  hidden_dim: 128
+  num_layers: 4
+  num_heads: 4
+  ffn_dim: 256
+  ffn_type: swiglu
+  dropout: 0.1
+  rope_dim: null
+  rope_theta: 10000.0
+  max_seq_len: ${data.max_seq_len}
+  invisible_init_std: 0.02
+  cls_init_std: 0.02

--- a/src/tasks/blcs/models/__init__.py
+++ b/src/tasks/blcs/models/__init__.py
@@ -8,6 +8,7 @@ from torch import nn
 
 from src.tasks.blcs.models.blcs_model import BLCSModel
 from src.tasks.blcs.models.blcs_multiview_model import BLCSMultiViewModel
+from src.tasks.blcs.models.discriminators import build_blcs_discriminator
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -30,5 +31,6 @@ def build_blcs_model(config: DictConfig) -> nn.Module:
 __all__ = [
     "BLCSModel",
     "BLCSMultiViewModel",
+    "build_blcs_discriminator",
     "build_blcs_model",
 ]

--- a/src/tasks/blcs/models/discriminators/__init__.py
+++ b/src/tasks/blcs/models/discriminators/__init__.py
@@ -1,0 +1,28 @@
+"""BLCS discriminator modules."""
+
+from __future__ import annotations
+
+from omegaconf import DictConfig
+
+from src.tasks.blcs.models.discriminators.trajectory_discriminator import (
+    BLCSTrajectoryDiscriminator,
+)
+
+
+def build_blcs_discriminator(config: DictConfig) -> BLCSTrajectoryDiscriminator:
+    """Build the configured BLCS discriminator."""
+    train_cfg = config.get("training", {}) or {}
+    gan_cfg = train_cfg.get("gan", {}) or {}
+    disc_name = str(gan_cfg.get("discriminator", {}).get("name", "trajectory_transformer"))
+    if disc_name != "trajectory_transformer":
+        raise ValueError(
+            "Unknown BLCS discriminator name="
+            f"'{disc_name}'. Supported: ['trajectory_transformer']"
+        )
+    return BLCSTrajectoryDiscriminator.from_config(config)
+
+
+__all__ = [
+    "BLCSTrajectoryDiscriminator",
+    "build_blcs_discriminator",
+]

--- a/src/tasks/blcs/models/discriminators/trajectory_discriminator.py
+++ b/src/tasks/blcs/models/discriminators/trajectory_discriminator.py
@@ -1,0 +1,167 @@
+"""Transformer discriminator for BLCS 3D trajectories."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, cast
+
+import torch
+from torch import Tensor, nn
+
+from src.utils.models import (
+    RMSNorm,
+    TransformerBlock,
+    TransformerBlockConfig,
+    precompute_freqs_cis,
+)
+from src.utils.models.embeddings import Ball3DEmbedding, InvisibleTokenEmbedding
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+class BLCSTrajectoryDiscriminator(nn.Module):
+    """Transformer discriminator over 3D trajectory tokens."""
+
+    def __init__(
+        self,
+        *,
+        hidden_dim: int = 128,
+        num_layers: int = 4,
+        num_heads: int = 4,
+        ffn_dim: int | None = None,
+        dropout: float = 0.1,
+        rope_dim: int | None = None,
+        rope_theta: float = 10000.0,
+        ffn_type: str = "swiglu",
+        max_seq_len: int = 120,
+        invisible_init_std: float = 0.02,
+        cls_init_std: float = 0.02,
+    ) -> None:
+        super().__init__()
+
+        if hidden_dim % num_heads != 0:
+            raise ValueError(
+                f"hidden_dim={hidden_dim} must be divisible by num_heads={num_heads}"
+            )
+        if max_seq_len <= 0:
+            raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
+
+        head_dim = hidden_dim // num_heads
+        rope_dim = head_dim if rope_dim is None else int(rope_dim)
+        if rope_dim % 2 != 0:
+            raise ValueError(f"rope_dim must be even, got {rope_dim}")
+        if rope_dim > head_dim:
+            raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
+
+        if ffn_dim is None:
+            ffn_dim = int((8 * hidden_dim) / 3)
+            ffn_dim = (ffn_dim + 63) // 64 * 64
+
+        self.hidden_dim = int(hidden_dim)
+        self.max_seq_len = int(max_seq_len)
+        self.rope_dim = int(rope_dim)
+
+        self.invisible_token = InvisibleTokenEmbedding(
+            dim=self.hidden_dim,
+            init_std=float(invisible_init_std),
+        )
+        self.ball_embed = Ball3DEmbedding(
+            dim=self.hidden_dim,
+            dropout=float(dropout),
+            invisible_token=self.invisible_token,
+        )
+        self.cls_token = nn.Parameter(torch.randn(1, 1, self.hidden_dim) * float(cls_init_std))
+        self.blocks = nn.ModuleList(
+            [
+                TransformerBlock(
+                    TransformerBlockConfig(
+                        dim=self.hidden_dim,
+                        n_heads=int(num_heads),
+                        ffn_dim=int(ffn_dim),
+                        head_dim=head_dim,
+                        rope_dim=self.rope_dim,
+                        attn_dropout=float(dropout),
+                        rope_base=float(rope_theta),
+                        ffn_type=cast(Literal["swiglu", "mlp"], ffn_type),
+                    )
+                )
+                for _ in range(int(num_layers))
+            ]
+        )
+        self.final_norm = RMSNorm(self.hidden_dim)
+        self.head = nn.Linear(self.hidden_dim, 1)
+
+        freqs_cis = precompute_freqs_cis(
+            dim=self.rope_dim,
+            seqlen=self.max_seq_len + 1,
+            base=float(rope_theta),
+        )
+        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+
+    @classmethod
+    def from_config(cls, config: DictConfig) -> BLCSTrajectoryDiscriminator:
+        """Build discriminator from training.gan.discriminator config."""
+        train_cfg = config.get("training", {}) or {}
+        gan_cfg = train_cfg.get("gan", {}) or {}
+        disc_cfg = gan_cfg.get("discriminator", {}) or {}
+        data_cfg = config.get("data", {}) or {}
+
+        return cls(
+            hidden_dim=int(disc_cfg.get("hidden_dim", 128)),
+            num_layers=int(disc_cfg.get("num_layers", 4)),
+            num_heads=int(disc_cfg.get("num_heads", 4)),
+            ffn_dim=disc_cfg.get("ffn_dim", None),
+            dropout=float(disc_cfg.get("dropout", 0.1)),
+            rope_dim=disc_cfg.get("rope_dim", None),
+            rope_theta=float(disc_cfg.get("rope_theta", 10000.0)),
+            ffn_type=str(disc_cfg.get("ffn_type", "swiglu")),
+            max_seq_len=int(disc_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))),
+            invisible_init_std=float(disc_cfg.get("invisible_init_std", 0.02)),
+            cls_init_std=float(disc_cfg.get("cls_init_std", 0.02)),
+        )
+
+    def forward(
+        self,
+        position_3d: Tensor,
+        *,
+        mask: Tensor | None = None,
+    ) -> Tensor:
+        """Score 3D trajectories as real/fake.
+
+        Args:
+            position_3d: Trajectory tensor of shape (B, T, 3).
+            mask: Valid-timestep mask of shape (B, T).
+
+        Returns:
+            Tensor of shape (B,) containing discriminator logits.
+        """
+        batch_size, seq_len, _ = position_3d.shape
+        if seq_len > self.max_seq_len:
+            raise ValueError(
+                f"seq_len={seq_len} exceeds max_seq_len={self.max_seq_len}."
+            )
+
+        seq_mask = mask
+        if seq_mask is None:
+            seq_mask = torch.ones(batch_size, seq_len, device=position_3d.device, dtype=torch.bool)
+        else:
+            seq_mask = seq_mask > 0
+
+        x = self.ball_embed(position_3d, seq_mask.to(dtype=position_3d.dtype))
+        cls = self.cls_token.expand(batch_size, -1, -1)
+        x = torch.cat([cls, x], dim=1)
+
+        freqs_cis = cast(Tensor, self.freqs_cis[: seq_len + 1])
+        if freqs_cis.device != x.device:
+            freqs_cis = freqs_cis.to(x.device)
+
+        cls_valid = torch.ones(batch_size, 1, device=x.device, dtype=torch.bool)
+        attn_valid = torch.cat([cls_valid, seq_mask], dim=1)
+        attn_mask = attn_valid[:, None, :].expand(batch_size, seq_len + 1, seq_len + 1)
+
+        for block in self.blocks:
+            x = cast(Tensor, block(x, freqs_cis=freqs_cis, attn_mask=attn_mask))
+
+        x = cast(Tensor, self.final_norm(x))
+        logits = cast(Tensor, self.head(x[:, 0, :]))
+        return logits.squeeze(-1)

--- a/src/tasks/blcs/training/__init__.py
+++ b/src/tasks/blcs/training/__init__.py
@@ -1,11 +1,15 @@
 """BLCS training modules."""
 
+from src.tasks.blcs.training.gan_loss import LSGANLoss
+from src.tasks.blcs.training.gan_transition_callback import GANTransitionCallback
 from src.tasks.blcs.training.lightning_module import BLCSLightningModule
 from src.tasks.blcs.training.losses import BLCSLoss
 from src.tasks.blcs.training.metrics import BLCSMetrics
 
 __all__ = [
     "BLCSLightningModule",
+    "GANTransitionCallback",
+    "LSGANLoss",
     "BLCSLoss",
     "BLCSMetrics",
 ]

--- a/src/tasks/blcs/training/gan_loss.py
+++ b/src/tasks/blcs/training/gan_loss.py
@@ -1,0 +1,33 @@
+"""LSGAN loss helpers for BLCS adversarial training."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor, nn
+
+
+class LSGANLoss(nn.Module):
+    """Least-squares GAN losses for generator and discriminator."""
+
+    def __init__(
+        self,
+        *,
+        real_label: float = 1.0,
+        fake_label: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.real_label = float(real_label)
+        self.fake_label = float(fake_label)
+
+    def generator_loss(self, fake_logits: Tensor) -> Tensor:
+        """Encourage generated samples to be classified as real."""
+        target = torch.full_like(fake_logits, self.real_label)
+        return 0.5 * ((fake_logits - target) ** 2).mean()
+
+    def discriminator_loss(self, real_logits: Tensor, fake_logits: Tensor) -> Tensor:
+        """Classify real samples as 1 and fake samples as 0."""
+        real_target = torch.full_like(real_logits, self.real_label)
+        fake_target = torch.full_like(fake_logits, self.fake_label)
+        real_loss = (real_logits - real_target) ** 2
+        fake_loss = (fake_logits - fake_target) ** 2
+        return 0.5 * (real_loss.mean() + fake_loss.mean())

--- a/src/tasks/blcs/training/gan_training_strategy.py
+++ b/src/tasks/blcs/training/gan_training_strategy.py
@@ -1,0 +1,189 @@
+"""GAN training orchestration for BLCS manual optimization."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from torch import Tensor
+from torch.nn.utils import clip_grad_norm_, clip_grad_value_
+
+
+class BLCSGANTrainingStrategy:
+    """Own the GAN training procedure outside the LightningModule."""
+
+    def __init__(
+        self,
+        *,
+        generator_gradient_clip_val: float | None,
+        discriminator_gradient_clip_val: float | None,
+        scheduler_interval: str,
+    ) -> None:
+        self.generator_gradient_clip_val = generator_gradient_clip_val
+        self.discriminator_gradient_clip_val = discriminator_gradient_clip_val
+        self.scheduler_interval = scheduler_interval
+
+        self.phase_active = False
+        self.start_epoch: int | None = None
+        self.current_weight = 0.0
+        self.supervised_only_step_count = 0
+        self.hybrid_gan_step_count = 0
+
+    def activate_phase(self, start_epoch: int) -> None:
+        """Enable hybrid GAN training from the given epoch onward."""
+        self.phase_active = True
+        self.start_epoch = int(start_epoch)
+
+    def set_weight(self, weight: float) -> None:
+        """Update the current adversarial loss weight."""
+        self.current_weight = max(float(weight), 0.0)
+
+    def shared_step(self, module: Any, batch: Any, stage: str) -> tuple[Tensor, dict[str, float]]:
+        """Run the appropriate supervised or GAN training routine."""
+        if stage != "train" or not self.phase_active:
+            return self._supervised_step(module, batch, stage)
+        return self._gan_step(module, batch, stage)
+
+    def on_train_epoch_end(self, module: Any) -> None:
+        """Step manual schedulers on epoch boundaries when configured."""
+        if self.scheduler_interval != "epoch":
+            return
+
+        schedulers = self._manual_schedulers(module)
+        if not schedulers:
+            return
+        schedulers[0].step()
+        if self.phase_active and len(schedulers) > 1:
+            schedulers[1].step()
+
+    def _unwrap_optimizer(self, optimizer: Any) -> Any:
+        """Return the bare optimizer when Lightning wraps it."""
+        return optimizer.optimizer if hasattr(optimizer, "optimizer") else optimizer
+
+    def _manual_optimizers(self, module: Any) -> tuple[Any, Any]:
+        optimizers = module.optimizers()
+        if not isinstance(optimizers, (list, tuple)) or len(optimizers) != 2:
+            raise RuntimeError("Expected generator and discriminator optimizers in manual mode.")
+        return optimizers[0], optimizers[1]
+
+    def _manual_schedulers(self, module: Any) -> list[Any]:
+        schedulers = module.lr_schedulers()
+        if schedulers is None:
+            return []
+        if isinstance(schedulers, (list, tuple)):
+            return list(schedulers)
+        return [schedulers]
+
+    def _clip_manual_gradients(self, module: Any, optimizer: Any, clip_val: float | None) -> None:
+        if clip_val is None or float(clip_val) <= 0:
+            return
+        clip_algorithm = str(getattr(module.trainer, "gradient_clip_algorithm", "norm")).lower()
+        parameters = self._unwrap_optimizer(optimizer).param_groups
+        gradients = [
+            param
+            for group in parameters
+            for param in group["params"]
+            if param.grad is not None
+        ]
+        if not gradients:
+            return
+        if clip_algorithm == "value":
+            clip_grad_value_(gradients, float(clip_val))
+            return
+        clip_grad_norm_(gradients, float(clip_val))
+
+    def _step_manual_schedulers(self, module: Any, *, include_discriminator: bool) -> None:
+        if self.scheduler_interval != "step":
+            return
+        schedulers = self._manual_schedulers(module)
+        if not schedulers:
+            return
+        schedulers[0].step()
+        if include_discriminator and len(schedulers) > 1:
+            schedulers[1].step()
+
+    def _supervised_step(
+        self,
+        module: Any,
+        batch: Any,
+        stage: str,
+    ) -> tuple[Tensor, dict[str, float]]:
+        """Run the supervised BLCS training/evaluation step."""
+        result = module._compute_supervised_result(batch, stage)
+
+        if stage == "train":
+            generator_optimizer, _ = self._manual_optimizers(module)
+            module.toggle_optimizer(generator_optimizer)
+            generator_optimizer.zero_grad()
+            module.manual_backward(result["loss"])
+            self._clip_manual_gradients(
+                module,
+                generator_optimizer,
+                self.generator_gradient_clip_val,
+            )
+            generator_optimizer.step()
+            module.untoggle_optimizer(generator_optimizer)
+            self._step_manual_schedulers(module, include_discriminator=False)
+            self.supervised_only_step_count += 1
+            return result["loss"].detach(), result["metrics"]
+
+        return result["loss"], result["metrics"]
+
+    def _gan_step(
+        self,
+        module: Any,
+        batch: Any,
+        stage: str,
+    ) -> tuple[Tensor, dict[str, float]]:
+        """Run the hybrid supervised + LSGAN training step."""
+        if stage != "train":
+            return self._supervised_step(module, batch, stage)
+        if module.discriminator is None or module.gan_loss_fn is None:
+            raise RuntimeError("GAN components are not initialized.")
+
+        result = module._compute_supervised_result(batch, stage)
+        generator_optimizer, discriminator_optimizer = self._manual_optimizers(module)
+
+        mask = result["mask"]
+        pred_position = result["outputs"]["position"]
+        target_position = batch["position_3d"]
+
+        module.toggle_optimizer(discriminator_optimizer)
+        discriminator_optimizer.zero_grad()
+        real_logits = module.discriminator(target_position, mask=mask)
+        fake_logits = module.discriminator(pred_position.detach(), mask=mask)
+        discriminator_loss = module.gan_loss_fn.discriminator_loss(real_logits, fake_logits)
+        module.manual_backward(discriminator_loss)
+        self._clip_manual_gradients(
+            module,
+            discriminator_optimizer,
+            self.discriminator_gradient_clip_val,
+        )
+        discriminator_optimizer.step()
+        module.untoggle_optimizer(discriminator_optimizer)
+
+        module.toggle_optimizer(generator_optimizer)
+        generator_optimizer.zero_grad()
+        fake_logits_for_generator = module.discriminator(pred_position, mask=mask)
+        gan_loss = module.gan_loss_fn.generator_loss(fake_logits_for_generator)
+        hybrid_loss = result["loss"] + self.current_weight * gan_loss
+        module.manual_backward(hybrid_loss)
+        self._clip_manual_gradients(
+            module,
+            generator_optimizer,
+            self.generator_gradient_clip_val,
+        )
+        generator_optimizer.step()
+        module.untoggle_optimizer(generator_optimizer)
+
+        self._step_manual_schedulers(module, include_discriminator=True)
+        self.hybrid_gan_step_count += 1
+
+        metrics = {
+            **result["metrics"],
+            "loss_hybrid_total": hybrid_loss.item(),
+            "loss_gan_generator": gan_loss.item(),
+            "loss_gan_discriminator": discriminator_loss.item(),
+            "gan_weight": float(self.current_weight),
+            "gan_phase_active": float(self.phase_active),
+        }
+        return hybrid_loss.detach(), metrics

--- a/src/tasks/blcs/training/gan_transition_callback.py
+++ b/src/tasks/blcs/training/gan_transition_callback.py
@@ -1,0 +1,116 @@
+"""Callback that switches BLCS training from supervised to hybrid GAN mode."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+import pytorch_lightning as pl
+from torch import Tensor
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+class GANTransitionCallback(pl.Callback):
+    """Detect supervised convergence and enable hybrid GAN training."""
+
+    def __init__(self, config: DictConfig) -> None:
+        super().__init__()
+
+        gan_cfg = (config.get("training", {}) or {}).get("gan", {}) or {}
+        transition_cfg = gan_cfg.get("transition", {}) or {}
+
+        self.enabled = bool(gan_cfg.get("enabled", False))
+        self.monitor = str(transition_cfg.get("monitor", "val/pos_error_m"))
+        self.mode = str(transition_cfg.get("mode", "min"))
+        self.min_delta = float(transition_cfg.get("min_delta", 1.0e-3))
+        self.patience = int(transition_cfg.get("patience", 3))
+        self.min_supervised_epochs = int(transition_cfg.get("min_supervised_epochs", 1))
+        self.gan_target_weight = float(gan_cfg.get("target_weight", 0.1))
+        self.gan_warmup_epochs = int(gan_cfg.get("warmup_epochs", 5))
+
+        if self.mode not in {"min", "max"}:
+            raise ValueError(f"Unsupported transition mode '{self.mode}'. Use ['min', 'max'].")
+
+        self.best_score: float | None = None
+        self.bad_epochs = 0
+        self.has_switched_to_gan = False
+        self.switch_epoch: int | None = None
+
+    def state_dict(self) -> dict[str, Any]:
+        return {
+            "best_score": self.best_score,
+            "bad_epochs": self.bad_epochs,
+            "has_switched_to_gan": self.has_switched_to_gan,
+            "switch_epoch": self.switch_epoch,
+        }
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self.best_score = state_dict.get("best_score")
+        self.bad_epochs = int(state_dict.get("bad_epochs", 0))
+        self.has_switched_to_gan = bool(state_dict.get("has_switched_to_gan", False))
+        self.switch_epoch = state_dict.get("switch_epoch")
+
+    def on_fit_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        pl_module.set_gan_weight(0.0)
+
+    def on_train_epoch_start(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+    ) -> None:
+        if not self.enabled or not self.has_switched_to_gan or self.switch_epoch is None:
+            return
+
+        epochs_since_switch = max(trainer.current_epoch - self.switch_epoch + 1, 0)
+        if self.gan_warmup_epochs <= 1:
+            gan_weight = self.gan_target_weight
+        else:
+            progress = min(epochs_since_switch / self.gan_warmup_epochs, 1.0)
+            gan_weight = self.gan_target_weight * progress
+        pl_module.set_gan_weight(gan_weight)
+
+    def on_validation_epoch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+    ) -> None:
+        if not self.enabled or self.has_switched_to_gan:
+            return
+
+        if trainer.current_epoch + 1 < self.min_supervised_epochs:
+            return
+
+        monitor_value = trainer.callback_metrics.get(self.monitor)
+        if monitor_value is None:
+            return
+
+        current = float(cast(Tensor, monitor_value).detach().cpu().item())
+        if self.patience <= 0:
+            self._switch_to_gan(trainer, pl_module)
+            return
+
+        if self.best_score is None or self._is_improvement(current):
+            self.best_score = current
+            self.bad_epochs = 0
+            return
+
+        self.bad_epochs += 1
+        if self.bad_epochs >= self.patience:
+            self._switch_to_gan(trainer, pl_module)
+
+    def _is_improvement(self, current: float) -> bool:
+        assert self.best_score is not None
+        if self.mode == "min":
+            return current < (self.best_score - self.min_delta)
+        return current > (self.best_score + self.min_delta)
+
+    def _switch_to_gan(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+    ) -> None:
+        self.has_switched_to_gan = True
+        self.switch_epoch = trainer.current_epoch + 1
+        pl_module.activate_gan_phase(self.switch_epoch)
+        pl_module.set_gan_weight(0.0)

--- a/src/tasks/blcs/training/lightning_module.py
+++ b/src/tasks/blcs/training/lightning_module.py
@@ -9,14 +9,17 @@ import cv2
 import numpy as np
 import torch
 from torch import Tensor
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR, SequentialLR
 
 from src.tasks.base.training.lightning_module import BaseLightningModule
 from src.tasks.base.training.qualitative_callback import save_image_to_tensorboard
 from src.tasks.blcs.data.types import BLCSBatch, BLCSMultiViewBatch
-from src.tasks.blcs.models import build_blcs_model
+from src.tasks.blcs.models import build_blcs_discriminator, build_blcs_model
+from src.tasks.blcs.training.gan_loss import LSGANLoss
+from src.tasks.blcs.training.gan_training_strategy import BLCSGANTrainingStrategy
 from src.tasks.blcs.training.losses import BLCSLoss
 from src.tasks.blcs.training.metrics import BLCSMetrics
-
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -40,6 +43,8 @@ class BLCSLightningModule(BaseLightningModule):
         self.model = build_blcs_model(self.config)
 
         train_cfg = self.config.get("training", {})
+        trainer_cfg = train_cfg.get("trainer", {}) or {}
+        self.max_epochs = int(trainer_cfg.get("max_epochs", self.max_epochs))
         self.loss_fn = BLCSLoss(
             position_weight=train_cfg.get("position_loss_weight", 1.0),
             velocity_weight=train_cfg.get("velocity_loss_weight", 0.1),
@@ -47,6 +52,22 @@ class BLCSLightningModule(BaseLightningModule):
             reprojection_weight=train_cfg.get("reprojection_loss_weight", 0.0),
             uv_velocity_weight=train_cfg.get("uv_velocity_loss_weight", 0.0),
         )
+
+        gan_cfg = train_cfg.get("gan", {}) or {}
+        self.gan_enabled = bool(gan_cfg.get("enabled", False))
+        self.automatic_optimization = not self.gan_enabled
+        scheduler_interval = "epoch" if self.warmup_epochs is not None else "step"
+        self.gan_training = (
+            BLCSGANTrainingStrategy(
+                generator_gradient_clip_val=gan_cfg.get("generator_gradient_clip_val"),
+                discriminator_gradient_clip_val=gan_cfg.get("discriminator_gradient_clip_val"),
+                scheduler_interval=scheduler_interval,
+            )
+            if self.gan_enabled
+            else None
+        )
+        self.discriminator = build_blcs_discriminator(self.config) if self.gan_enabled else None
+        self.gan_loss_fn = LSGANLoss() if self.gan_enabled else None
 
         metrics_cfg = self.config.get("metrics", {})
         self.train_metrics = BLCSMetrics(
@@ -93,10 +114,184 @@ class BLCSLightningModule(BaseLightningModule):
             return self.val_metrics
         return self.test_metrics
 
-    def _shared_step(
-        self, batch: BLCSBatch | BLCSMultiViewBatch, stage: str
-    ) -> tuple[Tensor, dict[str, float]]:
-        """Shared step for training, validation, and test."""
+    def activate_gan_phase(self, start_epoch: int) -> None:
+        """Enable hybrid GAN training from the given epoch onward."""
+        if self.gan_training is None:
+            return
+        self.reset_gan_phase_schedules(start_epoch)
+        self.gan_training.activate_phase(start_epoch)
+
+    def set_gan_weight(self, weight: float) -> None:
+        """Set the current adversarial loss weight."""
+        if self.gan_training is None:
+            return
+        self.gan_training.set_weight(weight)
+
+    @property
+    def gan_phase_active(self) -> bool:
+        """Expose current GAN phase state for callbacks and tests."""
+        return self.gan_training.phase_active if self.gan_training is not None else False
+
+    @property
+    def current_gan_weight(self) -> float:
+        """Expose current adversarial weight for logging and tests."""
+        return self.gan_training.current_weight if self.gan_training is not None else 0.0
+
+    @property
+    def supervised_only_step_count(self) -> int:
+        """Expose supervised-only update count for tests."""
+        return self.gan_training.supervised_only_step_count if self.gan_training is not None else 0
+
+    @property
+    def hybrid_gan_step_count(self) -> int:
+        """Expose hybrid GAN update count for tests."""
+        return self.gan_training.hybrid_gan_step_count if self.gan_training is not None else 0
+
+    def _unwrap_optimizer(self, optimizer: Any) -> Any:
+        """Return the bare optimizer when Lightning wraps it."""
+        return optimizer.optimizer if hasattr(optimizer, "optimizer") else optimizer
+
+    def _manual_optimizers(self) -> tuple[Any, Any]:
+        optimizers = self.optimizers()
+        if not isinstance(optimizers, (list, tuple)) or len(optimizers) != 2:
+            raise RuntimeError("Expected generator and discriminator optimizers in manual mode.")
+        return optimizers[0], optimizers[1]
+
+    def _manual_schedulers(self) -> list[Any]:
+        schedulers = self.lr_schedulers()
+        if schedulers is None:
+            return []
+        if isinstance(schedulers, (list, tuple)):
+            return list(schedulers)
+        return [schedulers]
+
+    def _build_optimizer_for_parameters(self, parameters: Any) -> AdamW:
+        kwargs: dict[str, Any] = {
+            "lr": self.learning_rate,
+            "weight_decay": self.weight_decay,
+        }
+        if self.optimizer_betas is not None:
+            kwargs["betas"] = self.optimizer_betas
+        return AdamW(parameters, **kwargs)
+
+    def _build_scheduler_for_optimizer(
+        self,
+        optimizer: AdamW,
+        *,
+        total_steps_override: int | None = None,
+        max_epochs_override: int | None = None,
+    ) -> Any:
+        if self.warmup_epochs is not None:
+            warmup_epochs = int(self.warmup_epochs)
+            max_epochs = (
+                int(max_epochs_override) if max_epochs_override is not None else int(self.max_epochs)
+            )
+            if warmup_epochs > 0:
+                warmup_scheduler = LinearLR(
+                    optimizer,
+                    start_factor=0.01,
+                    end_factor=1.0,
+                    total_iters=warmup_epochs,
+                )
+                cosine_scheduler = CosineAnnealingLR(
+                    optimizer,
+                    T_max=max(max_epochs - warmup_epochs, 1),
+                    eta_min=self.min_lr,
+                )
+                return SequentialLR(
+                    optimizer,
+                    schedulers=[warmup_scheduler, cosine_scheduler],
+                    milestones=[warmup_epochs],
+                )
+            return CosineAnnealingLR(
+                optimizer,
+                T_max=max(max_epochs, 1),
+                eta_min=self.min_lr,
+            )
+
+        warmup_steps = int(self.warmup_steps or 0)
+        total_steps = (
+            int(total_steps_override)
+            if total_steps_override is not None
+            else self._estimate_total_steps()
+        )
+        if warmup_steps > 0:
+            warmup_scheduler = LinearLR(
+                optimizer,
+                start_factor=0.01,
+                end_factor=1.0,
+                total_iters=warmup_steps,
+            )
+            cosine_scheduler = CosineAnnealingLR(
+                optimizer,
+                T_max=max(total_steps - warmup_steps, 1),
+                eta_min=self.min_lr,
+            )
+            return SequentialLR(
+                optimizer,
+                schedulers=[warmup_scheduler, cosine_scheduler],
+                milestones=[warmup_steps],
+            )
+        return CosineAnnealingLR(
+            optimizer,
+            T_max=max(total_steps, 1),
+            eta_min=self.min_lr,
+        )
+
+    def reset_gan_phase_schedules(self, start_epoch: int) -> None:
+        """Reset generator/discriminator LR schedules when GAN training starts."""
+        if not self.gan_enabled:
+            return
+
+        schedulers = self._manual_schedulers()
+        if len(schedulers) < 2:
+            return
+
+        generator_optimizer, discriminator_optimizer = self._manual_optimizers()
+        optimizers = [generator_optimizer, discriminator_optimizer]
+        remaining_total_steps = max(self._estimate_total_steps() - int(self.global_step), 1)
+        remaining_epochs = max(int(self.max_epochs) - int(start_epoch), 1)
+
+        for optimizer, scheduler in zip(optimizers, schedulers, strict=True):
+            fresh_optimizer = self._build_optimizer_for_parameters([torch.nn.Parameter(torch.zeros(()))])
+            fresh_scheduler = self._build_scheduler_for_optimizer(
+                fresh_optimizer,
+                total_steps_override=remaining_total_steps,
+                max_epochs_override=remaining_epochs,
+            )
+            scheduler.load_state_dict(fresh_scheduler.state_dict())
+
+            current_groups = self._unwrap_optimizer(optimizer).param_groups
+            fresh_groups = fresh_optimizer.param_groups
+            for current_group, fresh_group in zip(current_groups, fresh_groups, strict=True):
+                current_group["lr"] = fresh_group["lr"]
+                if "initial_lr" in fresh_group:
+                    current_group["initial_lr"] = fresh_group["initial_lr"]
+
+    def configure_optimizers(self) -> Any:
+        """Configure optional generator/discriminator optimizers for GAN mode."""
+        if not self.gan_enabled:
+            return super().configure_optimizers()
+        if self.discriminator is None:
+            raise RuntimeError("Discriminator must be instantiated when GAN is enabled.")
+
+        generator_optimizer = self._build_optimizer_for_parameters(self.model.parameters())
+        discriminator_optimizer = self._build_optimizer_for_parameters(
+            self.discriminator.parameters()
+        )
+        generator_scheduler = self._build_scheduler_for_optimizer(generator_optimizer)
+        discriminator_scheduler = self._build_scheduler_for_optimizer(discriminator_optimizer)
+        return [generator_optimizer, discriminator_optimizer], [
+            generator_scheduler,
+            discriminator_scheduler,
+        ]
+
+    def _compute_supervised_result(
+        self,
+        batch: BLCSBatch | BLCSMultiViewBatch,
+        stage: str,
+    ) -> dict[str, Any]:
+        """Compute forward pass, supervised losses, and metrics."""
         outputs = self._forward_from_batch(batch)
         mask = self._normalize_loss_mask(batch)
 
@@ -121,16 +316,34 @@ class BLCSLightningModule(BaseLightningModule):
             mask,
         )
 
-        return losses["total"], {
-            **metrics,
-            **{f"loss_{k}": v.item() for k, v in losses.items()},
+        return {
+            "loss": losses["total"],
+            "losses": losses,
+            "metrics": {
+                **metrics,
+                **{f"loss_{k}": v.item() for k, v in losses.items()},
+            },
+            "outputs": outputs,
+            "mask": mask,
         }
 
     def training_step(self, batch: BLCSBatch | BLCSMultiViewBatch, batch_idx: int) -> Tensor:
         """Training step."""
-        loss, metrics = self._shared_step(batch, "train")
+        _ = batch_idx
+        if self.gan_training is not None:
+            loss, metrics = self.gan_training.shared_step(self, batch, "train")
+        else:
+            result = self._compute_supervised_result(batch, "train")
+            loss, metrics = result["loss"], result["metrics"]
         self.log("train/loss", loss, prog_bar=True)
         self.log("train/pos_error_m", metrics.get("position_error_m", 0), prog_bar=True)
+        if self.gan_enabled:
+            self.log("train/gan_weight", float(self.current_gan_weight))
+            self.log("train/gan_phase_active", float(self.gan_phase_active))
+            if "loss_gan_generator" in metrics:
+                self.log("train/loss_gan_generator", metrics["loss_gan_generator"])
+            if "loss_gan_discriminator" in metrics:
+                self.log("train/loss_gan_discriminator", metrics["loss_gan_discriminator"])
         return loss
 
     def on_train_epoch_end(self) -> None:
@@ -139,10 +352,17 @@ class BLCSLightningModule(BaseLightningModule):
         for name, value in metrics.items():
             self.log(f"train/epoch_{name}", value)
         self.train_metrics.reset()
+        if self.gan_training is not None:
+            self.gan_training.on_train_epoch_end(self)
 
     def validation_step(self, batch: BLCSBatch | BLCSMultiViewBatch, batch_idx: int) -> None:
         """Validation step."""
-        loss, metrics = self._shared_step(batch, "val")
+        _ = batch_idx
+        if self.gan_training is not None:
+            loss, metrics = self.gan_training.shared_step(self, batch, "val")
+        else:
+            result = self._compute_supervised_result(batch, "val")
+            loss, metrics = result["loss"], result["metrics"]
         self.log("val/loss", loss, prog_bar=True)
         self.log("val/pos_error_m", metrics.get("position_error_m", 0), prog_bar=True)
 
@@ -155,7 +375,12 @@ class BLCSLightningModule(BaseLightningModule):
 
     def test_step(self, batch: BLCSBatch | BLCSMultiViewBatch, batch_idx: int) -> None:
         """Test step."""
-        loss, metrics = self._shared_step(batch, "test")
+        _ = batch_idx
+        if self.gan_training is not None:
+            loss, metrics = self.gan_training.shared_step(self, batch, "test")
+        else:
+            result = self._compute_supervised_result(batch, "test")
+            loss, metrics = result["loss"], result["metrics"]
         self.log("test/loss", loss)
         self.log("test/pos_error_m", metrics.get("position_error_m", 0))
 
@@ -221,11 +446,12 @@ class BLCSLightningModule(BaseLightningModule):
                 mx = all_pts.max(axis=0)
                 rng = (mx - mn).clip(1e-3)
                 margin = 30
+                canvas_h, canvas_w = canvas.shape[:2]
 
                 def to_px(p: np.ndarray) -> tuple[int, int]:
-                    x = int((p[0] - mn[0]) / rng[0] * (fig_w - 2 * margin) + margin)
-                    y = int((p[1] - mn[1]) / rng[1] * (fig_h - 2 * margin) + margin)
-                    return (np.clip(x, 0, fig_w - 1), np.clip(y, 0, fig_h - 1))
+                    x = int((p[0] - mn[0]) / rng[0] * (canvas_w - 2 * margin) + margin)
+                    y = int((p[1] - mn[1]) / rng[1] * (canvas_h - 2 * margin) + margin)
+                    return (np.clip(x, 0, canvas_w - 1), np.clip(y, 0, canvas_h - 1))
 
                 for t in range(len(gt_2d)):
                     if not valid[t]:

--- a/src/tasks/blcs/training/runner.py
+++ b/src/tasks/blcs/training/runner.py
@@ -25,6 +25,23 @@ class BLCSTrainingRunner(BaseTrainingRunner):
     def __init__(self, *, generator_config: GeneratorConfig | None = None) -> None:
         self.generator_config = generator_config
 
+    def _gan_enabled(self, config: Any) -> bool:
+        train_cfg = config.get("training", {}) or {}
+        return bool((train_cfg.get("gan", {}) or {}).get("enabled", False))
+
+    def _apply_gan_runtime_config(self, config: Any) -> None:
+        if not self._gan_enabled(config):
+            raise RuntimeError("GAN runtime config should only be applied when GAN is enabled.")
+        early_cfg = config.training.early_stopping
+        early_cfg.enabled = False
+        trainer_cfg = config.training.trainer
+        trainer_cfg.gradient_clip_val = None
+
+    def prepare_config(self, config: Any) -> None:
+        """Apply BLCS-specific runtime config mutations before training setup."""
+        if self._gan_enabled(config):
+            self._apply_gan_runtime_config(config)
+
     def build_datamodule(self, config: Any) -> pl.LightningDataModule:
         """Build unified BLCS data module."""
         backend = str(config.get("data", {}).get("backend", "npz"))
@@ -65,6 +82,13 @@ class BLCSTrainingRunner(BaseTrainingRunner):
         """Add chunk rotation callback when using chunked backend."""
         extras: list[Any] = []
         from src.tasks.blcs.data.chunked_datamodule import ChunkedBLCSDataModule
+
+        if self._gan_enabled(config):
+            from src.tasks.blcs.training.gan_transition_callback import (
+                GANTransitionCallback,
+            )
+
+            extras.append(GANTransitionCallback(config))
 
         if isinstance(datamodule, ChunkedBLCSDataModule):
             from src.tasks.blcs.training.chunk_rotation_callback import (

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -14,8 +14,9 @@ from src.tasks.blcs.training.runner import BLCSTrainingRunner
 from src.tasks.court_detection.training.runner import CourtDetectionTrainingRunner
 from src.tasks.event_detection.training.runner import EventDetectionTrainingRunner
 from src.tasks.plcs.training.runner import PLCSTrainingRunner
-from src.tasks.trajectory_completion.training.runner import TrajectoryCompletionTrainingRunner
-
+from src.tasks.trajectory_completion.training.runner import (
+    TrajectoryCompletionTrainingRunner,
+)
 
 RunnerFactory = Any  # Callable[[DictConfig], runner_instance]
 
@@ -29,6 +30,7 @@ class SmokeCase:
     overrides: tuple[str, ...]
     supports_test_phase: bool
     expect_qualitative: bool
+    expect_gan_training: bool = False
     runner_factory: RunnerFactory | None = None
 
 
@@ -36,6 +38,7 @@ class SmokeCase:
 class SmokeVariant:
     name: str
     overrides: tuple[str, ...] = ()
+    expect_gan_training: bool = False
 
 
 @dataclass(frozen=True)
@@ -101,6 +104,21 @@ SMOKE_TASK_SPECS = (
         ),
         variants=(
             SmokeVariant(name="single"),
+            SmokeVariant(
+                name="single_gan",
+                overrides=(
+                    "training/gan=lsgan",
+                    "training.trainer.max_epochs=2",
+                    "training.gan.transition.patience=0",
+                    "training.gan.warmup_epochs=1",
+                    "training.gan.discriminator.hidden_dim=32",
+                    "training.gan.discriminator.num_layers=2",
+                    "training.gan.discriminator.num_heads=4",
+                    "training.gan.discriminator.ffn_dim=64",
+                    "training.gan.discriminator.max_seq_len=64",
+                ),
+                expect_gan_training=True,
+            ),
             SmokeVariant(
                 name="multiview",
                 overrides=(
@@ -237,7 +255,24 @@ SMOKE_TASK_SPECS = (
             "model.ffn_dim=64",
             "model.max_seq_len=64",
         ),
-        variants=(SmokeVariant(name="multiview"),),
+        variants=(
+            SmokeVariant(name="multiview"),
+            SmokeVariant(
+                name="multiview_gan",
+                overrides=(
+                    "training/gan=lsgan",
+                    "training.trainer.max_epochs=2",
+                    "training.gan.transition.patience=0",
+                    "training.gan.warmup_epochs=1",
+                    "training.gan.discriminator.hidden_dim=32",
+                    "training.gan.discriminator.num_layers=2",
+                    "training.gan.discriminator.num_heads=4",
+                    "training.gan.discriminator.ffn_dim=64",
+                    "training.gan.discriminator.max_seq_len=64",
+                ),
+                expect_gan_training=True,
+            ),
+        ),
         supports_test_phase=True,
         expect_qualitative=True,
         runner_factory=_blcs_chunked_runner_factory,
@@ -294,6 +329,7 @@ def _build_smoke_cases(task_specs: tuple[SmokeTaskSpec, ...]) -> tuple[SmokeCase
                     ),
                     supports_test_phase=task_spec.supports_test_phase,
                     expect_qualitative=task_spec.expect_qualitative,
+                    expect_gan_training=variant.expect_gan_training,
                     runner_factory=task_spec.runner_factory,
                 )
             )
@@ -346,6 +382,23 @@ def _assert_common_artifacts(output_dir: Path, *, expect_qualitative: bool) -> N
         assert not qualitative_dir.exists()
 
 
+def _assert_gan_training(case: SmokeCase, callbacks: list[Any], lightning_module: Any) -> None:
+    if not case.expect_gan_training:
+        return
+
+    from src.tasks.blcs.training.gan_transition_callback import GANTransitionCallback
+
+    gan_callbacks = [cb for cb in callbacks if isinstance(cb, GANTransitionCallback)]
+    assert gan_callbacks
+
+    gan_callback = gan_callbacks[0]
+    assert gan_callback.has_switched_to_gan
+    assert lightning_module.gan_phase_active
+    assert lightning_module.supervised_only_step_count > 0
+    assert lightning_module.hybrid_gan_step_count > 0
+    assert lightning_module.current_gan_weight > 0
+
+
 @pytest.mark.integration
 @pytest.mark.local_data
 @pytest.mark.slow
@@ -371,6 +424,7 @@ def test_scene_training_smoke_contracts(case: SmokeCase, tmp_path: Path) -> None
     trainer = runner.build_trainer(config, callbacks, logger)
 
     trainer.fit(lightning_module, datamodule=datamodule)
+    _assert_gan_training(case, callbacks, lightning_module)
 
     if case.supports_test_phase:
         trainer.test(lightning_module, datamodule=datamodule)


### PR DESCRIPTION
## Summary

Add BLCS GAN training support with a dedicated discriminator, adversarial losses,
and a transition callback that switches from supervised training into GAN mode.
Keep LightningModule focused on task/model wiring by moving GAN training flow into
an external strategy, and reset the generator/discriminator LR schedule when GAN
training starts so the GAN phase runs on a fresh warmup plus cosine decay cycle.

## Changes

- Add BLCS GAN config, discriminator modules, adversarial loss helpers, and a GAN transition callback/strategy.
- Introduce `prepare_config()` in the base training runner so BLCS can apply GAN runtime config without overriding `save_config()` or callback construction.
- Reset optimizer LR and scheduler state when `_switch_to_gan` fires, so the GAN phase restarts warmup plus cosine decay from the switch point.
- Extend BLCS training smoke tests to cover the GAN configuration path.

## Validation

- `.venv/bin/python -m py_compile src/tasks/blcs/training/lightning_module.py src/tasks/blcs/training/gan_training_strategy.py src/tasks/blcs/training/gan_transition_callback.py src/tasks/blcs/training/runner.py src/tasks/base/training/runner.py`
- `.venv/bin/pytest tests/tasks/test_training_smoke_contracts.py -k 'blcs and (single or single_gan)'`

## Related Issues

- References #382

## Notes

- This PR establishes the BLCS-side GAN training foundation; reuse across PLCS, trajectory completion, and event detection remains follow-up work under #382.
