### PR TITLE
Fix PLCS GAN training config selection

### DIFF
--- a/src/tasks/plcs/configs/training/default.yaml
+++ b/src/tasks/plcs/configs/training/default.yaml
@@ -1,7 +1,3 @@
-defaults:
-  - _gan
-  - _self_
-
 # ---- Trainer (Lightning Trainer settings) ----
 trainer:
   max_epochs: 200

--- a/src/tasks/plcs/configs/training/gan.yaml
+++ b/src/tasks/plcs/configs/training/gan.yaml
@@ -1,0 +1,7 @@
+defaults:
+  - default
+  - _gan
+  - _self_
+
+gan:
+  enabled: true

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -202,7 +202,7 @@ SMOKE_TASK_SPECS = (
             SmokeVariant(
                 name="multiview_gan",
                 overrides=(
-                    "training.gan.enabled=true",
+                    "training=gan",
                     "training.trainer.max_epochs=2",
                     "training.gan.transition.patience=0",
                     "training.gan.warmup_epochs=1",


### PR DESCRIPTION
## Summary

- Split PLCS GAN training configuration from the default training config.
- Default PLCS training no longer composes inactive GAN discriminator settings, avoiding `${model.max_seq_len}` resolution for frame/sequence models.
- GAN smoke coverage now selects `training=gan` explicitly.

## Changes

- Removed `_gan` composition from `src/tasks/plcs/configs/training/default.yaml`.
- Added `src/tasks/plcs/configs/training/gan.yaml` for explicit GAN training selection.
- Updated the PLCS GAN smoke variant to use `training=gan`.

## Validation

- `python -m pytest tests/tasks/test_training_smoke_contracts.py::test_scene_training_smoke_contracts -k 'plcs' --no-cov -q --tb=short` (7 passed)
- GPU smoke: `python -m src.tasks.plcs.scripts.train ...` for default PLCS frame, 1 epoch fit/test completed.
- GPU smoke: `python -m src.tasks.plcs.scripts.train data=sequence loss=sequence ...` for PLCS sequence, 1 epoch fit/test completed.

## Related Issues

- Closes #432

## Notes

- This PR is stacked on `feat/issue-382-extend-gan-training`, where the shared scene-task GAN training config exists.
