### PR TITLE
refactor: Localize worker count validation

### DIFF
--- a/src/tasks/blcs/configs/data/chunked_multi.yaml
+++ b/src/tasks/blcs/configs/data/chunked_multi.yaml
@@ -27,7 +27,7 @@ chunk:
   epochs_per_chunk: 3
   prefetch_chunks: 3
   chunks_dir: "data/blcs/chunks"
-  generation_workers: 8  # parallel scene generation workers (0 = sequential)
+  generation_workers: 8  # parallel scene generation workers (must be >= 1)
 
 # Augmentation
 augmentation:

--- a/src/tasks/blcs/data/chunk_manager.py
+++ b/src/tasks/blcs/data/chunk_manager.py
@@ -8,14 +8,13 @@ from pathlib import Path
 from src.tasks.base.data.chunk_manager import (
     ChunkGenerator,
     ChunkInfo,
-    ChunkManager as BaseChunkManager,
     ChunkState,
 )
-from src.tasks.blcs.generate_dataset.io.dataset_io import BLCSDatasetWriter
-from src.tasks.blcs.generate_dataset.scene_generator import (
-    BLCSSceneGenerator,
-    GeneratorConfig,
+from src.tasks.base.data.chunk_manager import (
+    ChunkManager as BaseChunkManager,
 )
+from src.tasks.blcs.generate_dataset.io.dataset_io import BLCSDatasetWriter
+from src.tasks.blcs.generate_dataset.scene_generator import GeneratorConfig
 from src.tasks.blcs.generate_dataset.utils.parallel_runner import (
     generate_parallel_scenes,
 )
@@ -32,7 +31,6 @@ class _BLCSChunkGenerator:
         self.generator_config = generator_config
         self.generator_device = generator_device
         self.generation_workers = generation_workers
-        self._generator: BLCSSceneGenerator | None = None
 
     def __call__(
         self,
@@ -42,30 +40,15 @@ class _BLCSChunkGenerator:
         stop_event: threading.Event,
     ) -> None:
         writer = BLCSDatasetWriter(str(chunk_dir))
-        if self.generation_workers > 0:
-            for scene_data in generate_parallel_scenes(
-                generator_config=self.generator_config,
-                device=self.generator_device,
-                num_scenes=num_scenes,
-                num_workers=self.generation_workers,
-            ):
-                if stop_event.is_set():
-                    break
-                writer.save_scene(scene_data)
-            return
-
-        for scene_data in self._get_generator().generate(num_scenes):
+        for scene_data in generate_parallel_scenes(
+            generator_config=self.generator_config,
+            device=self.generator_device,
+            num_scenes=num_scenes,
+            num_workers=self.generation_workers,
+        ):
             if stop_event.is_set():
                 break
             writer.save_scene(scene_data)
-
-    def _get_generator(self) -> BLCSSceneGenerator:
-        if self._generator is None:
-            self._generator = BLCSSceneGenerator(
-                config=self.generator_config,
-                device=self.generator_device,
-            )
-        return self._generator
 
 
 class ChunkManager(BaseChunkManager):
@@ -80,7 +63,7 @@ class ChunkManager(BaseChunkManager):
         epochs_per_chunk: int = 3,
         prefetch_chunks: int = 1,
         generator_device: str = "cpu",
-        generation_workers: int = 0,
+        generation_workers: int = 1,
     ) -> None:
         self.generator_config = generator_config
         self.generator_device = generator_device
@@ -91,7 +74,7 @@ class ChunkManager(BaseChunkManager):
             chunk_generator_factory=lambda: _BLCSChunkGenerator(
                 generator_config=generator_config,
                 generator_device=generator_device,
-                generation_workers=generation_workers,
+                generation_workers=self.generation_workers,
             ),
             scenes_per_chunk=scenes_per_chunk,
             epochs_per_chunk=epochs_per_chunk,

--- a/src/tasks/blcs/data/chunked_datamodule.py
+++ b/src/tasks/blcs/data/chunked_datamodule.py
@@ -44,7 +44,7 @@ class ChunkedBLCSDataModule(BLCSDataModule):
         self.epochs_per_chunk = int(chunk_cfg.get("epochs_per_chunk", 3))
         self.prefetch_chunks = int(chunk_cfg.get("prefetch_chunks", 1))
         self.chunks_dir = Path(chunk_cfg.get("chunks_dir", "data/blcs/chunks"))
-        self.generation_workers = int(chunk_cfg.get("generation_workers", 0))
+        self.generation_workers = int(chunk_cfg.get("generation_workers", 1))
         self.generator_device = str(data_cfg.get("generator_device", "cpu"))
 
         self.chunk_manager: ChunkManager | None = None

--- a/src/tasks/blcs/generate_dataset/utils/parallel_runner.py
+++ b/src/tasks/blcs/generate_dataset/utils/parallel_runner.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor
 from itertools import repeat
-from collections.abc import Iterator
 
 import torch
 
 from src.tasks.blcs.generate_dataset.scene_generator import (
-    BLCSSceneGenerator,
     BLCSSceneData,
+    BLCSSceneGenerator,
     GeneratorConfig,
 )
 
 _WORKER_SCENE_GENERATOR: BLCSSceneGenerator | None = None
+
+
+def _require_positive_worker_count(num_workers: int) -> None:
+    if num_workers <= 0:
+        raise ValueError(
+            "Parallel BLCS scene generation requires num_workers >= 1 "
+            f"(got {num_workers})"
+        )
 
 
 def _get_worker_scene_generator(
@@ -53,9 +61,13 @@ def generate_parallel_scenes(
     num_scenes: int,
     num_workers: int,
 ) -> Iterator[BLCSSceneData]:
+    _require_positive_worker_count(num_workers)
+    if num_scenes <= 0:
+        raise ValueError(
+            f"Parallel BLCS scene generation requires num_scenes >= 1 (got {num_scenes})"
+        )
+
     max_workers = min(num_workers, num_scenes)
-    if max_workers <= 0:
-        return
 
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
         yield from executor.map(

--- a/src/tasks/blcs/scripts/generate_dataset.py
+++ b/src/tasks/blcs/scripts/generate_dataset.py
@@ -30,10 +30,9 @@ from tqdm.auto import tqdm
 
 from src.tasks.blcs.generate_dataset.config import build_generator_config
 from src.tasks.blcs.generate_dataset.io.dataset_io import BLCSDatasetWriter
-from src.tasks.blcs.generate_dataset.scene_generator import (
-    GeneratorConfig,
+from src.tasks.blcs.generate_dataset.utils.parallel_runner import (
+    generate_parallel_scenes,
 )
-from src.tasks.blcs.generate_dataset.utils.parallel_runner import generate_parallel_scenes
 
 logging.basicConfig(
     level=logging.INFO,
@@ -82,32 +81,27 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
             f"Invalid split ratios: train={train_ratio}, val={val_ratio} (sum > 1.0)"
         )
 
-    generator_config = build_generator_config(cfg)
-
     num_scenes = int(cfg.generator.num_scenes)
     num_workers = int(cfg.run.get("num_workers", 1))
-    effective_workers = min(num_workers, num_scenes)
     device = str(cfg.run.device)
+    generator_config = build_generator_config(cfg)
 
     logger.info("Output directory: %s", output_dir)
     logger.info("Number of scenes: %s", num_scenes)
     logger.info("Max rallies per scene: %s", cfg.rally.max_rallies)
     logger.info("Device: %s", device)
 
-    if effective_workers > 1 and torch.device(device).type != "cpu":
+    if torch.device(device).type != "cpu":
         raise ValueError(
             "Parallel BLCS dataset generation requires run.device=cpu when "
             f"run.num_workers={num_workers}"
         )
-    
+
     writer = BLCSDatasetWriter(output_dir)
 
     logger.info("Starting scene generation...")
-    logger.info(
-        "Scene generation mode: %s",
-        "parallel" if effective_workers > 1 else "serial",
-    )
-    logger.info("Scene generation workers: %s", effective_workers)
+    logger.info("Scene generation mode: parallel")
+    logger.info("Scene generation workers: %s", num_workers)
 
     total_scenes = 0
 
@@ -116,12 +110,11 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
             generator_config=generator_config,
             device=device,
             num_scenes=num_scenes,
-            num_workers=effective_workers,
+            num_workers=num_workers,
         ),
         desc="Generating scenes",
         total=num_scenes,
     ):
-        
         writer.save_scene(scene_data)
         total_scenes += 1
 

--- a/src/tasks/event_detection/configs/data/chunked_blcs_rally_3d.yaml
+++ b/src/tasks/event_detection/configs/data/chunked_blcs_rally_3d.yaml
@@ -23,7 +23,7 @@ chunk:
   epochs_per_chunk: 3
   prefetch_chunks: 1
   chunks_dir: "data/blcs/chunks"
-  generation_workers: 0
+  generation_workers: 1
 
 label:
   sigma_frames: 2.5

--- a/src/tasks/event_detection/configs/data/chunked_blcs_rally_uv.yaml
+++ b/src/tasks/event_detection/configs/data/chunked_blcs_rally_uv.yaml
@@ -28,7 +28,7 @@ chunk:
   epochs_per_chunk: 3
   prefetch_chunks: 1
   chunks_dir: "data/blcs/chunks"
-  generation_workers: 0
+  generation_workers: 1
 
 # Labels (soft targets)
 label:

--- a/src/tasks/event_detection/data/chunked_datamodule.py
+++ b/src/tasks/event_detection/data/chunked_datamodule.py
@@ -32,7 +32,7 @@ class ChunkedEventDetectionDataModule(EventDetectionDataModule):
         self.epochs_per_chunk = int(chunk_cfg.get("epochs_per_chunk", 3))
         self.prefetch_chunks = int(chunk_cfg.get("prefetch_chunks", 1))
         self.chunks_dir = Path(chunk_cfg.get("chunks_dir", "data/blcs/chunks"))
-        self.generation_workers = int(chunk_cfg.get("generation_workers", 0))
+        self.generation_workers = int(chunk_cfg.get("generation_workers", 1))
         self.generator_device = str(data_cfg.get("generator_device", "cpu"))
 
         self.chunk_manager: ChunkManager | None = None

--- a/src/tasks/plcs/configs/data/chunked_multiview.yaml
+++ b/src/tasks/plcs/configs/data/chunked_multiview.yaml
@@ -29,7 +29,7 @@ chunk:
   epochs_per_chunk: 3
   prefetch_chunks: 3
   chunks_dir: "data/plcs/chunks"
-  generation_workers: 8  # parallel scene generation workers (0 = sequential)
+  generation_workers: 8  # parallel scene generation workers (must be >= 1)
 
 augmentation:
   keypoint_noise_std: 0.0001

--- a/src/tasks/plcs/data/chunk_manager.py
+++ b/src/tasks/plcs/data/chunk_manager.py
@@ -4,21 +4,20 @@ from __future__ import annotations
 
 import threading
 from pathlib import Path
-from typing import Any
 
 from omegaconf import DictConfig
 
 from src.tasks.base.data.chunk_manager import (
     ChunkGenerator,
     ChunkInfo,
-    ChunkManager as BaseChunkManager,
     ChunkState,
+)
+from src.tasks.base.data.chunk_manager import (
+    ChunkManager as BaseChunkManager,
 )
 from src.tasks.plcs.generate_dataset.io.dataset_io import PLCSDatasetWriter
 from src.tasks.plcs.generate_dataset.utils.parallel_runner import (
-    build_scene_generator,
     generate_parallel_scenes,
-    generate_serial_scene,
 )
 from src.tasks.plcs.utils import prepare_generation_config
 
@@ -35,9 +34,8 @@ class _PLCSChunkGenerator:
         self.generator_device = generator_device
         self.generation_workers = generation_workers
         self._next_scene_index = 0
-        self._scene_generator: Any | None = None
 
-        if self.generation_workers > 0 and self.generator_device != "cpu":
+        if self.generator_device != "cpu":
             raise ValueError(
                 "Parallel PLCS chunk generation requires data.generator_device=cpu "
                 f"when data.chunk.generation_workers={self.generation_workers}"
@@ -53,33 +51,16 @@ class _PLCSChunkGenerator:
         writer = PLCSDatasetWriter(str(chunk_dir))
         start_index = self._allocate_scene_range(num_scenes)
 
-        if self.generation_workers > 0:
-            for scene_data in generate_parallel_scenes(
-                config=self.config,
-                device=self.generator_device,
-                start_index=start_index,
-                num_scenes=num_scenes,
-                num_workers=self.generation_workers,
-            ):
-                if stop_event.is_set():
-                    break
-                writer.save_scene(scene_data)
-        else:
-            scene_generator = self._get_scene_generator()
-            for scene_index in range(start_index, start_index + num_scenes):
-                if stop_event.is_set():
-                    break
-                writer.save_scene(
-                    generate_serial_scene(
-                        scene_generator,
-                        scene_index,
-                    )
-                )
-
-    def _get_scene_generator(self) -> Any:
-        if self._scene_generator is None:
-            self._scene_generator = build_scene_generator(self.config, self.generator_device)
-        return self._scene_generator
+        for scene_data in generate_parallel_scenes(
+            config=self.config,
+            device=self.generator_device,
+            start_index=start_index,
+            num_scenes=num_scenes,
+            num_workers=self.generation_workers,
+        ):
+            if stop_event.is_set():
+                break
+            writer.save_scene(scene_data)
 
     def _allocate_scene_range(self, num_scenes: int) -> int:
         start_index = self._next_scene_index
@@ -99,18 +80,18 @@ class ChunkManager(BaseChunkManager):
         epochs_per_chunk: int = 3,
         prefetch_chunks: int = 1,
         generator_device: str = "cpu",
-        generation_workers: int = 0,
+        generation_workers: int = 1,
     ) -> None:
+        self.generation_workers = generation_workers
         self.config = prepare_generation_config(config)
         self.generator_device = generator_device
-        self.generation_workers = generation_workers
 
         super().__init__(
             chunks_dir=chunks_dir,
             chunk_generator_factory=lambda: _PLCSChunkGenerator(
                 config=self.config,
                 generator_device=generator_device,
-                generation_workers=generation_workers,
+                generation_workers=self.generation_workers,
             ),
             scenes_per_chunk=scenes_per_chunk,
             epochs_per_chunk=epochs_per_chunk,

--- a/src/tasks/plcs/data/chunked_datamodule.py
+++ b/src/tasks/plcs/data/chunked_datamodule.py
@@ -29,7 +29,7 @@ class ChunkedPLCSDataModule(PLCSDataModule):
         self.epochs_per_chunk = int(chunk_cfg.get("epochs_per_chunk", 3))
         self.prefetch_chunks = int(chunk_cfg.get("prefetch_chunks", 1))
         self.chunks_dir = Path(chunk_cfg.get("chunks_dir", "data/plcs/chunks"))
-        self.generation_workers = int(chunk_cfg.get("generation_workers", 0))
+        self.generation_workers = int(chunk_cfg.get("generation_workers", 1))
         self.generator_device = str(data_cfg.get("generator_device", "cpu"))
 
         self.chunk_manager: ChunkManager | None = None

--- a/src/tasks/plcs/generate_dataset/utils/parallel_runner.py
+++ b/src/tasks/plcs/generate_dataset/utils/parallel_runner.py
@@ -14,6 +14,14 @@ from src.tasks.plcs.generate_dataset.scene_generator import SceneData, SceneGene
 _WORKER_SCENE_GENERATOR: SceneGenerator | None = None
 
 
+def _require_positive_worker_count(num_workers: int) -> None:
+    if num_workers <= 0:
+        raise ValueError(
+            "Parallel PLCS scene generation requires num_workers >= 1 "
+            f"(got {num_workers})"
+        )
+
+
 def build_scene_generator(
     config: DictConfig,
     device: str,
@@ -29,30 +37,6 @@ def build_scene_generator(
         motion_sampler=motion_sampler,
         device=device,
     )
-
-
-def generate_serial_scene(
-    scene_generator: SceneGenerator,
-    scene_index: int,
-) -> SceneData:
-    """Generate one scene in the current process."""
-    return scene_generator.generate_scene(
-        scene_id=f"scene_{scene_index:06d}",
-    )
-
-
-def generate_serial_scenes(
-    scene_generator: SceneGenerator,
-    *,
-    start_index: int,
-    num_scenes: int,
-) -> Iterator[SceneData]:
-    """Generate PLCS scenes sequentially in the current process."""
-    for scene_index in range(start_index, start_index + num_scenes):
-        yield generate_serial_scene(
-            scene_generator,
-            scene_index,
-        )
 
 
 def _get_worker_scene_generator(
@@ -80,7 +64,7 @@ def _generate_scene_task(
 
     torch.set_num_threads(1)
     scene_generator = _get_worker_scene_generator(config_dict, device)
-    return generate_serial_scene(scene_generator, scene_index)
+    return scene_generator.generate_scene(scene_id=f"scene_{scene_index:06d}")
 
 
 def generate_parallel_scenes(
@@ -91,9 +75,13 @@ def generate_parallel_scenes(
     num_workers: int,
 ) -> Iterator[SceneData]:
     """Generate PLCS scenes in parallel worker processes."""
+    _require_positive_worker_count(num_workers)
+    if num_scenes <= 0:
+        raise ValueError(
+            f"Parallel PLCS scene generation requires num_scenes >= 1 (got {num_scenes})"
+        )
+
     max_workers = min(num_workers, num_scenes)
-    if max_workers <= 0:
-        return
 
     config_dict = OmegaConf.to_container(config, resolve=True)
     if not isinstance(config_dict, dict):

--- a/src/tasks/plcs/scripts/generate_dataset.py
+++ b/src/tasks/plcs/scripts/generate_dataset.py
@@ -25,12 +25,10 @@ from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
 from tqdm import tqdm
 
-from src.tasks.plcs.generate_dataset.utils.parallel_runner import (
-    build_scene_generator,
-    generate_parallel_scenes,
-    generate_serial_scenes,
-)
 from src.tasks.plcs.generate_dataset.io.dataset_io import PLCSDatasetWriter
+from src.tasks.plcs.generate_dataset.utils.parallel_runner import (
+    generate_parallel_scenes,
+)
 
 
 def _seed_everything(seed: int) -> None:
@@ -82,41 +80,22 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry
     # Generate scenes
     num_scenes = int(cfg.simulation.num_scenes)
     num_workers = int(cfg.run.get("num_workers", 1))
-    effective_workers = min(num_workers, num_scenes)
-    if effective_workers > 1 and torch.device(device).type != "cpu":
+    if torch.device(device).type != "cpu":
         raise ValueError(
             "Parallel PLCS dataset generation requires run.device=cpu when "
             f"run.num_workers={num_workers}"
         )
 
-    if effective_workers > 1:
-        results = generate_parallel_scenes(
-            config=cfg,
-            device=device,
-            start_index=0,
-            num_scenes=num_scenes,
-            num_workers=effective_workers,
-        )
-    else:
-        print("\nInitializing motion sampler...")
-        scene_generator = build_scene_generator(cfg, device)
-        print(
-            "Available categories: "
-            f"{scene_generator.motion_sampler.get_available_categories()}"
-        )
-        print("\nInitializing scene generator...")
-        results = generate_serial_scenes(
-            scene_generator,
-            start_index=0,
-            num_scenes=num_scenes,
-        )
+    results = generate_parallel_scenes(
+        config=cfg,
+        device=device,
+        start_index=0,
+        num_scenes=num_scenes,
+        num_workers=num_workers,
+    )
 
     print(f"\nGenerating {num_scenes} scenes...")
-    print(
-        "Scene generation mode: "
-        f"{'parallel' if effective_workers > 1 else 'serial'} "
-        f"(workers={effective_workers})"
-    )
+    print(f"Scene generation mode: parallel (workers={num_workers})")
 
     successful = 0
     failed = 0

--- a/src/tasks/trajectory_completion/configs/data/chunked_blcs_rally_uv.yaml
+++ b/src/tasks/trajectory_completion/configs/data/chunked_blcs_rally_uv.yaml
@@ -24,7 +24,7 @@ chunk:
   epochs_per_chunk: 3
   prefetch_chunks: 1
   chunks_dir: data/blcs/chunks
-  generation_workers: 0
+  generation_workers: 1
 
 supervise_visible_only: true
 

--- a/src/tasks/trajectory_completion/data/chunked_datamodule.py
+++ b/src/tasks/trajectory_completion/data/chunked_datamodule.py
@@ -36,7 +36,7 @@ class ChunkedTrajectoryCompletionDataModule(TrajectoryCompletionDataModule):
         self.epochs_per_chunk = int(chunk_cfg.get("epochs_per_chunk", 3))
         self.prefetch_chunks = int(chunk_cfg.get("prefetch_chunks", 1))
         self.chunks_dir = Path(chunk_cfg.get("chunks_dir", "data/blcs/chunks"))
-        self.generation_workers = int(chunk_cfg.get("generation_workers", 0))
+        self.generation_workers = int(chunk_cfg.get("generation_workers", 1))
         self.generator_device = str(data_cfg.get("generator_device", "cpu"))
 
         self.chunk_manager: ChunkManager | None = None

--- a/tests/tasks/test_dataset_generation_contracts.py
+++ b/tests/tasks/test_dataset_generation_contracts.py
@@ -292,7 +292,7 @@ def _assert_blcs_scene_contract(scene_dir: Path) -> None:
 @pytest.mark.parametrize(
     ("num_scenes", "num_workers"),
     [(1, 1), (2, 2)],
-    ids=["serial", "parallel"],
+    ids=["single_worker", "multi_worker"],
 )
 def test_plcs_generator_output_contract(
     tmp_path: Path,
@@ -373,17 +373,43 @@ def test_plcs_parallel_generator_requires_cpu(tmp_path: Path) -> None:
     assert "Parallel PLCS dataset generation requires run.device=cpu" in combined_output
 
 
+def test_plcs_generator_requires_positive_num_workers(tmp_path: Path) -> None:
+    output_dir = tmp_path / "plcs"
+    completed = _run_generator_raw(
+        "src.tasks.plcs.scripts.generate_dataset",
+        output_dir,
+        [
+            "simulation.num_scenes=1",
+            "run.device=cpu",
+            "run.num_workers=0",
+        ],
+    )
+
+    assert completed.returncode != 0
+    combined_output = f"{completed.stdout}\n{completed.stderr}"
+    assert "Parallel PLCS scene generation requires num_workers >= 1" in combined_output
+
+
 @pytest.mark.integration
 @pytest.mark.slow
-def test_blcs_generator_output_contract(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("num_scenes", "num_workers"),
+    [(1, 1), (2, 2)],
+    ids=["single_worker", "multi_worker"],
+)
+def test_blcs_generator_output_contract(
+    tmp_path: Path,
+    num_scenes: int,
+    num_workers: int,
+) -> None:
     output_dir = tmp_path / "blcs"
     _run_generator(
         "src.tasks.blcs.scripts.generate_dataset",
         output_dir,
         [
-            "generator.num_scenes=2",
+            f"generator.num_scenes={num_scenes}",
             "run.device=cpu",
-            "run.num_workers=2",
+            f"run.num_workers={num_workers}",
         ],
     )
 
@@ -414,3 +440,20 @@ def test_blcs_generator_output_contract(tmp_path: Path) -> None:
 
     for scene_dir in scene_dirs:
         _assert_blcs_scene_contract(scene_dir)
+
+
+def test_blcs_generator_requires_positive_num_workers(tmp_path: Path) -> None:
+    output_dir = tmp_path / "blcs"
+    completed = _run_generator_raw(
+        "src.tasks.blcs.scripts.generate_dataset",
+        output_dir,
+        [
+            "generator.num_scenes=1",
+            "run.device=cpu",
+            "run.num_workers=0",
+        ],
+    )
+
+    assert completed.returncode != 0
+    combined_output = f"{completed.stdout}\n{completed.stderr}"
+    assert "Parallel BLCS scene generation requires num_workers >= 1" in combined_output


### PR DESCRIPTION
## Summary

- Localizes positive worker-count validation to the BLCS and PLCS parallel runners.
- Removes downstream ownership of `generation_workers` validation from scripts, datamodules, and chunk managers.
- Updates dataset generation contract tests to expect runner-owned validation errors.

## Changes

- Removed shared `require_positive_worker_count` usage from downstream BLCS/PLCS chunk and script entry points.
- Added runner-local `_require_positive_worker_count` helpers in BLCS and PLCS parallel generation utilities.
- Kept downstream modules passing configured worker counts through unchanged so `parallel_runner.py` owns the invariant.

## Validation

- `.venv/bin/python -m pytest tests/tasks/test_dataset_generation_contracts.py`
- `.venv/bin/python -m ruff check src/tasks/base/data/chunk_manager.py src/tasks/blcs/generate_dataset/utils/parallel_runner.py src/tasks/plcs/generate_dataset/utils/parallel_runner.py src/tasks/blcs/scripts/generate_dataset.py src/tasks/plcs/scripts/generate_dataset.py src/tasks/blcs/data/chunk_manager.py src/tasks/plcs/data/chunk_manager.py src/tasks/blcs/data/chunked_datamodule.py src/tasks/plcs/data/chunked_datamodule.py src/tasks/event_detection/data/chunked_datamodule.py src/tasks/trajectory_completion/data/chunked_datamodule.py tests/tasks/test_dataset_generation_contracts.py`

## Related Issues

- None
