### PR TITLE
Redesign coordinate embeddings and add group tokens

### DIFF
--- a/src/utils/models/embeddings/__init__.py
+++ b/src/utils/models/embeddings/__init__.py
@@ -2,12 +2,18 @@
 
 from src.utils.models.embeddings.ball import Ball3DEmbedding, BallUVEmbedding
 from src.utils.models.embeddings.court import CourtKPUVEmbedding
+from src.utils.models.embeddings.group_tokens import (
+    CourtBallGroupEmbedding,
+    CourtPlayerGroupEmbedding,
+)
 from src.utils.models.embeddings.player import PlayerKPUVEmbedding
 from src.utils.models.embeddings.invisible_embedding import InvisibleTokenEmbedding
 
 __all__ = [
     "InvisibleTokenEmbedding",
     "CourtKPUVEmbedding",
+    "CourtBallGroupEmbedding",
+    "CourtPlayerGroupEmbedding",
     "PlayerKPUVEmbedding",
     "BallUVEmbedding",
     "Ball3DEmbedding",

--- a/src/utils/models/embeddings/ball.py
+++ b/src/utils/models/embeddings/ball.py
@@ -6,6 +6,7 @@ import torch
 from torch import nn, Tensor
 
 from src.utils.models.embeddings.invisible_embedding import InvisibleTokenEmbedding
+from src.utils.models.embeddings.projection import CoordinateProjection, apply_visibility_mask
 
 
 class BallUVEmbedding(nn.Module):
@@ -13,7 +14,7 @@ class BallUVEmbedding(nn.Module):
 
     Args:
         dim: Embedding dimension.
-        dropout: Dropout probability.
+        dropout: Retained for API compatibility; ignored by the current projection stack.
         invisible_token: Shared invisible token module.
     """
 
@@ -25,10 +26,7 @@ class BallUVEmbedding(nn.Module):
         invisible_token: InvisibleTokenEmbedding,
     ) -> None:
         super().__init__()
-        self.proj = nn.Sequential(
-            nn.Linear(2, int(dim)),
-            nn.Dropout(float(dropout)),
-        )
+        self.proj = CoordinateProjection(input_dim=2, dim=int(dim))
         self.invisible_token = invisible_token
 
     def forward(self, ball_uv: Tensor, ball_vis: Tensor | None = None) -> Tensor:
@@ -42,13 +40,7 @@ class BallUVEmbedding(nn.Module):
             Tensor: Embedded tokens, shape (B, T, D).
         """
         feat = self.proj(ball_uv)
-        if ball_vis is None:
-            return feat
-
-        mask = (ball_vis > 0).unsqueeze(-1)
-        inv = self.invisible_token().to(dtype=feat.dtype, device=feat.device)
-        inv = inv.view(1, 1, -1).expand_as(feat)
-        return torch.where(mask, feat, inv)
+        return apply_visibility_mask(feat, ball_vis, self.invisible_token)
 
 
 class Ball3DEmbedding(nn.Module):
@@ -56,7 +48,7 @@ class Ball3DEmbedding(nn.Module):
 
     Args:
         dim: Embedding dimension.
-        dropout: Dropout probability.
+        dropout: Retained for API compatibility; ignored by the current projection stack.
         invisible_token: Shared invisible token module.
     """
 
@@ -68,10 +60,7 @@ class Ball3DEmbedding(nn.Module):
         invisible_token: InvisibleTokenEmbedding,
     ) -> None:
         super().__init__()
-        self.proj = nn.Sequential(
-            nn.Linear(3, int(dim)),
-            nn.Dropout(float(dropout)),
-        )
+        self.proj = CoordinateProjection(input_dim=3, dim=int(dim))
         self.invisible_token = invisible_token
 
     def forward(self, ball_pos: Tensor, ball_vis: Tensor | None = None) -> Tensor:
@@ -85,26 +74,4 @@ class Ball3DEmbedding(nn.Module):
             Tensor: Embedded tokens, shape (B, T, D).
         """
         feat = self.proj(ball_pos)
-        if ball_vis is None:
-            return feat
-
-        mask = (ball_vis > 0).unsqueeze(-1)
-        inv = self.invisible_token().to(dtype=feat.dtype, device=feat.device)
-        inv = inv.view(1, 1, -1).expand_as(feat)
-        return torch.where(mask, feat, inv)
-
-
-if __name__ == "__main__":
-    torch.manual_seed(0)
-    invisible = InvisibleTokenEmbedding(dim=8)
-    uv_embed = BallUVEmbedding(dim=8, dropout=0.0, invisible_token=invisible)
-    ball_uv = torch.randn(2, 4, 2)
-    ball_vis = torch.tensor([[1, 0, 1, 0], [1, 1, 1, 1]], dtype=torch.float32)
-    out_uv = uv_embed(ball_uv, ball_vis)
-    assert out_uv.shape == (2, 4, 8)
-
-    pos_embed = Ball3DEmbedding(dim=8, dropout=0.0, invisible_token=invisible)
-    ball_pos = torch.randn(2, 4, 3)
-    out_pos = pos_embed(ball_pos, ball_vis)
-    assert out_pos.shape == (2, 4, 8)
-    print("Ball embeddings smoke ok")
+        return apply_visibility_mask(feat, ball_vis, self.invisible_token)

--- a/src/utils/models/embeddings/court.py
+++ b/src/utils/models/embeddings/court.py
@@ -6,6 +6,7 @@ import torch
 from torch import nn, Tensor
 
 from src.utils.models.embeddings.invisible_embedding import InvisibleTokenEmbedding
+from src.utils.models.embeddings.projection import CoordinateProjection, apply_visibility_mask
 from src.utils.schema.court import NUM_COURT_KP
 
 
@@ -14,7 +15,7 @@ class CourtKPUVEmbedding(nn.Module):
 
     Args:
         dim: Embedding dimension.
-        dropout: Dropout probability.
+        dropout: Retained for API compatibility; ignored by the current projection stack.
         invisible_token: Shared invisible token module.
     """
 
@@ -26,10 +27,7 @@ class CourtKPUVEmbedding(nn.Module):
         invisible_token: InvisibleTokenEmbedding,
     ) -> None:
         super().__init__()
-        self.proj = nn.Sequential(
-            nn.Linear(2, int(dim)),
-            nn.Dropout(float(dropout)),
-        )
+        self.proj = CoordinateProjection(input_dim=2, dim=int(dim))
         self.invisible_token = invisible_token
 
     def forward(self, court_kp: Tensor, court_vis: Tensor | None = None) -> Tensor:
@@ -44,24 +42,7 @@ class CourtKPUVEmbedding(nn.Module):
         """
         batch_size = int(court_kp.shape[0])
         if court_kp.dim() == 2:
-            court_kp = court_kp.view(batch_size, -1, 2)
+            court_kp = court_kp.reshape(batch_size, -1, 2)
 
         feat = self.proj(court_kp)
-        if court_vis is None:
-            return feat
-
-        mask = (court_vis > 0).unsqueeze(-1)
-        inv = self.invisible_token().to(dtype=feat.dtype, device=feat.device)
-        inv = inv.view(1, 1, -1).expand_as(feat)
-        return torch.where(mask, feat, inv)
-
-
-if __name__ == "__main__":
-    torch.manual_seed(0)
-    invisible = InvisibleTokenEmbedding(dim=8)
-    embed = CourtKPUVEmbedding(dim=8, dropout=0.0, invisible_token=invisible)
-    court_kp = torch.randn(2, NUM_COURT_KP, 2)
-    court_vis = torch.tensor([[1] * NUM_COURT_KP, [0] * NUM_COURT_KP], dtype=torch.float32)
-    out = embed(court_kp, court_vis)
-    assert out.shape == (2, NUM_COURT_KP, 8)
-    print("CourtKPUVEmbedding smoke ok")
+        return apply_visibility_mask(feat, court_vis, self.invisible_token)

--- a/src/utils/models/embeddings/group_tokens.py
+++ b/src/utils/models/embeddings/group_tokens.py
@@ -1,0 +1,148 @@
+"""Court-context group-token embeddings."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor, nn
+
+from src.utils.models.embeddings.invisible_embedding import InvisibleTokenEmbedding
+from src.utils.models.embeddings.projection import (
+    CoordinateProjection,
+    apply_visibility_mask,
+)
+from src.utils.schema.court import NUM_COURT_KP
+from src.utils.schema.player import NUM_HUMAN_KP
+
+
+def _flatten_court_kp(court_kp: Tensor) -> Tensor:
+    if court_kp.dim() >= 2 and tuple(court_kp.shape[-2:]) == (NUM_COURT_KP, 2):
+        return court_kp.reshape(*court_kp.shape[:-2], NUM_COURT_KP * 2)
+    if court_kp.dim() >= 1 and court_kp.shape[-1] == NUM_COURT_KP * 2:
+        return court_kp
+    raise ValueError(
+        "court_kp must have shape (..., NUM_COURT_KP, 2) or (..., NUM_COURT_KP * 2).",
+    )
+
+
+def _flatten_ball_uv(ball_uv: Tensor) -> Tensor:
+    if ball_uv.dim() >= 2 and tuple(ball_uv.shape[-2:]) == (1, 2):
+        return ball_uv.reshape(*ball_uv.shape[:-2], 2)
+    if ball_uv.dim() >= 1 and ball_uv.shape[-1] == 2:
+        return ball_uv
+    raise ValueError("ball_uv must have shape (..., 2) or (..., 1, 2).")
+
+
+def _flatten_human_kp(human_kp: Tensor) -> Tensor:
+    if human_kp.dim() >= 2 and tuple(human_kp.shape[-2:]) == (NUM_HUMAN_KP, 2):
+        return human_kp.reshape(*human_kp.shape[:-2], NUM_HUMAN_KP * 2)
+    if human_kp.dim() >= 1 and human_kp.shape[-1] == NUM_HUMAN_KP * 2:
+        return human_kp
+    raise ValueError(
+        "human_kp must have shape (..., NUM_HUMAN_KP, 2) or (..., NUM_HUMAN_KP * 2).",
+    )
+
+
+def _normalize_group_visibility(
+    group_vis: Tensor | None,
+    *,
+    expected_shape: torch.Size,
+) -> Tensor | None:
+    if group_vis is None:
+        return None
+
+    mask = group_vis if group_vis.dtype == torch.bool else group_vis > 0
+    if tuple(mask.shape) != tuple(expected_shape):
+        raise ValueError(
+            "group_vis must match the group token leading shape "
+            f"{tuple(expected_shape)}, got {tuple(mask.shape)}.",
+        )
+    return mask
+
+
+class _CourtContextGroupEmbedding(nn.Module):
+    def __init__(
+        self,
+        *,
+        dim: int,
+        group_input_dim: int,
+        invisible_token: InvisibleTokenEmbedding,
+    ) -> None:
+        super().__init__()
+        self.proj = CoordinateProjection(
+            input_dim=NUM_COURT_KP * 2 + int(group_input_dim),
+            dim=int(dim),
+        )
+        self.invisible_token = invisible_token
+
+    def _embed_group(
+        self,
+        *,
+        court_flat: Tensor,
+        group_flat: Tensor,
+        group_vis: Tensor | None,
+    ) -> Tensor:
+        if tuple(court_flat.shape[:-1]) != tuple(group_flat.shape[:-1]):
+            raise ValueError("court and group inputs must share the same leading dimensions.")
+
+        feat = self.proj(torch.cat((court_flat, group_flat), dim=-1))
+        visible = _normalize_group_visibility(
+            group_vis,
+            expected_shape=court_flat.shape[:-1],
+        )
+        return apply_visibility_mask(feat, visible, self.invisible_token)
+
+
+class CourtBallGroupEmbedding(_CourtContextGroupEmbedding):
+    """Embed court and ball coordinates into one token per camera/time element.
+
+    The token visibility is controlled only by ``group_vis``. Callers should
+    provide one visibility flag per output token, for example shape ``(B, T)``.
+    """
+
+    def __init__(self, *, dim: int, invisible_token: InvisibleTokenEmbedding) -> None:
+        super().__init__(dim=dim, group_input_dim=2, invisible_token=invisible_token)
+
+    def forward(
+        self,
+        court_kp: Tensor,
+        ball_uv: Tensor,
+        group_vis: Tensor | None = None,
+    ) -> Tensor:
+        """Return one embedding token for each leading court/ball element."""
+        court_flat = _flatten_court_kp(court_kp)
+        ball_flat = _flatten_ball_uv(ball_uv)
+        return self._embed_group(
+            court_flat=court_flat,
+            group_flat=ball_flat,
+            group_vis=group_vis,
+        )
+
+
+class CourtPlayerGroupEmbedding(_CourtContextGroupEmbedding):
+    """Embed court and player coordinates into one token per camera/time element.
+
+    The token visibility is controlled only by ``group_vis``. Callers should
+    provide one visibility flag per output token, for example shape ``(B, T)``.
+    """
+
+    def __init__(self, *, dim: int, invisible_token: InvisibleTokenEmbedding) -> None:
+        super().__init__(
+            dim=dim,
+            group_input_dim=NUM_HUMAN_KP * 2,
+            invisible_token=invisible_token,
+        )
+
+    def forward(
+        self,
+        court_kp: Tensor,
+        human_kp: Tensor,
+        group_vis: Tensor | None = None,
+    ) -> Tensor:
+        """Return one embedding token for each leading court/player element."""
+        court_flat = _flatten_court_kp(court_kp)
+        human_flat = _flatten_human_kp(human_kp)
+        return self._embed_group(
+            court_flat=court_flat,
+            group_flat=human_flat,
+            group_vis=group_vis,
+        )

--- a/src/utils/models/embeddings/player.py
+++ b/src/utils/models/embeddings/player.py
@@ -6,6 +6,7 @@ import torch
 from torch import nn, Tensor
 
 from src.utils.models.embeddings.invisible_embedding import InvisibleTokenEmbedding
+from src.utils.models.embeddings.projection import CoordinateProjection, apply_visibility_mask
 from src.utils.schema.player import NUM_HUMAN_KP
 
 
@@ -14,7 +15,7 @@ class PlayerKPUVEmbedding(nn.Module):
 
     Args:
         dim: Embedding dimension.
-        dropout: Dropout probability.
+        dropout: Retained for API compatibility; ignored by the current projection stack.
         invisible_token: Shared invisible token module.
     """
 
@@ -26,10 +27,7 @@ class PlayerKPUVEmbedding(nn.Module):
         invisible_token: InvisibleTokenEmbedding,
     ) -> None:
         super().__init__()
-        self.proj = nn.Sequential(
-            nn.Linear(2, int(dim)),
-            nn.Dropout(float(dropout)),
-        )
+        self.proj = CoordinateProjection(input_dim=2, dim=int(dim))
         self.invisible_token = invisible_token
 
     def forward(self, human_kp: Tensor, human_vis: Tensor | None = None) -> Tensor:
@@ -44,24 +42,7 @@ class PlayerKPUVEmbedding(nn.Module):
         """
         batch_size = int(human_kp.shape[0])
         if human_kp.dim() == 2:
-            human_kp = human_kp.view(batch_size, NUM_HUMAN_KP, 2)
+            human_kp = human_kp.reshape(batch_size, NUM_HUMAN_KP, 2)
 
         feat = self.proj(human_kp)
-        if human_vis is None:
-            return feat
-
-        mask = (human_vis > 0).unsqueeze(-1)
-        inv = self.invisible_token().to(dtype=feat.dtype, device=feat.device)
-        inv = inv.view(1, 1, -1).expand_as(feat)
-        return torch.where(mask, feat, inv)
-
-
-if __name__ == "__main__":
-    torch.manual_seed(0)
-    invisible = InvisibleTokenEmbedding(dim=8)
-    embed = PlayerKPUVEmbedding(dim=8, dropout=0.0, invisible_token=invisible)
-    human_kp = torch.randn(2, NUM_HUMAN_KP, 2)
-    human_vis = torch.tensor([[1] * NUM_HUMAN_KP, [0] * NUM_HUMAN_KP], dtype=torch.float32)
-    out = embed(human_kp, human_vis)
-    assert out.shape == (2, NUM_HUMAN_KP, 8)
-    print("PlayerKPUVEmbedding smoke ok")
+        return apply_visibility_mask(feat, human_vis, self.invisible_token)

--- a/src/utils/models/embeddings/projection.py
+++ b/src/utils/models/embeddings/projection.py
@@ -1,0 +1,57 @@
+"""Shared projection and masking helpers for coordinate embeddings."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor, nn
+
+from src.utils.models.components.norm import RMSNorm
+from src.utils.models.embeddings.invisible_embedding import InvisibleTokenEmbedding
+
+
+class CoordinateProjection(nn.Module):
+    """Project coordinate features with the shared two-layer stack."""
+
+    def __init__(self, *, input_dim: int, dim: int) -> None:
+        super().__init__()
+        input_dim = int(input_dim)
+        dim = int(dim)
+        if dim % 2 != 0:
+            raise ValueError(
+                "CoordinateProjection requires an even dim so the hidden layer can use dim / 2.",
+            )
+        hidden_dim = dim // 2
+        self.layers = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            RMSNorm(hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, dim),
+            RMSNorm(dim),
+            nn.GELU(),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Project coordinate features into the model embedding space."""
+        return self.layers(x)
+
+
+def apply_visibility_mask(
+    feat: Tensor,
+    visible: Tensor | None,
+    invisible_token: InvisibleTokenEmbedding,
+) -> Tensor:
+    """Replace invisible elements with the shared invisible token."""
+    if visible is None:
+        return feat
+
+    mask = visible if visible.dtype == torch.bool else visible > 0
+    if mask.dim() == feat.dim() - 1:
+        mask = mask.unsqueeze(-1)
+    if mask.dim() != feat.dim():
+        raise ValueError(
+            f"Visibility mask rank {mask.dim()} is incompatible with feature rank {feat.dim()}.",
+        )
+
+    inv = invisible_token().to(dtype=feat.dtype, device=feat.device)
+    inv = inv.view(*([1] * (feat.dim() - 1)), -1).expand_as(feat)
+    return torch.where(mask, feat, inv)


### PR DESCRIPTION
## Summary

- Redesign coordinate embeddings to use the shared two-layer projection stack.
- Add court-context group-token embeddings for court+ball and court+player inputs.
- Apply group-token invisible substitution from token-level `group_vis` only.

## Changes

- Added `CoordinateProjection` and `apply_visibility_mask` helpers for shared coordinate projection and invisible-token replacement.
- Updated ball, court, and player coordinate embeddings to use the shared projection stack.
- Added `CourtBallGroupEmbedding` and `CourtPlayerGroupEmbedding`, exported from the embeddings package.
- Changed group-token visibility handling so `group_vis` must match the output token leading shape, e.g. `[B, T]`, with no court/keypoint visibility collapse inside `group_tokens.py`.

## Validation

- `.venv/bin/ruff check src/utils/models/embeddings/group_tokens.py`
- `.venv/bin/python -m compileall src/utils/models/embeddings`
- Smoke check for `CourtBallGroupEmbedding` and `CourtPlayerGroupEmbedding` with `[B, T]` `group_vis`, invisible-token substitution, and invalid `[B, T, 1]` visibility rejection.

## Related Issues

- Closes #414
