### PR TITLE
Add worktrees to VS Code workspace

### DIFF
--- a/.agents/skills/git-worktree-create/SKILL.md
+++ b/.agents/skills/git-worktree-create/SKILL.md
@@ -86,12 +86,14 @@ ls -ld data .venv outputs third_party
 - Links `data`, `.venv`, `outputs`, and `third_party` from the primary worktree.
 - Adds local git exclude entries for those top-level links.
 - Marks tracked `third_party` entries as `skip-worktree` in the target worktree so the root symlink does not create noisy status output.
+- Adds the target worktree folder to the active VS Code window with `code --add` when the `code` command is available.
 
 Environment overrides:
 
 - `BASE_REF=<ref>`: default base ref when `--base` is omitted.
 - `WT_PARENT=<path>`: parent directory for new worktrees.
 - `WT_FORCE_LINKS=1`: replace non-empty untracked link paths when needed.
+- `WT_VSCODE_ADD=0`: skip adding the worktree folder to the active VS Code window.
 
 ## Definition of done
 

--- a/.agents/skills/git-worktree-create/scripts/create_worktree.sh
+++ b/.agents/skills/git-worktree-create/scripts/create_worktree.sh
@@ -11,9 +11,10 @@ Creates or reuses a git worktree for tennis-lab issue work and links shared path
   data, .venv, outputs, third_party
 
 Environment:
-  BASE_REF=main        Default base ref when --base is omitted.
-  WT_PARENT=<dir>      Parent directory for worktrees.
-  WT_FORCE_LINKS=1     Replace non-empty untracked link paths.
+  BASE_REF=main          Default base ref when --base is omitted.
+  WT_PARENT=<dir>        Parent directory for worktrees.
+  WT_FORCE_LINKS=1       Replace non-empty untracked link paths.
+  WT_VSCODE_ADD=0        Skip adding the worktree to the active VS Code window.
 USAGE
 }
 
@@ -24,6 +25,22 @@ die() {
 
 info() {
   echo "$*"
+}
+
+add_to_vscode_workspace() {
+  local target_worktree="$1"
+
+  [[ "${WT_VSCODE_ADD:-1}" != "0" ]] || return 0
+  command -v code >/dev/null 2>&1 || {
+    info "vscode=skipped (code command not found)"
+    return 0
+  }
+
+  if code --add "$target_worktree" >/dev/null 2>&1; then
+    info "vscode=added"
+  else
+    info "vscode=skipped (code --add failed)"
+  fi
 }
 
 slugify() {
@@ -261,6 +278,7 @@ replace_with_symlink "$WT_DIR" "$MAIN_WORKTREE" data
 replace_with_symlink "$WT_DIR" "$MAIN_WORKTREE" .venv
 replace_with_symlink "$WT_DIR" "$MAIN_WORKTREE" outputs
 link_third_party "$WT_DIR" "$MAIN_WORKTREE"
+add_to_vscode_workspace "$WT_DIR"
 
 info "branch=$BRANCH"
 info "worktree=$WT_DIR"


### PR DESCRIPTION
## Summary

- Automatically add newly created or reused worktrees to the active VS Code workspace.
- Document the VS Code auto-add behavior and opt-out environment variable.

## Changes

- Add `add_to_vscode_workspace` helper around `code --add`.
- Keep worktree creation successful when the `code` command is unavailable or fails.
- Add `WT_VSCODE_ADD=0` for callers that want to skip VS Code workspace registration.

## Validation

- `.agents/skills/git-worktree-create/scripts/create_worktree.sh --help`
- `WT_VSCODE_ADD=0 .agents/skills/git-worktree-create/scripts/create_worktree.sh --branch feat/issue-428-worktree-setup-skill`
- `git diff --check`

## Related Issues

- None
