### PR TITLE
DINO pseudo3d のデフォルトバックボーンを Swin に切り替える

### DIFF
--- a/src/tasks/ball_detection/configs/model/dino_pseudo3d.yaml
+++ b/src/tasks/ball_detection/configs/model/dino_pseudo3d.yaml
@@ -14,8 +14,8 @@ input_layout: bcthw
 # Swin-only options:
 # backbone_pretrain_img_size: null  # auto-resolve from backbone_name, e.g. 384
 # backbone_use_checkpoint: false    # enable only when you need lower GPU memory
-backbone_checkpoint_path: /mnt/d/weights/DINO/backbone_body_state.pth
-backbone_name: resnet50
+backbone_checkpoint_path: null
+backbone_name: swin_L_384_22k
 backbone_dilation: false
 return_interm_indices: [0, 1, 2, 3]
 # Swin only. Ignored for ResNet backbones.


### PR DESCRIPTION
## 概要

DINO pseudo3d のモデル設定を、ResNet バックボーン前提から Swin-L 5-scale バックボーン前提へ切り替えます。
Colab で抽出した Swin backbone checkpoint を指定して学習できる状態にします。

## 変更内容

- `dino_pseudo3d.yaml` の `backbone_name` を `swin_L_384_22k` に変更
- `backbone_checkpoint_path` を環境依存の `/mnt/d/...` から `null` に変更
- Colab 実行時に Hydra override で `/content/tennis-lab/checkpoints/DINO/swin_backbone_state_checkpoint0027_5scale.pth` を指定できる前提に整理

## 検証

- `git diff` で設定差分を確認
- 実学習コマンドは Colab 上で実行予定

## 関連Issue

- なし

## 補足

Swin backbone checkpoint のダウンロード、抽出、inspect、学習コマンドは別途案内します。
