### PR TITLE
fix: Correct BLCS LSGAN max_seq_len config reference

### DIFF
--- a/src/tasks/blcs/configs/training/gan/lsgan.yaml
+++ b/src/tasks/blcs/configs/training/gan/lsgan.yaml
@@ -21,6 +21,6 @@ discriminator:
   dropout: 0.1
   rope_dim: null
   rope_theta: 10000.0
-  max_seq_len: ${data.max_seq_len}
+  max_seq_len: ${model.max_seq_len}
   invisible_init_std: 0.02
   cls_init_std: 0.02


### PR DESCRIPTION
## Summary

- Fix the BLCS LSGAN discriminator config to read `max_seq_len` from `model` instead of `data`.
- Avoid the runtime interpolation error caused by `data.max_seq_len` not existing in this config path.

## Changes

- Update `src/tasks/blcs/configs/training/gan/lsgan.yaml` from `${data.max_seq_len}` to `${model.max_seq_len}`.
- Keep the fix scoped to the broken default config reference.
- Document that validation was intentionally skipped for this change.

## Validation

- Not run, per request.

## Related Issues

- References #

## Notes

- Existing tests override this value, so they do not exercise the broken default config path.
