### PR TITLE
Fix Trajectory Completion train test phase

### DIFF
--- a/src/tasks/trajectory_completion/data/datamodule.py
+++ b/src/tasks/trajectory_completion/data/datamodule.py
@@ -41,12 +41,14 @@ class TrajectoryCompletionDataModule(pl.LightningDataModule):
         split_cfg = data_cfg.get("split", {}) or {}
         self.train_file = str(split_cfg.get("train_file", "train.txt"))
         self.val_file = str(split_cfg.get("val_file", "val.txt"))
+        self.test_file = str(split_cfg.get("test_file", "test.txt"))
 
         self.batch_size = int(data_cfg.get("batch_size", 16))
         self.num_workers = int(data_cfg.get("num_workers", 4))
         self.pin_memory = bool(data_cfg.get("pin_memory", True))
         self.train_dataset = None
         self.val_dataset = None
+        self.test_dataset = None
 
     def setup(self, stage: str | None = None) -> None:
         if not self.scene_dir.exists():
@@ -62,6 +64,14 @@ class TrajectoryCompletionDataModule(pl.LightningDataModule):
             self.val_dataset = BLCSUVTrajectoryCompletionDataset(
                 scene_dir=self.scene_dir,
                 split_file=self.val_file,
+                config=self.config,
+                augment=False,
+            )
+
+        if stage in ("test", None):
+            self.test_dataset = BLCSUVTrajectoryCompletionDataset(
+                scene_dir=self.scene_dir,
+                split_file=self.test_file,
                 config=self.config,
                 augment=False,
             )
@@ -84,6 +94,19 @@ class TrajectoryCompletionDataModule(pl.LightningDataModule):
             raise RuntimeError("Call setup() before val_dataloader().")
         return DataLoader(
             self.val_dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            drop_last=False,
+            collate_fn=collate_uv_trajectories,
+        )
+
+    def test_dataloader(self) -> DataLoader:
+        if self.test_dataset is None:
+            raise RuntimeError("Call setup() before test_dataloader().")
+        return DataLoader(
+            self.test_dataset,
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=self.num_workers,

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -491,7 +491,7 @@ SMOKE_TASK_SPECS = (
                 ),
             ),
         ),
-        supports_test_phase=False,
+        supports_test_phase=True,
         expect_qualitative=True,
     ),
     SmokeTaskSpec(
@@ -535,7 +535,7 @@ SMOKE_TASK_SPECS = (
                 expect_gan_training=True,
             ),
         ),
-        supports_test_phase=False,
+        supports_test_phase=True,
         expect_qualitative=True,
     ),
 )


### PR DESCRIPTION
## Summary

- Add Trajectory Completion test dataset and dataloader support so the train CLI can complete the fit plus test flow.
- Update training smoke expectations to treat Trajectory Completion test phase as supported.

## Changes

- Read `data.split.test_file` in `TrajectoryCompletionDataModule` with `test.txt` as the default.
- Build a non-augmented test dataset in `setup('test')` and expose `test_dataloader()`.
- Mark Trajectory Completion smoke variants as supporting test phase.

## Validation

- `python -m pytest tests/tasks/test_training_smoke_contracts.py::test_scene_training_smoke_contracts -k 'trajectory_completion' --no-cov -q --tb=short` (4 passed after rebase onto latest `main`)
- GPU smoke: `python -m src.tasks.trajectory_completion.scripts.train ...` 1 epoch fit/test completed.

## Related Issues

- Closes #434

## Notes

- Rebased onto latest `main`; the existing `ManualGANSupportMixin` supplies the Lightning `test_step` path.
