### PR TITLE
fix: Handle PLCS court keypoint padding

### DIFF
--- a/src/tasks/plcs/data/dataset.py
+++ b/src/tasks/plcs/data/dataset.py
@@ -217,6 +217,7 @@ def collate_plcs_batch(batch: list[dict[str, Tensor]]) -> PLCSBatch | dict[str, 
 
         human_kp = sample["human_kp"]
         court_kp = sample["court_kp"]
+        n_kp = int(court_kp.shape[2])
         human_vis = sample["human_vis"]
         court_vis = sample["court_vis"]
         human_mask = sample["human_mask"]


### PR DESCRIPTION
## Summary

- Fix PLCS batch collation when padding court keypoints for variable-length and variable-view samples.
- Derive the court keypoint count from each sample inside `collate_plcs_batch` instead of referencing an undefined local.

## Changes

- Add a local `n_kp` value from `sample["court_kp"].shape[2]` in `collate_plcs_batch`.
- Keep the existing padding logic and adapter flow unchanged.

## Validation

- Ran an in-environment Python smoke test that calls `collate_plcs_batch` with two synthetic samples using different `seq_len` and `n_views` values.
- Confirmed the collated tensor shapes are `(2, 2, 3, 20, 2)` for `court_kp`, `(2, 2, 3, 20)` for `court_vis`, and `(2, 2, 3, 17, 2)` for `human_kp`.

## Related Issues

- None.
