### PR TITLE
GitHubテンプレートを日本語化

### DIFF
--- a/.agents/skills/gh-issue/SKILL.md
+++ b/.agents/skills/gh-issue/SKILL.md
@@ -11,6 +11,8 @@ Use this skill for issue creation, maintenance, and Project triage in `Motoki070
 
 This repository defines issue templates under `.github/ISSUE_TEMPLATE/`, so issue creation should start from those templates instead of writing a free-form body from scratch.
 
+Issue titles and bodies should be written in Japanese by default. Preserve GitHub keywords, labels, branch names, commands, file paths, and other technical identifiers in their original form when that is clearer.
+
 ## Defaults and fixed values
 
 - Repo: `Motoki0705/tennis-lab`
@@ -22,6 +24,7 @@ This repository defines issue templates under `.github/ISSUE_TEMPLATE/`, so issu
 ## Template selection rules
 
 - Preserve the selected template's section structure.
+- Fill issue titles, headings, and body text in Japanese.
 - Remove template comments and unused placeholder bullets before creating or updating the issue.
 
 ## Labels in this repo (from `gh label list`)

--- a/.agents/skills/gh-pr-create/SKILL.md
+++ b/.agents/skills/gh-pr-create/SKILL.md
@@ -9,6 +9,8 @@ description: Use this skill when creating a new GitHub pull request for Motoki07
 
 Use this skill for PR creation in `Motoki0705/tennis-lab`.
 
+PR titles and bodies should be written in Japanese by default. Preserve GitHub keywords such as `Closes`, labels, branch names, commands, file paths, and other technical identifiers in their original form when that is clearer.
+
 ## Fixed defaults
 
 - Repo: `Motoki0705/tennis-lab`
@@ -18,6 +20,7 @@ Use this skill for PR creation in `Motoki0705/tennis-lab`.
 ## Template rules
 
 - Preserve the PR template's section structure.
+- Fill PR titles, headings, and body text in Japanese.
 - Remove template comments and unused placeholder bullets before creating the PR.
 
 ## Create a PR

--- a/.github/ISSUE_TEMPLATE/01_bug.md
+++ b/.github/ISSUE_TEMPLATE/01_bug.md
@@ -1,50 +1,50 @@
 ---
-name: Bug Report
-about: Report a defect, regression, or unexpected behavior
-title: "[Bug] "
+name: バグ報告
+about: 不具合、リグレッション、想定外の挙動を報告する
+title: "[バグ] "
 labels: ["bug"]
 ---
 
-## Summary
+## 概要
 
-<!-- Describe the bug in 1-3 lines. -->
-
--
-
-## Expected Behavior
-
-<!-- Describe the expected behavior. -->
+<!-- 不具合の内容を1〜3行で説明してください。 -->
 
 -
 
-## Actual Behavior
+## 期待される挙動
 
-<!-- Describe what actually happened. -->
+<!-- 本来どのように動くべきかを説明してください。 -->
 
 -
 
-## Steps To Reproduce
+## 実際の挙動
 
-<!-- List the minimum steps needed to reproduce the issue. -->
+<!-- 実際に何が起きたかを説明してください。 -->
+
+-
+
+## 再現手順
+
+<!-- 再現に必要な最小手順を記載してください。 -->
 
 1.
 2.
 3.
 
-## Scope / Impact
+## 影響範囲
 
-<!-- Describe affected modules, users, or workflows. -->
-
--
-
-## Validation / Artifacts
-
-<!-- Add logs, screenshots, metrics, commands, or file paths if available. -->
+<!-- 影響を受けるモジュール、ユーザー、ワークフローを記載してください。 -->
 
 -
 
-## Notes
+## 検証情報・成果物
 
-<!-- Optional: assumptions, temporary workaround, or follow-up context. -->
+<!-- ログ、スクリーンショット、メトリクス、実行コマンド、ファイルパスなどがあれば記載してください。 -->
+
+-
+
+## 補足
+
+<!-- 任意: 前提、暫定回避策、追加の文脈などを記載してください。 -->
 
 -

--- a/.github/ISSUE_TEMPLATE/02_feature.md
+++ b/.github/ISSUE_TEMPLATE/02_feature.md
@@ -1,44 +1,44 @@
 ---
-name: Feature Request
-about: Propose a feature, enhancement, or implementation task
-title: "[Feature] "
+name: 機能要望
+about: 機能、改善、実装タスクを提案する
+title: "[機能] "
 labels: ["enhancement"]
 ---
 
-## Summary
+## 概要
 
-<!-- Describe the requested feature or change in 1-3 lines. -->
-
--
-
-## Problem
-
-<!-- Explain the problem, limitation, or opportunity this addresses. -->
+<!-- 要望する機能や変更を1〜3行で説明してください。 -->
 
 -
 
-## Proposal
+## 課題
 
-<!-- Describe the proposed approach. -->
-
--
-
-## Scope
-
-<!-- Clarify what is in scope and out of scope if needed. -->
+<!-- この変更で解決したい課題、制約、機会を説明してください。 -->
 
 -
 
-## Acceptance Criteria
+## 提案
 
-<!-- List the conditions for considering this work complete. -->
+<!-- 想定している対応方針を説明してください。 -->
+
+-
+
+## スコープ
+
+<!-- 必要に応じて、対応範囲と対象外を明確にしてください。 -->
+
+-
+
+## 受け入れ条件
+
+<!-- 完了と判断する条件を記載してください。 -->
 
 -
 -
 -
 
-## Notes
+## 補足
 
-<!-- Optional: dependencies, risks, alternatives, or references. -->
+<!-- 任意: 依存関係、リスク、代替案、参照情報などを記載してください。 -->
 
 -

--- a/.github/ISSUE_TEMPLATE/03_research.md
+++ b/.github/ISSUE_TEMPLATE/03_research.md
@@ -1,44 +1,44 @@
 ---
-name: Research
-about: Track investigation, research, or exploratory work
-title: "[Research] "
+name: 調査
+about: 調査、検証、探索的な作業を管理する
+title: "[調査] "
 labels: ["research"]
 ---
 
-## Summary
+## 概要
 
-<!-- Describe what needs to be investigated. -->
-
--
-
-## Motivation
-
-<!-- Explain why this investigation is needed now. -->
+<!-- 調査したい内容を説明してください。 -->
 
 -
 
-## Questions
+## 背景
 
-<!-- List the main questions this research should answer. -->
+<!-- なぜ今この調査が必要なのかを説明してください。 -->
+
+-
+
+## 確認したいこと
+
+<!-- この調査で答えるべき主な問いを記載してください。 -->
 
 -
 -
 -
 
-## Approach
+## 調査方針
 
-<!-- Describe the planned investigation method, sources, or experiments. -->
-
--
-
-## Deliverables
-
-<!-- Describe the expected output: memo, recommendation, prototype, etc. -->
+<!-- 調査方法、参照する情報源、実験内容などを記載してください。 -->
 
 -
 
-## Notes
+## 成果物
 
-<!-- Optional: constraints, assumptions, related links, or follow-ups. -->
+<!-- 想定するアウトプット: メモ、提案、プロトタイプなどを記載してください。 -->
+
+-
+
+## 補足
+
+<!-- 任意: 制約、前提、関連リンク、後続作業などを記載してください。 -->
 
 -

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,44 +1,44 @@
 <!--
-PR body template for `gh pr create --body-file`.
+`gh pr create --body-file` 用のPR本文テンプレートです。
 
-Suggested workflow:
-1. Copy this file to a tmp file.
+推奨ワークフロー:
+1. このファイルを一時ファイルにコピーする。
    BODY_FILE="$(mktemp /tmp/pr-body-XXXXXX.md)"
    cp .github/pull_request_template.md "$BODY_FILE"
-2. Edit the tmp file and remove guidance comments if they are no longer needed.
-3. Create the PR with:
+2. 一時ファイルを編集し、不要な案内コメントを削除する。
+3. 次のようにPRを作成する。
    gh pr create --body-file "$BODY_FILE"
 -->
 
-## Summary
+## 概要
 
-<!-- What this PR changes in 2-5 lines. -->
-
--
-
-## Changes
-
-<!-- List concrete implementation changes. -->
-
--
--
--
-
-## Validation
-
-<!-- List commands you ran or checks you performed. If untested, say why. -->
+<!-- このPRで変更する内容を2〜5行で記載してください。 -->
 
 -
 
-## Related Issues
+## 変更内容
 
-<!-- Use GitHub closing/reference keywords as needed. -->
+<!-- 具体的な実装変更を記載してください。 -->
+
+-
+-
+-
+
+## 検証
+
+<!-- 実行したコマンドや確認内容を記載してください。未検証の場合は理由を書いてください。 -->
+
+-
+
+## 関連Issue
+
+<!-- 必要に応じて GitHub の closing/reference キーワードを使用してください。 -->
 
 - Closes #
 - References #
 
-## Notes
+## 補足
 
-<!-- Optional: reviewers should know this before merging. Delete if not needed. -->
+<!-- 任意: レビュー時やマージ前に共有したいことがあれば記載してください。不要なら削除してください。 -->
 
 -


### PR DESCRIPTION
## 概要

- IssueテンプレートとPRテンプレートを日本語化しました。
- `gh-issue` / `gh-pr-create` skill に、Issue/PRのタイトルと本文を日本語で作成する運用を明記しました。

## 変更内容

- バグ報告、機能要望、調査のIssueテンプレートを日本語化
- PR本文テンプレートの見出しと案内コメントを日本語化
- GitHubキーワードや技術識別子は必要に応じて原文のまま残す方針をskillに追記

## 検証

- `.agents/skills/gh-pr-create/scripts/prepare_body.sh .github/pull_request_template.md`
- `git diff --check origin/main...HEAD`

## 関連Issue

- なし
