### PR TITLE
feat: Render camera objects in BLCS generate_dataset WebUI

### DIFF
--- a/src/tasks/blcs/generate_dataset/webui/src/app/page.tsx
+++ b/src/tasks/blcs/generate_dataset/webui/src/app/page.tsx
@@ -50,6 +50,7 @@ const COURT_CENTER = { x: 0, y: 0, z: 0 };
 
 export default function Page() {
   const [drawerOpen, setDrawerOpen] = useState(true);
+  const [cameraSearchOpen, setCameraSearchOpen] = useState(true);
 
   const [cells, setCells] = useState<CellInfo[]>([]);
   const [court, setCourt] = useState<CourtGeometryResponse | null>(null);
@@ -251,6 +252,26 @@ export default function Page() {
         Open Controls
       </button>
 
+      <button
+        onClick={() => setCameraSearchOpen(true)}
+        style={{
+          position: "fixed",
+          right: 16,
+          bottom: 16,
+          zIndex: 9,
+          display: cameraSearchOpen ? "none" : "block",
+          border: "1px solid rgba(255,255,255,0.22)",
+          background: "rgba(10,10,10,0.6)",
+          color: "#fff",
+          borderRadius: 12,
+          padding: "10px 12px",
+          cursor: "pointer",
+          backdropFilter: "blur(6px)",
+        }}
+      >
+        Open Camera Search
+      </button>
+
       <ControlsDrawer
         open={drawerOpen}
         setOpen={setDrawerOpen}
@@ -313,19 +334,22 @@ export default function Page() {
         ) : null}
       </div>
 
-      <CameraSearchPanel
-        presets={cameraPresets}
-        activePresetId={activePresetId}
-        zMin={cameraZMin}
-        setZMin={setCameraZMin}
-        zMax={cameraZMax}
-        setZMax={setCameraZMax}
-        lockLookAtCenter={lockLookAtCenter}
-        setLockLookAtCenter={setLockLookAtCenter}
-        onApplyPreset={applyCameraPreset}
-        cameraPos={cameraCurrentPos}
-        cameraDir={cameraCurrentDir}
-      />
+      {cameraSearchOpen ? (
+        <CameraSearchPanel
+          presets={cameraPresets}
+          activePresetId={activePresetId}
+          onClose={() => setCameraSearchOpen(false)}
+          zMin={cameraZMin}
+          setZMin={setCameraZMin}
+          zMax={cameraZMax}
+          setZMax={setCameraZMax}
+          lockLookAtCenter={lockLookAtCenter}
+          setLockLookAtCenter={setLockLookAtCenter}
+          onApplyPreset={applyCameraPreset}
+          cameraPos={cameraCurrentPos}
+          cameraDir={cameraCurrentDir}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/tasks/blcs/generate_dataset/webui/src/app/page.tsx
+++ b/src/tasks/blcs/generate_dataset/webui/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { apiGetCells, apiGetCourtGeometry, apiSimulateShot } from "../lib/api";
 import type {
+  CameraPreset,
   CellInfo,
   CourtGeometryResponse,
   Side,
@@ -44,6 +45,8 @@ function computeVelocityFromAngles(params: {
   const vz = params.speed * sinEl;
   return { vx, vy, vz };
 }
+
+const COURT_CENTER = { x: 0, y: 0, z: 0 };
 
 export default function Page() {
   const [drawerOpen, setDrawerOpen] = useState(true);
@@ -88,10 +91,14 @@ export default function Page() {
     y: -18,
     z: 6,
   });
+  const [cameraLookAtTarget, setCameraLookAtTarget] = useState<{ x: number; y: number; z: number } | null>(
+    COURT_CENTER
+  );
   const [cameraPoseVersion, setCameraPoseVersion] = useState(0);
   const [cameraCurrentPos, setCameraCurrentPos] = useState<{ x: number; y: number; z: number } | null>(null);
   const [cameraCurrentDir, setCameraCurrentDir] = useState<{ x: number; y: number; z: number } | null>(null);
   const [activePresetId, setActivePresetId] = useState<string | null>(null);
+  const [presetApplyVersion, setPresetApplyVersion] = useState(0);
 
   // Simulation state.
   const [running, setRunning] = useState(false);
@@ -100,28 +107,34 @@ export default function Page() {
 
   const targetSide: Side = fromSide === "near" ? "far" : "near";
 
-  const cameraPresets = useMemo(() => {
+  const cameraPresets = useMemo<CameraPreset[]>(() => {
     const fx = 9.145;
     const fy = 18.285;
     return [
-      { id: "corner_nw", label: "Corner NW", pos: { x: -fx, y: fy, z: cameraZMin } },
-      { id: "corner_ne", label: "Corner NE", pos: { x: fx, y: fy, z: cameraZMin } },
-      { id: "corner_se", label: "Corner SE", pos: { x: fx, y: -fy, z: cameraZMin } },
-      { id: "corner_sw", label: "Corner SW", pos: { x: -fx, y: -fy, z: cameraZMin } },
-      { id: "mid_n", label: "Mid North", pos: { x: 0, y: fy, z: cameraZMax } },
-      { id: "mid_e", label: "Mid East", pos: { x: fx, y: 0, z: cameraZMax } },
-      { id: "mid_s", label: "Mid South", pos: { x: 0, y: -fy, z: cameraZMax } },
-      { id: "mid_w", label: "Mid West", pos: { x: -fx, y: 0, z: cameraZMax } },
+      { id: "corner_nw", label: "Corner NW", pos: { x: -fx, y: fy, z: cameraZMin }, lookAt: COURT_CENTER },
+      { id: "corner_ne", label: "Corner NE", pos: { x: fx, y: fy, z: cameraZMin }, lookAt: COURT_CENTER },
+      { id: "corner_se", label: "Corner SE", pos: { x: fx, y: -fy, z: cameraZMin }, lookAt: COURT_CENTER },
+      { id: "corner_sw", label: "Corner SW", pos: { x: -fx, y: -fy, z: cameraZMin }, lookAt: COURT_CENTER },
+      { id: "mid_n", label: "Mid North", pos: { x: 0, y: fy, z: cameraZMax }, lookAt: COURT_CENTER },
+      { id: "mid_e", label: "Mid East", pos: { x: fx, y: 0, z: cameraZMax }, lookAt: COURT_CENTER },
+      { id: "mid_s", label: "Mid South", pos: { x: 0, y: -fy, z: cameraZMax }, lookAt: COURT_CENTER },
+      { id: "mid_w", label: "Mid West", pos: { x: -fx, y: 0, z: cameraZMax }, lookAt: COURT_CENTER },
     ];
   }, [cameraZMin, cameraZMax]);
 
   function applyCameraPreset(id: string) {
-    const preset = cameraPresets.find((p) => p.id === id);
-    if (!preset) return;
     setActivePresetId(id);
-    setCameraPose(preset.pos);
-    setCameraPoseVersion((v) => v + 1);
+    setPresetApplyVersion((v) => v + 1);
   }
+
+  useEffect(() => {
+    if (!activePresetId) return;
+    const preset = cameraPresets.find((candidate) => candidate.id === activePresetId);
+    if (!preset) return;
+    setCameraPose(preset.pos);
+    setCameraLookAtTarget(preset.lookAt);
+    setCameraPoseVersion((v) => v + 1);
+  }, [activePresetId, cameraPresets, presetApplyVersion]);
 
   useEffect(() => {
     let mounted = true;
@@ -206,13 +219,15 @@ export default function Page() {
         bounce2Pos={simResult?.events.bounce2_pos ?? null}
         netPos={simResult?.events.net_pos ?? null}
         cameraPose={cameraPose}
+        cameraLookAtTarget={cameraLookAtTarget}
         cameraPoseVersion={cameraPoseVersion}
         lockLookAtCenter={lockLookAtCenter}
+        activePresetId={activePresetId}
         onCameraPoseChange={(pos, dir) => {
           setCameraCurrentPos(pos);
           setCameraCurrentDir(dir);
         }}
-        cameraMarkers={cameraPresets.map((p) => p.pos)}
+        cameraMarkers={cameraPresets}
       />
 
       {/* Minimal HUD */}

--- a/src/tasks/blcs/generate_dataset/webui/src/components/CameraSearchPanel.tsx
+++ b/src/tasks/blcs/generate_dataset/webui/src/components/CameraSearchPanel.tsx
@@ -1,10 +1,4 @@
-import type { Vec3 } from "../lib/types";
-
-type CameraPreset = {
-  id: string;
-  label: string;
-  pos: Vec3;
-};
+import type { CameraPreset, Vec3 } from "../lib/types";
 
 function fmt(v: number) {
   return v.toFixed(3);

--- a/src/tasks/blcs/generate_dataset/webui/src/components/CameraSearchPanel.tsx
+++ b/src/tasks/blcs/generate_dataset/webui/src/components/CameraSearchPanel.tsx
@@ -7,6 +7,7 @@ function fmt(v: number) {
 export function CameraSearchPanel(props: {
   presets: CameraPreset[];
   activePresetId: string | null;
+  onClose: () => void;
   zMin: number;
   setZMin: (v: number) => void;
   zMax: number;
@@ -34,7 +35,31 @@ export function CameraSearchPanel(props: {
         boxShadow: "0 20px 40px rgba(0,0,0,0.35)",
       }}
     >
-      <div style={{ fontWeight: 700, marginBottom: 10 }}>Camera Search</div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          marginBottom: 10,
+        }}
+      >
+        <div style={{ fontWeight: 700 }}>Camera Search</div>
+        <button
+          onClick={props.onClose}
+          style={{
+            border: "1px solid rgba(255,255,255,0.18)",
+            background: "rgba(255,255,255,0.06)",
+            color: "#fff",
+            borderRadius: 10,
+            padding: "6px 10px",
+            fontSize: 12,
+            cursor: "pointer",
+          }}
+        >
+          Close
+        </button>
+      </div>
 
       <div style={{ fontSize: 12, opacity: 0.85, marginBottom: 8 }}>
         Presets: 4 corners at z_min, 4 edge-midpoints at z_max.

--- a/src/tasks/blcs/generate_dataset/webui/src/components/Trajectory3D.tsx
+++ b/src/tasks/blcs/generate_dataset/webui/src/components/Trajectory3D.tsx
@@ -5,7 +5,7 @@ import * as THREE from "three";
 
 import { Court3D } from "./Court3D";
 import { FpsControls } from "./FpsControls";
-import type { CellInfo, CourtGeometryResponse, Side, Vec3 } from "../lib/types";
+import type { CameraPreset, CellInfo, CourtGeometryResponse, Side, Vec3 } from "../lib/types";
 
 function EventMarker(props: { pos: Vec3; color: string }) {
   return (
@@ -18,6 +18,7 @@ function EventMarker(props: { pos: Vec3; color: string }) {
 
 function CameraSync(props: {
   cameraPose: Vec3 | null;
+  cameraLookAtTarget: Vec3 | null;
   cameraPoseVersion: number;
   lockLookAtCenter: boolean;
   onCameraPoseChange: (pos: Vec3, dir: Vec3) => void;
@@ -33,9 +34,21 @@ function CameraSync(props: {
     camera.position.set(props.cameraPose.x, props.cameraPose.y, props.cameraPose.z);
     if (props.lockLookAtCenter) {
       camera.lookAt(0, 0, 0);
+    } else if (props.cameraLookAtTarget) {
+      camera.lookAt(
+        props.cameraLookAtTarget.x,
+        props.cameraLookAtTarget.y,
+        props.cameraLookAtTarget.z
+      );
     }
     camera.updateProjectionMatrix();
-  }, [camera, props.cameraPose, props.cameraPoseVersion, props.lockLookAtCenter]);
+  }, [
+    camera,
+    props.cameraPose,
+    props.cameraLookAtTarget,
+    props.cameraPoseVersion,
+    props.lockLookAtCenter,
+  ]);
 
   useFrame((_, dt: number) => {
     reportClock.current += dt;
@@ -61,16 +74,63 @@ function CameraSync(props: {
   return null;
 }
 
-function CameraMarker(props: { pos: Vec3; active: boolean }) {
+function CameraMarker(props: { pos: Vec3; lookAt: Vec3; active: boolean }) {
+  const quaternion = useMemo(() => {
+    const position = new THREE.Vector3(props.pos.x, props.pos.y, props.pos.z);
+    const target = new THREE.Vector3(props.lookAt.x, props.lookAt.y, props.lookAt.z);
+    const forward = target.sub(position);
+    if (forward.lengthSq() < 1e-6) {
+      forward.set(1, 0, 0);
+    } else {
+      forward.normalize();
+    }
+
+    const worldUp = new THREE.Vector3(0, 0, 1);
+    const right = new THREE.Vector3().crossVectors(worldUp, forward);
+    if (right.lengthSq() < 1e-6) {
+      right.set(0, 1, 0).cross(forward);
+    }
+    right.normalize();
+
+    const up = new THREE.Vector3().crossVectors(forward, right).normalize();
+    const basis = new THREE.Matrix4().makeBasis(forward, right, up);
+    return new THREE.Quaternion().setFromRotationMatrix(basis);
+  }, [props.lookAt.x, props.lookAt.y, props.lookAt.z, props.pos.x, props.pos.y, props.pos.z]);
+
+  const bodyColor = props.active ? "#fde047" : "#f97316";
+  const accentColor = props.active ? "#fff7c2" : "#fed7aa";
+
   return (
-    <mesh position={[props.pos.x, props.pos.y, props.pos.z]}>
-      <sphereGeometry args={[props.active ? 0.28 : 0.22, 16, 16]} />
-      <meshStandardMaterial
-        color={props.active ? "#fde047" : "#f97316"}
-        transparent
-        opacity={props.active ? 0.95 : 0.75}
-      />
-    </mesh>
+    <group
+      position={[props.pos.x, props.pos.y, props.pos.z]}
+      quaternion={quaternion}
+      scale={props.active ? 1.16 : 1}
+    >
+      <mesh>
+        <boxGeometry args={[0.5, 0.3, 0.26]} />
+        <meshStandardMaterial color={bodyColor} roughness={0.42} metalness={0.08} />
+      </mesh>
+
+      <mesh position={[0.34, 0, 0]} rotation={[0, 0, Math.PI / 2]}>
+        <cylinderGeometry args={[0.085, 0.11, 0.28, 24]} />
+        <meshStandardMaterial color="#111827" roughness={0.35} metalness={0.22} />
+      </mesh>
+
+      <mesh position={[0.47, 0, 0]} rotation={[0, 0, Math.PI / 2]}>
+        <cylinderGeometry args={[0.05, 0.07, 0.08, 24]} />
+        <meshStandardMaterial color={accentColor} transparent opacity={0.92} roughness={0.12} />
+      </mesh>
+
+      <mesh position={[-0.04, 0, 0.2]}>
+        <boxGeometry args={[0.18, 0.18, 0.09]} />
+        <meshStandardMaterial color={accentColor} roughness={0.48} metalness={0.06} />
+      </mesh>
+
+      <mesh position={[-0.08, 0, -0.2]}>
+        <boxGeometry args={[0.16, 0.18, 0.1]} />
+        <meshStandardMaterial color="#0f172a" roughness={0.7} metalness={0.04} />
+      </mesh>
+    </group>
   );
 }
 
@@ -88,10 +148,12 @@ export function Trajectory3D(props: {
   bounce2Pos: Vec3 | null;
   netPos: Vec3 | null;
   cameraPose: Vec3 | null;
+  cameraLookAtTarget: Vec3 | null;
   cameraPoseVersion: number;
   lockLookAtCenter: boolean;
+  activePresetId: string | null;
   onCameraPoseChange: (pos: Vec3, dir: Vec3) => void;
-  cameraMarkers: Vec3[];
+  cameraMarkers: CameraPreset[];
 }) {
   const trajectoryPoints = useMemo(() => {
     if (!props.positions || props.positions.length <= 1) return null;
@@ -135,17 +197,31 @@ export function Trajectory3D(props: {
         {props.bounce1Pos ? <EventMarker pos={props.bounce1Pos} color="#111" /> : null}
         {props.bounce2Pos ? <EventMarker pos={props.bounce2Pos} color="#111" /> : null}
 
-        {props.cameraMarkers.map((m, i) => {
-          const isActive =
+        {props.cameraMarkers.map((marker) => {
+          const tooCloseToViewer =
             props.cameraPose !== null &&
-            Math.abs(props.cameraPose.x - m.x) < 1e-6 &&
-            Math.abs(props.cameraPose.y - m.y) < 1e-6 &&
-            Math.abs(props.cameraPose.z - m.z) < 1e-6;
-          return <CameraMarker key={i} pos={m} active={isActive} />;
+            (props.cameraPose.x - marker.pos.x) ** 2 +
+              (props.cameraPose.y - marker.pos.y) ** 2 +
+              (props.cameraPose.z - marker.pos.z) ** 2 <
+              0.9 ** 2;
+          if (tooCloseToViewer) {
+            return null;
+          }
+
+          const isActive = props.activePresetId === marker.id;
+          return (
+            <CameraMarker
+              key={marker.id}
+              pos={marker.pos}
+              lookAt={marker.lookAt}
+              active={isActive}
+            />
+          );
         })}
 
         <CameraSync
           cameraPose={props.cameraPose}
+          cameraLookAtTarget={props.cameraLookAtTarget}
           cameraPoseVersion={props.cameraPoseVersion}
           lockLookAtCenter={props.lockLookAtCenter}
           onCameraPoseChange={props.onCameraPoseChange}

--- a/src/tasks/blcs/generate_dataset/webui/src/components/Trajectory3D.tsx
+++ b/src/tasks/blcs/generate_dataset/webui/src/components/Trajectory3D.tsx
@@ -201,17 +201,17 @@ export function Trajectory3D(props: {
         {props.bounce2Pos ? <EventMarker pos={props.bounce2Pos} color="#111" /> : null}
 
         {props.cameraMarkers.map((marker) => {
+          const isActive = props.activePresetId === marker.id;
           const tooCloseToViewer =
             props.cameraPose !== null &&
             (props.cameraPose.x - marker.pos.x) ** 2 +
               (props.cameraPose.y - marker.pos.y) ** 2 +
               (props.cameraPose.z - marker.pos.z) ** 2 <
               (0.9 * CAMERA_MARKER_SCALE) ** 2;
-          if (tooCloseToViewer) {
+          if (tooCloseToViewer && !isActive) {
             return null;
           }
 
-          const isActive = props.activePresetId === marker.id;
           return (
             <CameraMarker
               key={marker.id}

--- a/src/tasks/blcs/generate_dataset/webui/src/components/Trajectory3D.tsx
+++ b/src/tasks/blcs/generate_dataset/webui/src/components/Trajectory3D.tsx
@@ -7,6 +7,8 @@ import { Court3D } from "./Court3D";
 import { FpsControls } from "./FpsControls";
 import type { CameraPreset, CellInfo, CourtGeometryResponse, Side, Vec3 } from "../lib/types";
 
+const CAMERA_MARKER_SCALE = 1.5;
+
 function EventMarker(props: { pos: Vec3; color: string }) {
   return (
     <mesh position={[props.pos.x, props.pos.y, props.pos.z + 0.02]}>
@@ -99,12 +101,13 @@ function CameraMarker(props: { pos: Vec3; lookAt: Vec3; active: boolean }) {
 
   const bodyColor = props.active ? "#fde047" : "#f97316";
   const accentColor = props.active ? "#fff7c2" : "#fed7aa";
+  const markerScale = props.active ? CAMERA_MARKER_SCALE * 1.16 : CAMERA_MARKER_SCALE;
 
   return (
     <group
       position={[props.pos.x, props.pos.y, props.pos.z]}
       quaternion={quaternion}
-      scale={props.active ? 1.16 : 1}
+      scale={markerScale}
     >
       <mesh>
         <boxGeometry args={[0.5, 0.3, 0.26]} />
@@ -203,7 +206,7 @@ export function Trajectory3D(props: {
             (props.cameraPose.x - marker.pos.x) ** 2 +
               (props.cameraPose.y - marker.pos.y) ** 2 +
               (props.cameraPose.z - marker.pos.z) ** 2 <
-              0.9 ** 2;
+              (0.9 * CAMERA_MARKER_SCALE) ** 2;
           if (tooCloseToViewer) {
             return null;
           }

--- a/src/tasks/blcs/generate_dataset/webui/src/lib/types.ts
+++ b/src/tasks/blcs/generate_dataset/webui/src/lib/types.ts
@@ -4,6 +4,13 @@ export type TargetMode = "none" | "cell" | "point";
 export type Vec2 = { x: number; y: number };
 export type Vec3 = { x: number; y: number; z: number };
 
+export type CameraPreset = {
+  id: string;
+  label: string;
+  pos: Vec3;
+  lookAt: Vec3;
+};
+
 export type CellBounds = {
   x_min: number;
   x_max: number;


### PR DESCRIPTION
## Summary

- Replace BLCS generate_dataset WebUI camera sphere markers with oriented camera-like 3D objects.
- Extend camera presets with look-at targets so the object orientation and the viewer camera stay aligned.
- Keep active preset highlighting while avoiding self-occlusion when the viewer is positioned on a preset.

## Changes

- Add a shared `CameraPreset` type with `lookAt` and thread preset orientation through the page and 3D scene.
- Render camera markers as composed Three.js primitives rotated toward each preset target instead of generic spheres.
- Switch active marker detection to preset ids and skip rendering markers that overlap the active viewer position.

## Validation

- `cd /home/kamimura/projects/tennis-lab-pr-403/src/tasks/blcs/generate_dataset/webui && npm run build`

## Related Issues

- Closes #403
- References #402

## Notes

- This change stays within the WebUI layer and does not alter the dataset or API contract.
