### PR TITLE
Fix Event Detection train test phase

### DIFF
--- a/src/tasks/event_detection/data/datamodule.py
+++ b/src/tasks/event_detection/data/datamodule.py
@@ -47,6 +47,7 @@ class DataConfig:
     scene_dir: Path
     train_split_file: str
     val_split_file: str
+    test_split_file: str
     batch_size: int
     num_workers: int
     input_type: Literal["uv", "3d"]
@@ -69,6 +70,7 @@ class EventDetectionDataModule(pl.LightningDataModule):
             scene_dir=Path(str(data_cfg.get("scene_dir", "data/blcs"))),
             train_split_file=str((data_cfg.get("split", {}) or {}).get("train_file", "train.txt")),
             val_split_file=str((data_cfg.get("split", {}) or {}).get("val_file", "val.txt")),
+            test_split_file=str((data_cfg.get("split", {}) or {}).get("test_file", "test.txt")),
             batch_size=int(data_cfg.get("batch_size", 16)),
             num_workers=int(data_cfg.get("num_workers", 4)),
             input_type=input_type,
@@ -77,6 +79,7 @@ class EventDetectionDataModule(pl.LightningDataModule):
 
         self.train_dataset = None
         self.val_dataset = None
+        self.test_dataset = None
 
     def setup(self, stage: str | None = None) -> None:
         scene_dir = self._resolved.scene_dir
@@ -102,10 +105,21 @@ class EventDetectionDataModule(pl.LightningDataModule):
                 augment=False,
             )
 
+        if stage in ("test", None):
+            self.test_dataset = BLCSRallyEventDataset(
+                scene_dir=scene_dir,
+                split_file=self._resolved.test_split_file,
+                input_type=self._resolved.input_type,
+                config=self.config,
+                augment=False,
+            )
+
+    def _collate_fn(self):
+        return collate_3d if self._resolved.input_type == "3d" else collate_uv
+
     def train_dataloader(self) -> DataLoader:
         if self.train_dataset is None:
             raise RuntimeError("Call setup('fit') before train_dataloader().")
-        collate = collate_3d if self._resolved.input_type == "3d" else collate_uv
         return DataLoader(
             self.train_dataset,
             batch_size=self._resolved.batch_size,
@@ -113,18 +127,29 @@ class EventDetectionDataModule(pl.LightningDataModule):
             num_workers=self._resolved.num_workers,
             pin_memory=self._resolved.pin_memory,
             drop_last=True,
-            collate_fn=collate,
+            collate_fn=self._collate_fn(),
         )
 
     def val_dataloader(self) -> DataLoader:
         if self.val_dataset is None:
             raise RuntimeError("Call setup('fit') before val_dataloader().")
-        collate = collate_3d if self._resolved.input_type == "3d" else collate_uv
         return DataLoader(
             self.val_dataset,
             batch_size=self._resolved.batch_size,
             shuffle=False,
             num_workers=self._resolved.num_workers,
             pin_memory=self._resolved.pin_memory,
-            collate_fn=collate,
+            collate_fn=self._collate_fn(),
+        )
+
+    def test_dataloader(self) -> DataLoader:
+        if self.test_dataset is None:
+            raise RuntimeError("Call setup('test') before test_dataloader().")
+        return DataLoader(
+            self.test_dataset,
+            batch_size=self._resolved.batch_size,
+            shuffle=False,
+            num_workers=self._resolved.num_workers,
+            pin_memory=self._resolved.pin_memory,
+            collate_fn=self._collate_fn(),
         )

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -297,7 +297,7 @@ SMOKE_TASK_SPECS = (
                 overrides=("model=uv_transformer_nocourt",),
             ),
         ),
-        supports_test_phase=False,
+        supports_test_phase=True,
         expect_qualitative=True,
     ),
     SmokeTaskSpec(
@@ -334,7 +334,7 @@ SMOKE_TASK_SPECS = (
                 expect_gan_training=True,
             ),
         ),
-        supports_test_phase=False,
+        supports_test_phase=True,
         expect_qualitative=True,
     ),
     SmokeTaskSpec(
@@ -386,7 +386,7 @@ SMOKE_TASK_SPECS = (
             "model.max_seq_len=64",
         ),
         variants=(SmokeVariant(name="traj3d_transformer"),),
-        supports_test_phase=False,
+        supports_test_phase=True,
         expect_qualitative=True,
     ),
     SmokeTaskSpec(
@@ -423,7 +423,7 @@ SMOKE_TASK_SPECS = (
                 expect_gan_training=True,
             ),
         ),
-        supports_test_phase=False,
+        supports_test_phase=True,
         expect_qualitative=True,
     ),
     SmokeTaskSpec(


### PR DESCRIPTION
## Summary

- Add Event Detection test dataset and dataloader support so train CLIs can complete the fit plus test flow.
- Update training smoke expectations to treat Event Detection test phase as supported.

## Changes

- Read `data.split.test_file` in `EventDetectionDataModule` with `test.txt` as the default.
- Build a non-augmented test dataset in `setup('test')` and expose `test_dataloader()`.
- Mark Event Detection smoke variants as supporting test phase.

## Validation

- `python -m pytest tests/tasks/test_training_smoke_contracts.py::test_scene_training_smoke_contracts -k 'event_detection' --no-cov -q --tb=short` (7 passed after rebase onto latest `main`)
- GPU smoke: `python -m src.tasks.event_detection.scripts.train_uv ...` 1 epoch fit/test completed.
- GPU smoke: `python -m src.tasks.event_detection.scripts.train_3d ...` 1 epoch fit/test completed.

## Related Issues

- Closes #433

## Notes

- Rebased onto latest `main`; the existing `ManualGANSupportMixin` supplies the Lightning `test_step` path.
