### PR TITLE
feat: Add ball detection visualization workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 > `assets/` 配下にタスク別の比較GIFを置く想定です（GTとPredを同一画面で比較）。
 
-### WASB（2Dボール検出）
+### Ball Detection（2Dボール検出）
 
 <p align="center">
-  <img src="assets/wasb/gt_vs_pred.gif" width="840" />
+  <img src="assets/ball_detection/game1_clip1_prediction.gif" width="840" />
 </p>
 
-- 実装/実行: [third_party/WASB-SBDT/README.md](third_party/WASB-SBDT/README.md)
+- 実装/実行: [src/tasks/ball_detection/README.md](src/tasks/ball_detection/README.md)
 
 ### Court Detection（CourtKP20）
 
@@ -104,7 +104,7 @@ python -m src.<task>.scripts.<entrypoint> key=value
 
 - [src/tasks/blcs/README.md](src/tasks/blcs/README.md)
 - [src/tasks/plcs/README.md](src/tasks/plcs/README.md)
-- [third_party/WASB-SBDT/README.md](third_party/WASB-SBDT/README.md)
+- [src/tasks/ball_detection/README.md](src/tasks/ball_detection/README.md)
 - [src/tasks/court_detection/README.md](src/tasks/court_detection/README.md)
 - [src/tasks/trajectory_completion/README.md](src/tasks/trajectory_completion/README.md)
 - [src/tasks/event_detection/README.md](src/tasks/event_detection/README.md)
@@ -121,7 +121,7 @@ VS Code を使う場合は `.devcontainer/devcontainer.json` を利用して dev
 
 ### どこに何があるか（タスク）
 
-- WASB: 画像上の2Dボール位置（`third_party/WASB-SBDT`）
+- Ball Detection: 画像上の2Dボール位置（`src/tasks/ball_detection`）
 - Court Detection: 20点コートキーポイント（`src/tasks/court_detection`）
 - PLCS: 2Dスケルトン → コート上3Dプレーヤー位置/yaw（`src/tasks/plcs`）
 - BLCS: 2Dボール位置 → コート上3Dボール軌道（`src/tasks/blcs`）
@@ -135,7 +135,7 @@ VS Code を使う場合は `.devcontainer/devcontainer.json` を利用して dev
 ```
 Video
   ├─ Court Detection  → court_kp (2D)
-  ├─ WASB             → ball_uv (2D)
+  ├─ Ball Detection   → ball_uv (2D)
   ├─ (optional) GVHMR → human_kp (2D) + SMPL (local)
   ├─ PLCS             → player_pos/yaw (3D on court)
   ├─ BLCS             → ball_pos_world (3D on court)

--- a/src/tasks/ball_detection/README.md
+++ b/src/tasks/ball_detection/README.md
@@ -93,6 +93,28 @@ python -m src.tasks.ball_detection.scripts.visualize_augmentation \
 出力は `outputs/ball_detection/augmentation_preview/` に保存されます。  
 上段が元シーケンス、下段が augmentation をすべて有効にしたシーケンスです。
 
+### 推論可視化
+
+```bash
+# 既定の clip / checkpoint で GIF を生成
+python -m src.tasks.ball_detection.scripts.visualize
+
+# clip と出力先を上書き
+python -m src.tasks.ball_detection.scripts.visualize \
+    visualization.clip_dir=data/tennis/game1/Clip1 \
+    visualization.save=assets/ball_detection/game1_clip1_prediction.gif
+```
+
+既定では `outputs/ball_detection/stunet/logs/version_2/checkpoints/ball-detection-epoch=18.ckpt`
+を使い、clip 全体に sliding-window 推論を流して、重なった window の heatmap を
+フレームごとに平均した上で GIF を生成します。
+
+- 左パネル: RGB フレームに GT と予測位置を重ねた表示
+- 右パネル: 予測 heatmap overlay
+- GT は赤、しきい値以上の予測は緑で表示
+
+![Ball detection visualization](../../../assets/ball_detection/game1_clip1_prediction.gif)
+
 ### コード・データのパッケージング
 
 ```bash
@@ -156,8 +178,12 @@ src/tasks/ball_detection/
 ├── configs/
 │   ├── data/rgb_sequence.yaml
 │   ├── model/stunet.yaml
-│   ├── training/default.yaml
+│   ├── preview_heatmaps.yaml
+│   ├── run/visualize.yaml
 │   ├── train.yaml
+│   ├── training/default.yaml
+│   ├── visualize.yaml
+│   ├── visualization/default.yaml
 │   ├── visualize_augmentation.yaml
 │   └── package.yaml
 ├── data/
@@ -169,17 +195,23 @@ src/tasks/ball_detection/
 ├── scripts/
 │   ├── download_videos.py
 │   ├── package.py
+│   ├── preview_heatmaps.py
 │   ├── train.py
+│   ├── visualize.py
 │   └── visualize_augmentation.py
+├── visualization/
+│   ├── orchestrator.py
+│   └── rendering.py
 └── training/
+    ├── lightning_module.py
     ├── losses.py
     ├── metrics.py
-    └── pseudo_labeling.py
+    └── runner.py
 ```
 
 ## 注意点
 
-- `inference/` はまだ実質的な predictor 実装を持っていません。
+- `visualize.py` は clip 全体に対して sliding-window 推論を行い、重なり heatmap を平均して GIF 化します。
 - pseudo-label は `pseudo_label_root/phase_XX/` に phase ごとに保存されます。
 - 生動画ベースの半教師あり学習では `data/tennis/raw/videos/` の準備が前提です。
 - CUDA 上では `MaxPool3d` の backward に deterministic kernel が無い経路があるため、

--- a/src/tasks/ball_detection/configs/run/visualize.yaml
+++ b/src/tasks/ball_detection/configs/run/visualize.yaml
@@ -1,0 +1,2 @@
+output_dir: outputs/ball_detection/visualization
+device: auto

--- a/src/tasks/ball_detection/configs/visualization/default.yaml
+++ b/src/tasks/ball_detection/configs/visualization/default.yaml
@@ -1,0 +1,30 @@
+clip_dir: data/tennis/game1/Clip1
+checkpoint: outputs/ball_detection/stunet/logs/version_2/checkpoints/ball-detection-epoch=18.ckpt
+save: assets/ball_detection/game1_clip1_prediction.gif
+fps: 12
+window_stride: 1
+inference_batch_size: 4
+peak_threshold: ${metrics.peak_threshold}
+max_frames: null
+info: false
+
+draw:
+  gt_radius: 6
+  pred_radius: 6
+  thickness: 2
+  gt_color_rgb: [255, 96, 96]
+  pred_color_rgb: [96, 255, 128]
+  text_color_rgb: [245, 245, 245]
+  muted_text_color_rgb: [168, 168, 168]
+
+layout:
+  header_height: 44
+  tile_gap: 12
+  text_scale: 0.52
+  text_thickness: 1
+  background_rgb: [18, 18, 18]
+  heatmap_alpha: 0.45
+  show_heatmap_panel: true
+
+gif:
+  loop: 0

--- a/src/tasks/ball_detection/configs/visualize.yaml
+++ b/src/tasks/ball_detection/configs/visualize.yaml
@@ -1,0 +1,14 @@
+defaults:
+  - model: stunet
+  - data: rgb_sequence
+  - metrics: default
+  - visualization: default
+  - run: visualize
+  - _self_
+
+hydra:
+  run:
+    dir: ${run.output_dir}/${now:%Y-%m-%d_%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/tasks/ball_detection/inference/predictor.py
+++ b/src/tasks/ball_detection/inference/predictor.py
@@ -10,7 +10,9 @@ import torch
 from torch import Tensor
 
 from src.tasks.ball_detection.data.utils.input_adapter import to_model_input
-from src.tasks.ball_detection.training.lightning_module import BallDetectionLightningModule
+from src.tasks.ball_detection.training.lightning_module import (
+    BallDetectionLightningModule,
+)
 from src.tasks.base.inference.predictor import BasePredictor
 from src.utils.data.heatmaps import heatmaps_to_argmax
 
@@ -61,11 +63,19 @@ class BallDetectionPredictor(BasePredictor):
             FileNotFoundError: If checkpoint file does not exist.
         """
         checkpoints = cls._ensure_checkpoint(checkpoint_path)
+        if len(checkpoints) != 1:
+            raise ValueError(
+                "BallDetectionPredictor expects a single checkpoint, "
+                f"got {len(checkpoints)} checkpoints."
+            )
         resolved_device = cls._resolve_device(device)
 
         lightning_module = BallDetectionLightningModule.load_from_checkpoint(
             checkpoints[0],
             map_location=resolved_device,
+            strict=bool(kwargs.pop("strict", False)),
+            weights_only=bool(kwargs.pop("weights_only", False)),
+            **kwargs,
         )
 
         model = lightning_module.model
@@ -73,7 +83,6 @@ class BallDetectionPredictor(BasePredictor):
 
         return cls(model=model, device=resolved_device, model_config=model_config)
 
-    @torch.no_grad()
     def predict(
         self,
         images: Tensor,
@@ -94,18 +103,19 @@ class BallDetectionPredictor(BasePredictor):
                 - ``heatmaps``: Probability heatmaps ``(B, T, H, W)`` if
                   *return_heatmaps* is True.
         """
-        model_input = to_model_input(images.to(self.device), self.model_config)
-        logits = self.model(model_input)
+        with torch.no_grad():
+            model_input = to_model_input(images.to(self.device), self.model_config)
+            logits = self.model(model_input)
 
-        # (B, 1, T, H, W) -> (B, T, H, W)
-        logits = logits.squeeze(1)
-        heatmaps = torch.sigmoid(logits)
-        coords, peak_values = heatmaps_to_argmax(heatmaps)
+            # (B, 1, T, H, W) -> (B, T, H, W)
+            logits = logits.squeeze(1)
+            heatmaps = torch.sigmoid(logits)
+            coords, peak_values = heatmaps_to_argmax(heatmaps)
 
-        result: dict[str, Tensor] = {
-            "coords": coords.cpu(),
-            "visibility": peak_values.cpu(),
-        }
-        if return_heatmaps:
-            result["heatmaps"] = heatmaps.cpu()
-        return result
+            result: dict[str, Tensor] = {
+                "coords": coords.cpu(),
+                "visibility": peak_values.cpu(),
+            }
+            if return_heatmaps:
+                result["heatmaps"] = heatmaps.cpu()
+            return result

--- a/src/tasks/ball_detection/scripts/visualize.py
+++ b/src/tasks/ball_detection/scripts/visualize.py
@@ -1,0 +1,43 @@
+"""Visualize ball detection predictions for one clip.
+
+Usage:
+    python -m src.tasks.ball_detection.scripts.visualize
+    python -m src.tasks.ball_detection.scripts.visualize visualization.clip_dir=data/tennis/game1/Clip1
+    python -m src.tasks.ball_detection.scripts.visualize visualization.save=assets/ball_detection/custom_clip.gif
+
+Notes:
+    - Hydra loads configuration from `src/tasks/ball_detection/configs/visualize.yaml`.
+    - The script runs sliding-window inference over one clip and saves an animated GIF.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
+
+import hydra
+from omegaconf import DictConfig
+
+from src.tasks.ball_detection.visualization.orchestrator import (
+    build_runtime_config,
+    run_visualization,
+)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
+    """Typed wrapper for ``hydra.main``."""
+    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+
+
+@hydra_main(config_path="../configs", config_name="visualize", version_base="1.3")
+def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
+    """Hydra entry point."""
+    runtime = build_runtime_config(cfg)
+    return run_visualization(runtime)
+
+
+if __name__ == "__main__":
+    sys.exit(cast(Callable[[], int], main)())

--- a/src/tasks/ball_detection/visualization/__init__.py
+++ b/src/tasks/ball_detection/visualization/__init__.py
@@ -1,0 +1,13 @@
+"""Public visualization entry points for ball detection."""
+
+from src.tasks.ball_detection.visualization.orchestrator import (
+    RuntimeConfig,
+    build_runtime_config,
+    run_visualization,
+)
+
+__all__ = [
+    "RuntimeConfig",
+    "build_runtime_config",
+    "run_visualization",
+]

--- a/src/tasks/ball_detection/visualization/orchestrator.py
+++ b/src/tasks/ball_detection/visualization/orchestrator.py
@@ -1,0 +1,411 @@
+"""Orchestrate clip-level ball detection prediction visualizations."""
+
+from __future__ import annotations
+
+import csv
+import logging
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import torch
+from hydra.utils import to_absolute_path
+from omegaconf import DictConfig
+
+from src.tasks.ball_detection.data.argumentation import normalize_tensor_images_imagenet
+from src.tasks.ball_detection.inference import BallDetectionPredictor
+from src.tasks.ball_detection.visualization.rendering import (
+    DrawStyle,
+    LayoutStyle,
+    render_animation_frames,
+    save_gif,
+)
+from src.utils.data.heatmaps import heatmaps_to_argmax
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    """Resolved runtime settings for ball detection visualization."""
+
+    clip_dir: Path
+    checkpoint: Path
+    save: Path
+    device: str
+    fps: float
+    window_stride: int
+    inference_batch_size: int
+    sequence_length: int
+    image_size_hw: tuple[int, int]
+    peak_threshold: float
+    max_frames: int | None
+    normalize_imagenet: bool
+    imagenet_mean: tuple[float, float, float]
+    imagenet_std: tuple[float, float, float]
+    gif_loop: int
+    info: bool
+    clip_label: str
+    draw: DrawStyle
+    layout: LayoutStyle
+
+
+@dataclass(frozen=True)
+class FrameLabel:
+    """Ground-truth label for one frame."""
+
+    visibility: float
+    x: float
+    y: float
+
+
+@dataclass(frozen=True)
+class ClipSequence:
+    """Loaded and preprocessed clip data for inference and rendering."""
+
+    frame_names: tuple[str, ...]
+    render_frames_rgb: tuple[torch.Tensor, ...]
+    model_images: torch.Tensor
+    gt_coords_px: torch.Tensor
+    gt_visibility: torch.Tensor
+
+
+@dataclass(frozen=True)
+class PredictionSequence:
+    """Aggregated per-frame predictions for one clip."""
+
+    heatmaps: torch.Tensor
+    coords_px: torch.Tensor
+    confidences: torch.Tensor
+    visibility: torch.Tensor
+
+
+def build_runtime_config(cfg: DictConfig) -> RuntimeConfig:
+    """Build runtime config from composed Hydra config."""
+    vis = cfg.visualization
+    run = cfg.get("run", {})
+    data_cfg = cfg.get("data", {})
+    metrics_cfg = cfg.get("metrics", {})
+
+    clip_dir = Path(to_absolute_path(str(vis.clip_dir)))
+    checkpoint = Path(to_absolute_path(str(vis.checkpoint)))
+    output_dir = Path(to_absolute_path(str(run.get("output_dir", "outputs/ball_detection/visualization"))))
+    save_raw = vis.get("save")
+    save_path = (
+        Path(to_absolute_path(str(save_raw)))
+        if save_raw
+        else output_dir / _default_gif_name(clip_dir)
+    )
+
+    image_size_hw = _parse_hw(data_cfg.get("image_size", [288, 512]), name="data.image_size")
+    sequence_length = int(cfg.model.get("num_frames", 8))
+    window_stride = int(vis.get("window_stride", 1))
+    if window_stride <= 0 or window_stride > sequence_length:
+        raise ValueError(
+            f"visualization.window_stride must be in [1, {sequence_length}], got {window_stride}."
+        )
+
+    inference_batch_size = int(vis.get("inference_batch_size", 4))
+    if inference_batch_size <= 0:
+        raise ValueError("visualization.inference_batch_size must be positive.")
+
+    fps = float(vis.get("fps", 12.0))
+    if fps <= 0:
+        raise ValueError("visualization.fps must be positive.")
+
+    max_frames_raw = vis.get("max_frames")
+    max_frames = None if max_frames_raw in {None, "", 0} else int(max_frames_raw)
+    if max_frames is not None and max_frames <= 0:
+        raise ValueError("visualization.max_frames must be positive when set.")
+
+    normalize_cfg = data_cfg.get("augmentation", {}).get("normalize_imagenet", {})
+    normalize_imagenet = bool(normalize_cfg.get("enabled", False))
+    imagenet_mean = _parse_float_triplet(
+        normalize_cfg.get("mean", (0.485, 0.456, 0.406)),
+        name="data.augmentation.normalize_imagenet.mean",
+    )
+    imagenet_std = _parse_float_triplet(
+        normalize_cfg.get("std", (0.229, 0.224, 0.225)),
+        name="data.augmentation.normalize_imagenet.std",
+    )
+
+    draw_cfg = vis.get("draw", {})
+    layout_cfg = vis.get("layout", {})
+    gif_cfg = vis.get("gif", {})
+
+    return RuntimeConfig(
+        clip_dir=clip_dir,
+        checkpoint=checkpoint,
+        save=save_path,
+        device=_resolve_device(str(run.get("device", "auto"))),
+        fps=fps,
+        window_stride=window_stride,
+        inference_batch_size=inference_batch_size,
+        sequence_length=sequence_length,
+        image_size_hw=image_size_hw,
+        peak_threshold=float(vis.get("peak_threshold", metrics_cfg.get("peak_threshold", 0.5))),
+        max_frames=max_frames,
+        normalize_imagenet=normalize_imagenet,
+        imagenet_mean=imagenet_mean,
+        imagenet_std=imagenet_std,
+        gif_loop=int(gif_cfg.get("loop", 0)),
+        info=bool(vis.get("info", False)),
+        clip_label=f"{clip_dir.parent.name}/{clip_dir.name}",
+        draw=DrawStyle(
+            gt_radius=int(draw_cfg.get("gt_radius", 6)),
+            pred_radius=int(draw_cfg.get("pred_radius", 6)),
+            thickness=int(draw_cfg.get("thickness", 2)),
+            gt_color_rgb=_parse_rgb(draw_cfg.get("gt_color_rgb", [255, 96, 96]), name="visualization.draw.gt_color_rgb"),
+            pred_color_rgb=_parse_rgb(draw_cfg.get("pred_color_rgb", [96, 255, 128]), name="visualization.draw.pred_color_rgb"),
+            text_color_rgb=_parse_rgb(draw_cfg.get("text_color_rgb", [245, 245, 245]), name="visualization.draw.text_color_rgb"),
+            muted_text_color_rgb=_parse_rgb(draw_cfg.get("muted_text_color_rgb", [168, 168, 168]), name="visualization.draw.muted_text_color_rgb"),
+        ),
+        layout=LayoutStyle(
+            header_height=int(layout_cfg.get("header_height", 44)),
+            tile_gap=int(layout_cfg.get("tile_gap", 12)),
+            text_scale=float(layout_cfg.get("text_scale", 0.52)),
+            text_thickness=int(layout_cfg.get("text_thickness", 1)),
+            background_rgb=_parse_rgb(layout_cfg.get("background_rgb", [18, 18, 18]), name="visualization.layout.background_rgb"),
+            heatmap_alpha=float(layout_cfg.get("heatmap_alpha", 0.45)),
+            show_heatmap_panel=bool(layout_cfg.get("show_heatmap_panel", True)),
+        ),
+    )
+
+
+def run_visualization(cfg: RuntimeConfig) -> int:
+    """Run clip-level visualization and save a GIF."""
+    clip = _load_clip_sequence(cfg)
+
+    logger.info("Loaded clip %s with %d frames.", cfg.clip_label, len(clip.frame_names))
+    if cfg.info:
+        logger.info("Checkpoint: %s", cfg.checkpoint)
+        logger.info("Save path: %s", cfg.save)
+        logger.info("Sequence length: %d", cfg.sequence_length)
+        logger.info("Window stride: %d", cfg.window_stride)
+        return 0
+
+    predictor = BallDetectionPredictor.load_from_checkpoint(
+        cfg.checkpoint,
+        device=cfg.device,
+    )
+    predictions = _predict_clip(cfg=cfg, clip=clip, predictor=predictor)
+
+    rendered_frames = render_animation_frames(
+        frames_rgb=[frame.cpu().numpy() for frame in clip.render_frames_rgb],
+        frame_names=clip.frame_names,
+        gt_coords_px=[_coord_tensor_to_tuple(coord) for coord in clip.gt_coords_px],
+        gt_visibility=[bool(value.item() > 0.5) for value in clip.gt_visibility],
+        pred_coords_px=[_coord_tensor_to_tuple(coord) for coord in predictions.coords_px],
+        pred_visibility=[bool(value.item()) for value in predictions.visibility],
+        pred_confidences=[float(value.item()) for value in predictions.confidences],
+        pred_heatmaps=[heatmap.cpu().numpy() for heatmap in predictions.heatmaps],
+        peak_threshold=cfg.peak_threshold,
+        clip_label=cfg.clip_label,
+        draw=cfg.draw,
+        layout=cfg.layout,
+    )
+    save_gif(
+        frames_rgb=rendered_frames,
+        path=cfg.save,
+        fps=cfg.fps,
+        loop=cfg.gif_loop,
+    )
+    logger.info("Saved clip visualization to %s", cfg.save)
+    return 0
+
+
+def _load_clip_sequence(cfg: RuntimeConfig) -> ClipSequence:
+    label_path = cfg.clip_dir / "Label.csv"
+    if not cfg.clip_dir.exists():
+        raise FileNotFoundError(f"Clip directory not found: {cfg.clip_dir}")
+    if not label_path.exists():
+        raise FileNotFoundError(f"Label.csv not found for clip: {cfg.clip_dir}")
+
+    frame_paths = sorted(cfg.clip_dir.glob("*.jpg"))
+    if cfg.max_frames is not None:
+        frame_paths = frame_paths[: cfg.max_frames]
+    if len(frame_paths) < cfg.sequence_length:
+        raise ValueError(
+            f"Clip {cfg.clip_dir} has only {len(frame_paths)} frames, but model.num_frames={cfg.sequence_length}."
+        )
+
+    labels = _read_label_csv(label_path)
+    image_height, image_width = cfg.image_size_hw
+    render_frames_rgb: list[torch.Tensor] = []
+    model_frames: list[torch.Tensor] = []
+    gt_coords_px: list[tuple[float, float]] = []
+    gt_visibility: list[float] = []
+    frame_names: list[str] = []
+
+    for frame_path in frame_paths:
+        frame_bgr = cv2.imread(str(frame_path))
+        if frame_bgr is None:
+            raise RuntimeError(f"Failed to read frame: {frame_path}")
+
+        frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+        original_height, original_width = frame_rgb.shape[:2]
+        resized_rgb = cv2.resize(
+            frame_rgb,
+            (image_width, image_height),
+            interpolation=cv2.INTER_LINEAR,
+        )
+
+        render_frames_rgb.append(torch.from_numpy(resized_rgb.copy()).to(torch.uint8))
+
+        model_frame = torch.from_numpy(resized_rgb.transpose(2, 0, 1)).to(torch.float32) / 255.0
+        model_frames.append(model_frame)
+
+        label = labels.get(frame_path.name, FrameLabel(visibility=0.0, x=0.0, y=0.0))
+        if label.visibility > 0:
+            gt_coords_px.append(
+                (
+                    label.x * image_width / max(original_width, 1),
+                    label.y * image_height / max(original_height, 1),
+                )
+            )
+            gt_visibility.append(1.0)
+        else:
+            gt_coords_px.append((0.0, 0.0))
+            gt_visibility.append(0.0)
+
+        frame_names.append(frame_path.name)
+
+    model_images = torch.stack(model_frames, dim=0)
+    if cfg.normalize_imagenet:
+        model_images = normalize_tensor_images_imagenet(
+            model_images,
+            mean=cfg.imagenet_mean,
+            std=cfg.imagenet_std,
+        )
+
+    return ClipSequence(
+        frame_names=tuple(frame_names),
+        render_frames_rgb=tuple(render_frames_rgb),
+        model_images=model_images,
+        gt_coords_px=torch.tensor(gt_coords_px, dtype=torch.float32),
+        gt_visibility=torch.tensor(gt_visibility, dtype=torch.float32),
+    )
+
+
+def _predict_clip(
+    *,
+    cfg: RuntimeConfig,
+    clip: ClipSequence,
+    predictor: BallDetectionPredictor,
+) -> PredictionSequence:
+    window_starts = _build_window_starts(
+        frame_count=len(clip.frame_names),
+        sequence_length=cfg.sequence_length,
+        stride=cfg.window_stride,
+    )
+    logger.info("Running predictor over %d overlapping window(s).", len(window_starts))
+
+    heatmap_sum: torch.Tensor | None = None
+    heatmap_count = torch.zeros(len(clip.frame_names), dtype=torch.float32)
+
+    for start_chunk in _chunked(window_starts, cfg.inference_batch_size):
+        batch = torch.stack(
+            [clip.model_images[start : start + cfg.sequence_length] for start in start_chunk],
+            dim=0,
+        )
+        outputs = predictor.predict(batch, return_heatmaps=True)
+        batch_heatmaps = outputs["heatmaps"].to(torch.float32)
+
+        if heatmap_sum is None:
+            heatmap_sum = torch.zeros(
+                (len(clip.frame_names), *batch_heatmaps.shape[-2:]),
+                dtype=torch.float32,
+            )
+
+        for window_index, start in enumerate(start_chunk):
+            end = start + cfg.sequence_length
+            heatmap_sum[start:end] += batch_heatmaps[window_index]
+            heatmap_count[start:end] += 1.0
+
+    if heatmap_sum is None:
+        raise RuntimeError("Failed to aggregate prediction heatmaps for the clip.")
+
+    averaged_heatmaps = heatmap_sum / torch.clamp(heatmap_count, min=1.0).view(-1, 1, 1)
+    coords_normalized, confidences = heatmaps_to_argmax(averaged_heatmaps)
+
+    image_height, image_width = cfg.image_size_hw
+    coords_px = torch.empty_like(coords_normalized)
+    coords_px[:, 0] = coords_normalized[:, 0] * max(image_width - 1, 0)
+    coords_px[:, 1] = coords_normalized[:, 1] * max(image_height - 1, 0)
+    visibility = confidences >= cfg.peak_threshold
+
+    return PredictionSequence(
+        heatmaps=averaged_heatmaps,
+        coords_px=coords_px,
+        confidences=confidences,
+        visibility=visibility,
+    )
+
+
+def _build_window_starts(*, frame_count: int, sequence_length: int, stride: int) -> list[int]:
+    if frame_count < sequence_length:
+        raise ValueError(
+            f"frame_count must be >= sequence_length, got {frame_count} < {sequence_length}."
+        )
+
+    starts = list(range(0, frame_count - sequence_length + 1, stride))
+    last_start = frame_count - sequence_length
+    if starts[-1] != last_start:
+        starts.append(last_start)
+    return starts
+
+
+def _chunked(values: Sequence[int], chunk_size: int) -> Iterator[list[int]]:
+    for start_index in range(0, len(values), chunk_size):
+        yield list(values[start_index : start_index + chunk_size])
+
+
+def _read_label_csv(path: Path) -> dict[str, FrameLabel]:
+    labels: dict[str, FrameLabel] = {}
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        required_fields = {"file name", "visibility", "x-coordinate", "y-coordinate"}
+        missing = required_fields.difference(reader.fieldnames or [])
+        if missing:
+            raise ValueError(f"Missing required CSV columns in {path}: {sorted(missing)}")
+        for row in reader:
+            frame_name = str(row["file name"]).strip()
+            labels[frame_name] = FrameLabel(
+                visibility=float(row["visibility"] or 0.0),
+                x=float(row["x-coordinate"] or 0.0),
+                y=float(row["y-coordinate"] or 0.0),
+            )
+    return labels
+
+
+def _resolve_device(device: str) -> str:
+    if device == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    return device
+
+
+def _parse_hw(value: object, *, name: str) -> tuple[int, int]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)) or len(value) != 2:
+        raise ValueError(f"{name} must be a length-2 sequence.")
+    return int(value[0]), int(value[1])
+
+
+def _parse_rgb(value: object, *, name: str) -> tuple[int, int, int]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)) or len(value) != 3:
+        raise ValueError(f"{name} must be a length-3 RGB sequence.")
+    return int(value[0]), int(value[1]), int(value[2])
+
+
+def _parse_float_triplet(value: object, *, name: str) -> tuple[float, float, float]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)) or len(value) != 3:
+        raise ValueError(f"{name} must be a length-3 sequence.")
+    return float(value[0]), float(value[1]), float(value[2])
+
+
+def _default_gif_name(clip_dir: Path) -> str:
+    return f"{clip_dir.parent.name.lower()}_{clip_dir.name.lower()}_prediction.gif"
+
+
+def _coord_tensor_to_tuple(coord: torch.Tensor) -> tuple[float, float]:
+    return float(coord[0].item()), float(coord[1].item())

--- a/src/tasks/ball_detection/visualization/rendering.py
+++ b/src/tasks/ball_detection/visualization/rendering.py
@@ -1,0 +1,301 @@
+"""Rendering helpers for clip-level ball detection visualizations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import cv2
+import numpy as np
+from PIL import Image
+
+
+@dataclass(frozen=True)
+class DrawStyle:
+    """Marker and text styling for rendered frames."""
+
+    gt_radius: int
+    pred_radius: int
+    thickness: int
+    gt_color_rgb: tuple[int, int, int]
+    pred_color_rgb: tuple[int, int, int]
+    text_color_rgb: tuple[int, int, int]
+    muted_text_color_rgb: tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class LayoutStyle:
+    """Layout settings for rendered visualization frames."""
+
+    header_height: int
+    tile_gap: int
+    text_scale: float
+    text_thickness: int
+    background_rgb: tuple[int, int, int]
+    heatmap_alpha: float
+    show_heatmap_panel: bool
+
+
+def render_animation_frames(
+    *,
+    frames_rgb: Sequence[np.ndarray],
+    frame_names: Sequence[str],
+    gt_coords_px: Sequence[tuple[float, float]],
+    gt_visibility: Sequence[bool],
+    pred_coords_px: Sequence[tuple[float, float]],
+    pred_visibility: Sequence[bool],
+    pred_confidences: Sequence[float],
+    pred_heatmaps: Sequence[np.ndarray],
+    peak_threshold: float,
+    clip_label: str,
+    draw: DrawStyle,
+    layout: LayoutStyle,
+) -> list[np.ndarray]:
+    """Render animation frames for one clip."""
+    rendered_frames: list[np.ndarray] = []
+    total_frames = len(frames_rgb)
+
+    for frame_index, (
+        frame_rgb,
+        frame_name,
+        gt_coord_px,
+        gt_is_visible,
+        pred_coord_px,
+        pred_is_visible,
+        pred_confidence,
+        pred_heatmap,
+    ) in enumerate(
+        zip(
+            frames_rgb,
+            frame_names,
+            gt_coords_px,
+            gt_visibility,
+            pred_coords_px,
+            pred_visibility,
+            pred_confidences,
+            pred_heatmaps,
+            strict=True,
+        )
+    ):
+        panels = [
+            _render_prediction_panel(
+                frame_rgb=frame_rgb,
+                gt_coord_px=gt_coord_px,
+                gt_is_visible=gt_is_visible,
+                pred_coord_px=pred_coord_px,
+                pred_is_visible=pred_is_visible,
+                draw=draw,
+            )
+        ]
+
+        if layout.show_heatmap_panel:
+            panels.append(
+                _render_heatmap_panel(
+                    frame_rgb=frame_rgb,
+                    heatmap=pred_heatmap,
+                    gt_coord_px=gt_coord_px,
+                    gt_is_visible=gt_is_visible,
+                    pred_coord_px=pred_coord_px,
+                    pred_is_visible=pred_is_visible,
+                    draw=draw,
+                    layout=layout,
+                )
+            )
+
+        body = _compose_panels(
+            panels=panels,
+            tile_gap=layout.tile_gap,
+            background_rgb=layout.background_rgb,
+        )
+        header = np.full(
+            (layout.header_height, body.shape[1], 3),
+            layout.background_rgb,
+            dtype=np.uint8,
+        )
+
+        header_line_1 = f"{clip_label} | frame {frame_index + 1}/{total_frames} | {frame_name}"
+        visibility_text = "visible" if gt_is_visible else "hidden"
+        threshold_suffix = "drawn" if pred_is_visible else f"below {peak_threshold:.2f}"
+        header_line_2 = (
+            f"GT: {visibility_text} | Pred confidence: {pred_confidence:.3f} ({threshold_suffix})"
+        )
+
+        cv2.putText(
+            header,
+            header_line_1,
+            (8, 18),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            layout.text_scale,
+            draw.text_color_rgb,
+            layout.text_thickness,
+            lineType=cv2.LINE_AA,
+        )
+        cv2.putText(
+            header,
+            header_line_2,
+            (8, max(layout.header_height - 10, 30)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            layout.text_scale,
+            draw.text_color_rgb if pred_is_visible else draw.muted_text_color_rgb,
+            layout.text_thickness,
+            lineType=cv2.LINE_AA,
+        )
+
+        rendered_frames.append(np.concatenate([header, body], axis=0))
+
+    return rendered_frames
+
+
+def save_gif(
+    *,
+    frames_rgb: Sequence[np.ndarray],
+    path: Path,
+    fps: float,
+    loop: int = 0,
+) -> None:
+    """Save rendered RGB frames as an animated GIF."""
+    if not frames_rgb:
+        raise ValueError("At least one frame is required to save a GIF.")
+    if fps <= 0:
+        raise ValueError("fps must be positive.")
+    if path.suffix.lower() != ".gif":
+        raise ValueError(f"Only .gif outputs are supported, got: {path}")
+
+    duration_ms = max(int(round(1000.0 / fps)), 1)
+    pil_frames = [
+        Image.fromarray(frame).convert(
+            "P",
+            palette=Image.Palette.ADAPTIVE,
+            colors=256,
+        )
+        for frame in frames_rgb
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pil_frames[0].save(
+        path,
+        save_all=True,
+        append_images=pil_frames[1:],
+        duration=duration_ms,
+        loop=loop,
+        disposal=2,
+        optimize=True,
+    )
+
+
+def _render_prediction_panel(
+    *,
+    frame_rgb: np.ndarray,
+    gt_coord_px: tuple[float, float],
+    gt_is_visible: bool,
+    pred_coord_px: tuple[float, float],
+    pred_is_visible: bool,
+    draw: DrawStyle,
+) -> np.ndarray:
+    panel = frame_rgb.copy()
+    if gt_is_visible:
+        _draw_point(
+            panel,
+            coord_px=gt_coord_px,
+            radius=draw.gt_radius,
+            color_rgb=draw.gt_color_rgb,
+            thickness=draw.thickness,
+        )
+    if pred_is_visible:
+        _draw_point(
+            panel,
+            coord_px=pred_coord_px,
+            radius=draw.pred_radius,
+            color_rgb=draw.pred_color_rgb,
+            thickness=draw.thickness,
+        )
+    return panel
+
+
+def _render_heatmap_panel(
+    *,
+    frame_rgb: np.ndarray,
+    heatmap: np.ndarray,
+    gt_coord_px: tuple[float, float],
+    gt_is_visible: bool,
+    pred_coord_px: tuple[float, float],
+    pred_is_visible: bool,
+    draw: DrawStyle,
+    layout: LayoutStyle,
+) -> np.ndarray:
+    panel = frame_rgb.copy()
+    heatmap_uint8 = np.clip(heatmap, 0.0, 1.0)
+    heatmap_uint8 = (heatmap_uint8 * 255.0).astype(np.uint8)
+    heatmap_color = cv2.applyColorMap(heatmap_uint8, cv2.COLORMAP_JET)
+    heatmap_color = cv2.cvtColor(heatmap_color, cv2.COLOR_BGR2RGB)
+    heatmap_color = cv2.resize(
+        heatmap_color,
+        (panel.shape[1], panel.shape[0]),
+        interpolation=cv2.INTER_LINEAR,
+    )
+    panel = cv2.addWeighted(panel, 1.0 - layout.heatmap_alpha, heatmap_color, layout.heatmap_alpha, 0.0)
+
+    if gt_is_visible:
+        _draw_point(
+            panel,
+            coord_px=gt_coord_px,
+            radius=draw.gt_radius,
+            color_rgb=draw.gt_color_rgb,
+            thickness=draw.thickness,
+        )
+    if pred_is_visible:
+        _draw_point(
+            panel,
+            coord_px=pred_coord_px,
+            radius=draw.pred_radius,
+            color_rgb=draw.pred_color_rgb,
+            thickness=draw.thickness,
+        )
+
+    return cast(np.ndarray, panel)
+
+
+def _draw_point(
+    image_rgb: np.ndarray,
+    *,
+    coord_px: tuple[float, float],
+    radius: int,
+    color_rgb: tuple[int, int, int],
+    thickness: int,
+) -> None:
+    x_coord = int(round(coord_px[0]))
+    y_coord = int(round(coord_px[1]))
+    cv2.circle(
+        image_rgb,
+        (x_coord, y_coord),
+        radius,
+        color_rgb,
+        thickness=thickness,
+        lineType=cv2.LINE_AA,
+    )
+
+
+def _compose_panels(
+    *,
+    panels: Sequence[np.ndarray],
+    tile_gap: int,
+    background_rgb: tuple[int, int, int],
+) -> np.ndarray:
+    if not panels:
+        raise ValueError("At least one panel is required.")
+
+    panel_height = panels[0].shape[0]
+    panel_width = panels[0].shape[1]
+    canvas_width = len(panels) * panel_width + (len(panels) - 1) * tile_gap
+    canvas = np.full(
+        (panel_height, canvas_width, 3),
+        background_rgb,
+        dtype=np.uint8,
+    )
+
+    cursor_x = 0
+    for panel in panels:
+        canvas[:, cursor_x : cursor_x + panel_width] = panel
+        cursor_x += panel_width + tile_gap
+    return cast(np.ndarray, canvas)


### PR DESCRIPTION
## Summary

- Add a clip-level visualization workflow for `src/tasks/ball_detection` that renders prediction GIFs from sliding-window inference.
- Update the root README to reference the current `ball_detection` task and demo asset instead of deprecated WASB paths.

## Changes

- Add Hydra configs, CLI entrypoint, orchestration, and rendering helpers for ball detection visualization.
- Export the visualization module API and tighten predictor checkpoint loading behavior used by the visualization path.
- Document the workflow in `src/tasks/ball_detection/README.md` and replace WASB references in `README.md`.

## Validation

- `.venv/bin/python -m src.tasks.ball_detection.scripts.visualize visualization.info=true visualization.max_frames=8`

## Related Issues

- Closes #392

## Notes

- The PR includes `assets/ball_detection/game1_clip1_prediction.gif` as a generated demo artifact.
