### PR TITLE
chore(config): タスク設定のデフォルト値を調整

### DIFF
--- a/src/tasks/blcs/configs/data/chunked_multi.yaml
+++ b/src/tasks/blcs/configs/data/chunked_multi.yaml
@@ -17,7 +17,7 @@ pin_memory: true
 
 # Sequence/view sampling ranges (inclusive)
 seq_len_range: [64, 256]
-num_views_range: [4, 8]
+num_views_range: [4, 6]
 
 # Camera selection mode: "random", "first", or camera index
 camera_mode: "random"

--- a/src/tasks/blcs/configs/data/multiview.yaml
+++ b/src/tasks/blcs/configs/data/multiview.yaml
@@ -15,7 +15,7 @@ num_workers: 4
 
 # Sequence/view sampling ranges (inclusive)
 seq_len_range: [64, 256]
-num_views_range: [4, 8]
+num_views_range: [4, 6]
 
 # Camera selection mode: "random", "first", or camera index
 camera_mode: "random"

--- a/src/tasks/blcs/configs/train.yaml
+++ b/src/tasks/blcs/configs/train.yaml
@@ -1,6 +1,6 @@
 defaults:
-  - model: single
-  - data: single
+  - model: multiview_axial
+  - data: multiview_axial
   - training: default
   - metrics: default
   - run: train

--- a/src/tasks/blcs/configs/training/default.yaml
+++ b/src/tasks/blcs/configs/training/default.yaml
@@ -8,7 +8,7 @@ trainer:
   gradient_clip_val: 1.0
   deterministic: true
   precision: "bf16-mixed"
-  log_every_n_steps: 50
+  log_every_n_steps: 100
   check_val_every_n_epoch: 1
 
 # ---- Optimizer / schedule (LightningModule references) ----

--- a/src/tasks/event_detection/configs/data/blcs_rally_3d.yaml
+++ b/src/tasks/event_detection/configs/data/blcs_rally_3d.yaml
@@ -16,7 +16,7 @@ pin_memory: true
 # camera_mode is not used for 3d input_type but kept for config consistency
 camera_mode: "random"
 
-seq_len_range: [16, 1024]
+seq_len_range: [64, 1024]
 
 label:
   sigma_frames: 2.5

--- a/src/tasks/event_detection/configs/data/blcs_rally_uv.yaml
+++ b/src/tasks/event_detection/configs/data/blcs_rally_uv.yaml
@@ -21,7 +21,7 @@ pin_memory: true
 camera_mode: "random"
 
 # Sequence/window sampling
-seq_len_range: [16, 1024]
+seq_len_range: [64, 1024]
 
 # Labels (soft targets)
 label:

--- a/src/tasks/event_detection/configs/data/chunked_blcs_rally_3d.yaml
+++ b/src/tasks/event_detection/configs/data/chunked_blcs_rally_3d.yaml
@@ -18,7 +18,7 @@ pin_memory: true
 # camera_mode is not used for 3d input_type but kept for config consistency
 camera_mode: "random"
 
-seq_len_range: [16, 1024]
+seq_len_range: [64, 1024]
 
 generator_device: "cpu"
 

--- a/src/tasks/event_detection/configs/data/chunked_blcs_rally_uv.yaml
+++ b/src/tasks/event_detection/configs/data/chunked_blcs_rally_uv.yaml
@@ -23,7 +23,7 @@ pin_memory: true
 camera_mode: "random"
 
 # Sequence/window sampling
-seq_len_range: [16, 1024]
+seq_len_range: [64, 1024]
 
 generator_device: "cpu"
 

--- a/src/tasks/event_detection/configs/model/traj3d_transformer.yaml
+++ b/src/tasks/event_detection/configs/model/traj3d_transformer.yaml
@@ -1,6 +1,6 @@
 name: traj3d_transformer
-hidden_dim: 256
-num_layers: 6
+hidden_dim: 512
+num_layers: 12
 num_heads: 8
 dropout: 0.1
 ffn_dim: null

--- a/src/tasks/event_detection/configs/model/uv_transformer.yaml
+++ b/src/tasks/event_detection/configs/model/uv_transformer.yaml
@@ -1,6 +1,6 @@
 name: uv_transformer
-hidden_dim: 256
-num_layers: 6
+hidden_dim: 512
+num_layers: 12
 num_heads: 8
 dropout: 0.1
 ffn_dim: null

--- a/src/tasks/event_detection/configs/model/uv_transformer_nocourt.yaml
+++ b/src/tasks/event_detection/configs/model/uv_transformer_nocourt.yaml
@@ -1,6 +1,6 @@
 name: uv_transformer_nocourt
-hidden_dim: 256
-num_layers: 6
+hidden_dim: 512
+num_layers: 12
 num_heads: 8
 dropout: 0.1
 ffn_dim: null

--- a/src/tasks/plcs/configs/data/multiview.yaml
+++ b/src/tasks/plcs/configs/data/multiview.yaml
@@ -15,7 +15,7 @@ min_cameras: 2
 num_views_range: [3, 6]  # [min, max]
 
 # Sequence sampling
-seq_len_range: [64, 512]  # [min, max]
+seq_len_range: [64, 256]  # [min, max]
 
 augmentation:
   keypoint_noise_std: 0.0001

--- a/src/tasks/trajectory_completion/configs/data/blcs_rally_uv.yaml
+++ b/src/tasks/trajectory_completion/configs/data/blcs_rally_uv.yaml
@@ -14,7 +14,7 @@ split:
   test_file: test.txt
 
 camera_mode: random  # random | int camera index
-seq_len_range: [16, 1024]
+seq_len_range: [64, 1024]
 
 batch_size: 16
 num_workers: 4

--- a/src/tasks/trajectory_completion/configs/data/chunked_blcs_rally_uv.yaml
+++ b/src/tasks/trajectory_completion/configs/data/chunked_blcs_rally_uv.yaml
@@ -15,7 +15,7 @@ split:
   test_file: test.txt
 
 camera_mode: random
-seq_len_range: [16, 1024]
+seq_len_range: [64, 1024]
 
 batch_size: 16
 num_workers: 4

--- a/src/tasks/trajectory_completion/configs/model/uv_transformer.yaml
+++ b/src/tasks/trajectory_completion/configs/model/uv_transformer.yaml
@@ -1,7 +1,7 @@
 name: uv_transformer
 
-hidden_dim: 256
-num_ball_layers: 6
+hidden_dim: 512
+num_ball_layers: 12
 num_query_layers: 2
 num_heads: 8
 dropout: 0.1

--- a/src/tasks/trajectory_completion/configs/model/uv_transformer_nocourt.yaml
+++ b/src/tasks/trajectory_completion/configs/model/uv_transformer_nocourt.yaml
@@ -1,8 +1,8 @@
 name: uv_transformer_nocourt
 init_from_court_checkpoint: null
 
-hidden_dim: 256
-num_layers: 6
+hidden_dim: 512
+num_ball_layers: 12
 num_heads: 8
 dropout: 0.1
 ffn_dim: 704


### PR DESCRIPTION
## 概要

- タスク横断で学習用 config のデフォルト値を見直し、シーケンス長・ビュー数・Transformer 規模・ログ間隔を調整しました。

## 変更内容

- BLCS の既定データセットとモデル構成を multiview_axial 系へ切り替え、ビュー数上限とログ出力間隔を調整しました。
- Event detection と trajectory completion で入力シーケンス長の下限を 64 に引き上げ、Transformer 系モデルの hidden_dim とレイヤ数を増やしました。
- PLCS の multiview データ設定でシーケンス長の上限を 256 に縮めました。

## 検証

- git diff --check
- VS Code Problems: 変更した 16 個の YAML にエラーなし

## 関連Issue

- なし

## 補足

- 既存の未コミット変更を一時退避し、最新の main を fast-forward した後に新規ブランチへ復元して PR を作成しています。
