### PR TITLE
worktree のデフォルト作成先を .worktrees に変更

### DIFF
--- a/.agents/skills/git-worktree-create/SKILL.md
+++ b/.agents/skills/git-worktree-create/SKILL.md
@@ -45,7 +45,7 @@ feat__issue-428-worktree-setup-skill
 By default, worktrees are created under:
 
 ```text
-../tennis-lab.worktrees/
+.worktrees/
 ```
 
 ## Standard workflow
@@ -83,6 +83,7 @@ ls -ld data .venv outputs third_party
 - Resolves the repository's common git dir and primary worktree.
 - Fetches `origin/<base>` when possible without switching the current checkout.
 - Creates a branch from `origin/main` by default, or reuses an existing branch worktree.
+- Creates new worktrees under the primary worktree's `.worktrees/` directory by default.
 - Links `data`, `.venv`, `outputs`, and `third_party` from the primary worktree.
 - Adds local git exclude entries for those top-level links.
 - Marks tracked `third_party` entries as `skip-worktree` in the target worktree so the root symlink does not create noisy status output.

--- a/.agents/skills/git-worktree-create/scripts/create_worktree.sh
+++ b/.agents/skills/git-worktree-create/scripts/create_worktree.sh
@@ -242,7 +242,7 @@ COMMON_GIT_DIR="${repo_context[0]}"
 MAIN_WORKTREE="${repo_context[1]}"
 
 if [[ -z "$WT_PARENT" ]]; then
-  WT_PARENT="$(dirname "$MAIN_WORKTREE")/$(basename "$MAIN_WORKTREE").worktrees"
+  WT_PARENT="$MAIN_WORKTREE/.worktrees"
 fi
 
 mkdir -p "$WT_PARENT"

--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,7 @@ Thumbs.db
 
 # Agent workspace
 agents_workspace/tmp_cache/
+.worktrees/
 
 # Large files that should be tracked separately
 *.zip


### PR DESCRIPTION
## 概要

worktree 作成 skill のデフォルト作成先を、リポジトリ外の `../tennis-lab.worktrees/` から primary worktree 内の `.worktrees/` に変更します。

VS Code の Source Control で worktree を扱いやすくしつつ、`.worktrees/` 自体は Git 管理対象外にします。

## 変更内容

- `create_worktree.sh` のデフォルト `WT_PARENT` を `$MAIN_WORKTREE/.worktrees` に変更
- `git-worktree-create` skill の説明を `.worktrees/` 前提に更新
- `.gitignore` に `.worktrees/` を追加

## 検証

- `bash -n .agents/skills/git-worktree-create/scripts/create_worktree.sh`
- `git diff --check`

## 関連Issue

なし
