### PR TITLE
BLCS axialでGQA attentionを比較検証する

### DIFF
--- a/src/tasks/base/training/runner.py
+++ b/src/tasks/base/training/runner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import types
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -16,7 +17,11 @@ import pytorch_lightning as pl
 import torch
 from hydra.utils import to_absolute_path
 from omegaconf import OmegaConf
-from pytorch_lightning.callbacks import EarlyStopping, LearningRateMonitor, ModelCheckpoint
+from pytorch_lightning.callbacks import (
+    EarlyStopping,
+    LearningRateMonitor,
+    ModelCheckpoint,
+)
 from pytorch_lightning.loggers import TensorBoardLogger
 
 from src.tasks.base.training.qualitative_callback import QualitativeLoggingCallback
@@ -57,12 +62,14 @@ class BaseTrainingRunner:
         logger = self.build_logger(config, output_dir)
         callbacks = self.build_callbacks(config, datamodule, logger)
         trainer = self.build_trainer(config, callbacks, logger)
+        resume_ckpt = self.resolve_resume(config, output_dir)
 
-        trainer.fit(
-            lightning_module,
-            datamodule=datamodule,
-            ckpt_path=self.resolve_resume(config, output_dir),
-        )
+        with self.resume_checkpoint_load_env(resume_ckpt):
+            trainer.fit(
+                lightning_module,
+                datamodule=datamodule,
+                ckpt_path=resume_ckpt,
+            )
 
         if not self.skip_test(config):
             trainer.test(lightning_module, datamodule=datamodule)
@@ -95,7 +102,9 @@ class BaseTrainingRunner:
 
     def _apply_gan_runtime_config(self, config: Any) -> None:
         if not self._gan_enabled(config):
-            raise RuntimeError("GAN runtime config should only be applied when GAN is enabled.")
+            raise RuntimeError(
+                "GAN runtime config should only be applied when GAN is enabled."
+            )
         config.training.early_stopping.enabled = False
         config.training.trainer.gradient_clip_val = None
 
@@ -112,6 +121,23 @@ class BaseTrainingRunner:
             return None
         return self._ensure_absolute(str(resume))
 
+    @contextmanager
+    def resume_checkpoint_load_env(self, resume_ckpt: str | None):
+        """Temporarily allow full-state loading for trusted local resume checkpoints."""
+        if not resume_ckpt:
+            yield
+            return
+
+        env_key = "TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"
+        previous_value = os.environ.get(env_key)
+        if previous_value is None:
+            os.environ[env_key] = "1"
+        try:
+            yield
+        finally:
+            if previous_value is None:
+                os.environ.pop(env_key, None)
+
     def callbacks_extra(
         self, config: Any, datamodule: pl.LightningDataModule, logger: TensorBoardLogger
     ) -> list[Any]:
@@ -120,7 +146,9 @@ class BaseTrainingRunner:
         _ = logger
         extras: list[Any] = []
         if self._gan_enabled(config):
-            from src.tasks.base.training.gan_transition_callback import GANTransitionCallback
+            from src.tasks.base.training.gan_transition_callback import (
+                GANTransitionCallback,
+            )
 
             extras.append(GANTransitionCallback(config))
         return extras
@@ -253,9 +281,15 @@ class BaseTrainingRunner:
 
         if trainer_cfg.precision is not None:
             precision = trainer_cfg.precision
-            if str(precision) == "bf16-mixed" and torch.cuda.is_available() and not torch.cuda.is_bf16_supported():
+            if (
+                str(precision) == "bf16-mixed"
+                and torch.cuda.is_available()
+                and not torch.cuda.is_bf16_supported()
+            ):
                 precision = "16-mixed"
-                print("bf16-mixed is not supported on this GPU. Falling back to 16-mixed.")
+                print(
+                    "bf16-mixed is not supported on this GPU. Falling back to 16-mixed."
+                )
             kwargs["precision"] = precision
 
         optional_trainer_keys = (

--- a/src/tasks/blcs/configs/model/multiview_axial.yaml
+++ b/src/tasks/blcs/configs/model/multiview_axial.yaml
@@ -9,6 +9,8 @@ hidden_dim: 512
 
 num_layers: 8
 num_heads: 8
+attention_type: mha
+num_kv_heads: null
 ffn_dim: null
 ffn_type: swiglu
 dropout: 0.1

--- a/src/tasks/blcs/models/blcs_multiview_axial_model.py
+++ b/src/tasks/blcs/models/blcs_multiview_axial_model.py
@@ -28,6 +28,8 @@ class BLCSMultiViewAxialModel(nn.Module):
         self,
         hidden_dim: int = 256,
         num_heads: int = 8,
+        attention_type: Literal["mha", "gqa"] = "mha",
+        num_kv_heads: int | None = None,
         ffn_dim: int | None = None,
         ffn_type: Literal["swiglu", "mlp"] = "swiglu",
         dropout: float = 0.1,
@@ -52,9 +54,7 @@ class BLCSMultiViewAxialModel(nn.Module):
         if max_seq_len <= 0:
             raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
         if max_num_cameras <= 0:
-            raise ValueError(
-                f"max_num_cameras must be positive, got {max_num_cameras}"
-            )
+            raise ValueError(f"max_num_cameras must be positive, got {max_num_cameras}")
         if num_layers < 0:
             raise ValueError(f"num_layers must be non-negative, got {num_layers}")
 
@@ -100,6 +100,8 @@ class BLCSMultiViewAxialModel(nn.Module):
                         head_dim=head_dim,
                         rope_dim=self.rope_dim,
                         attn_dropout=dropout,
+                        attention_type=attention_type,
+                        n_kv_heads=num_kv_heads,
                         rope_base=self.rope_bases[1],
                         ffn_type=ffn_type,
                     )
@@ -117,6 +119,8 @@ class BLCSMultiViewAxialModel(nn.Module):
                         head_dim=head_dim,
                         rope_dim=self.rope_dim,
                         attn_dropout=dropout,
+                        attention_type=attention_type,
+                        n_kv_heads=num_kv_heads,
                         rope_base=self.rope_bases[0],
                         ffn_type=ffn_type,
                     )
@@ -163,8 +167,14 @@ class BLCSMultiViewAxialModel(nn.Module):
         return cls(
             hidden_dim=int(model_cfg.get("hidden_dim", 256)),
             num_heads=int(model_cfg.get("num_heads", 8)),
+            attention_type=cast(
+                Literal["mha", "gqa"], str(model_cfg.get("attention_type", "mha"))
+            ),
+            num_kv_heads=model_cfg.get("num_kv_heads", None),
             ffn_dim=model_cfg.get("ffn_dim", None),
-            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
+            ),
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_dim=model_cfg.get("rope_dim", None),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
@@ -172,10 +182,18 @@ class BLCSMultiViewAxialModel(nn.Module):
             rope_theta_camera=model_cfg.get("rope_theta_camera", None),
             num_layers=int(model_cfg.get("num_layers", 4)),
             predict_velocity=bool(model_cfg.get("predict_velocity", False)),
-            max_seq_len=int(model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))),
-            max_num_cameras=int(model_cfg.get("max_num_cameras", model_cfg.get("max_views", 8))),
+            max_seq_len=int(
+                model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))
+            ),
+            max_num_cameras=int(
+                model_cfg.get("max_num_cameras", model_cfg.get("max_views", 8))
+            ),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
-            num_court_tokens=int(model_cfg.get("num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP))),
+            num_court_tokens=int(
+                model_cfg.get(
+                    "num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP)
+                )
+            ),
         )
 
     @staticmethod
@@ -210,21 +228,29 @@ class BLCSMultiViewAxialModel(nn.Module):
 
     def _camera_freqs(self, *, batch_size: int, seq_len: int, n_cams: int) -> Tensor:
         freqs = self.token_freqs_cis[:seq_len, :n_cams]
-        return freqs.unsqueeze(0).expand(
-            batch_size,
-            seq_len,
-            n_cams,
-            self.rope_dim // 2,
-        ).reshape(batch_size * seq_len, n_cams, self.rope_dim // 2)
+        return (
+            freqs.unsqueeze(0)
+            .expand(
+                batch_size,
+                seq_len,
+                n_cams,
+                self.rope_dim // 2,
+            )
+            .reshape(batch_size * seq_len, n_cams, self.rope_dim // 2)
+        )
 
     def _time_freqs(self, *, batch_size: int, seq_len: int, n_cams: int) -> Tensor:
         freqs = self.token_freqs_cis[:seq_len, :n_cams].permute(1, 0, 2)
-        return freqs.unsqueeze(0).expand(
-            batch_size,
-            n_cams,
-            seq_len,
-            self.rope_dim // 2,
-        ).reshape(batch_size * n_cams, seq_len, self.rope_dim // 2)
+        return (
+            freqs.unsqueeze(0)
+            .expand(
+                batch_size,
+                n_cams,
+                seq_len,
+                self.rope_dim // 2,
+            )
+            .reshape(batch_size * n_cams, seq_len, self.rope_dim // 2)
+        )
 
     def forward(
         self,
@@ -236,7 +262,9 @@ class BLCSMultiViewAxialModel(nn.Module):
     ) -> dict[str, Tensor]:
         """Forward pass for multi-view BLCS inputs."""
         if ball_uv.dim() != 4:
-            raise ValueError(f"ball_uv must have shape (B, N, T, 2), got {tuple(ball_uv.shape)}")
+            raise ValueError(
+                f"ball_uv must have shape (B, N, T, 2), got {tuple(ball_uv.shape)}"
+            )
 
         batch_size, n_cams, seq_len_in, _ = ball_uv.shape
         if seq_len_in > self.max_seq_len:
@@ -279,9 +307,13 @@ class BLCSMultiViewAxialModel(nn.Module):
                 )
 
         if ball_vis is None:
-            raise ValueError("ball_vis is required for BLCSMultiViewAxialModel forward.")
+            raise ValueError(
+                "ball_vis is required for BLCSMultiViewAxialModel forward."
+            )
         if ball_mask is None:
-            raise ValueError("ball_mask is required for BLCSMultiViewAxialModel forward.")
+            raise ValueError(
+                "ball_mask is required for BLCSMultiViewAxialModel forward."
+            )
         if ball_vis.shape != (batch_size, n_cams, seq_len_in):
             raise ValueError(
                 f"ball_vis must have shape {(batch_size, n_cams, seq_len_in)}, "
@@ -293,20 +325,28 @@ class BLCSMultiViewAxialModel(nn.Module):
                 f"got {tuple(ball_mask.shape)}"
             )
 
-        court_flat = court_kp.reshape(batch_size * n_cams * seq_len_in, self.num_court_tokens, 2)
+        court_flat = court_kp.reshape(
+            batch_size * n_cams * seq_len_in, self.num_court_tokens, 2
+        )
         ball_flat = ball_uv.reshape(batch_size * n_cams * seq_len_in, 2)
         group_vis = ball_vis.reshape(batch_size * n_cams * seq_len_in)
-        x = self.group_embed(court_flat, ball_flat, group_vis).reshape(
-            batch_size,
-            n_cams,
-            seq_len_in,
-            self.hidden_dim,
-        ).permute(0, 2, 1, 3)
+        x = (
+            self.group_embed(court_flat, ball_flat, group_vis)
+            .reshape(
+                batch_size,
+                n_cams,
+                seq_len_in,
+                self.hidden_dim,
+            )
+            .permute(0, 2, 1, 3)
+        )
 
         token_valid = (ball_mask > 0).permute(0, 2, 1)
 
         camera_valid = token_valid.reshape(batch_size * seq_len_in, n_cams)
-        time_valid = token_valid.permute(0, 2, 1).reshape(batch_size * n_cams, seq_len_in)
+        time_valid = token_valid.permute(0, 2, 1).reshape(
+            batch_size * n_cams, seq_len_in
+        )
         camera_mask, _ = self._build_self_attn_mask(camera_valid)
         time_mask, _ = self._build_self_attn_mask(time_valid)
         camera_freqs = self._camera_freqs(
@@ -333,13 +373,17 @@ class BLCSMultiViewAxialModel(nn.Module):
             )
             x = x_camera.reshape(batch_size, seq_len_in, n_cams, self.hidden_dim)
 
-            x_time = x.permute(0, 2, 1, 3).reshape(batch_size * n_cams, seq_len_in, self.hidden_dim)
+            x_time = x.permute(0, 2, 1, 3).reshape(
+                batch_size * n_cams, seq_len_in, self.hidden_dim
+            )
             x_time = time_layer(
                 x_time,
                 freqs_cis=time_freqs,
                 attn_mask=time_mask,
             )
-            x = x_time.reshape(batch_size, n_cams, seq_len_in, self.hidden_dim).permute(0, 2, 1, 3)
+            x = x_time.reshape(batch_size, n_cams, seq_len_in, self.hidden_dim).permute(
+                0, 2, 1, 3
+            )
 
         x = x[:, :, 0, :]
         x = self.final_norm(x)

--- a/src/tasks/blcs/models/blcs_multiview_axial_model.py
+++ b/src/tasks/blcs/models/blcs_multiview_axial_model.py
@@ -167,14 +167,10 @@ class BLCSMultiViewAxialModel(nn.Module):
         return cls(
             hidden_dim=int(model_cfg.get("hidden_dim", 256)),
             num_heads=int(model_cfg.get("num_heads", 8)),
-            attention_type=cast(
-                Literal["mha", "gqa"], str(model_cfg.get("attention_type", "mha"))
-            ),
+            attention_type=str(model_cfg.get("attention_type", "mha")),
             num_kv_heads=model_cfg.get("num_kv_heads", None),
             ffn_dim=model_cfg.get("ffn_dim", None),
-            ffn_type=cast(
-                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
-            ),
+            ffn_type=str(model_cfg.get("ffn_type", "swiglu")),
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_dim=model_cfg.get("rope_dim", None),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),

--- a/src/utils/models/__init__.py
+++ b/src/utils/models/__init__.py
@@ -4,10 +4,14 @@ Strategy A: treat the DeepSeek-style, pure PyTorch implementation in
 `src.utils.models.components` as canonical and re-export it here.
 """
 
+from src.utils.models.architectures import (
+    TransformerSequenceDiscriminator,
+)
 from src.utils.models.components import (
     MLP,
     CrossAttnBlock,
     CrossAttnBlockConfig,
+    GroupedQuerySelfAttention,
     LayerNorm,
     MultiHeadCrossAttention,
     MultiHeadSelfAttention,
@@ -27,12 +31,10 @@ from src.utils.models.embeddings import (
     InvisibleTokenEmbedding,
     PlayerKPUVEmbedding,
 )
-from src.utils.models.architectures import (
-    TransformerSequenceDiscriminator,
-)
 
 __all__ = [
     # Attention
+    "GroupedQuerySelfAttention",
     "MultiHeadCrossAttention",
     "MultiHeadSelfAttention",
     # Norm

--- a/src/utils/models/components/__init__.py
+++ b/src/utils/models/components/__init__.py
@@ -14,6 +14,7 @@ Strategy A treats the DeepSeek-style implementation as canonical.
 """
 
 from src.utils.models.components.attention import (
+    GroupedQuerySelfAttention,
     MultiHeadCrossAttention,
     MultiHeadSelfAttention,
 )
@@ -33,6 +34,7 @@ from src.utils.models.components.rope import (
 
 __all__ = [
     # Attention
+    "GroupedQuerySelfAttention",
     "MultiHeadCrossAttention",
     "MultiHeadSelfAttention",
     # Norm

--- a/src/utils/models/components/attention.py
+++ b/src/utils/models/components/attention.py
@@ -40,15 +40,21 @@ def _normalize_attn_mask(
 
     if attn_mask.dim() == 2:
         if attn_mask.shape != (q_len, k_len):
-            raise ValueError(f"attn_mask shape must be {(q_len, k_len)}, got {tuple(attn_mask.shape)}")
+            raise ValueError(
+                f"attn_mask shape must be {(q_len, k_len)}, got {tuple(attn_mask.shape)}"
+            )
         attn_mask = attn_mask[None, None, :, :]  # (1,1,q,k)
     elif attn_mask.dim() == 3:
         if attn_mask.shape[1:] != (q_len, k_len):
-            raise ValueError(f"attn_mask shape must be (B,{q_len},{k_len}), got {tuple(attn_mask.shape)}")
+            raise ValueError(
+                f"attn_mask shape must be (B,{q_len},{k_len}), got {tuple(attn_mask.shape)}"
+            )
         attn_mask = attn_mask[:, None, :, :]  # (B,1,q,k)
     elif attn_mask.dim() == 4:
         if attn_mask.shape[-2:] != (q_len, k_len):
-            raise ValueError(f"attn_mask last dims must be ({q_len},{k_len}), got {tuple(attn_mask.shape)}")
+            raise ValueError(
+                f"attn_mask last dims must be ({q_len},{k_len}), got {tuple(attn_mask.shape)}"
+            )
         # keep as-is; should be broadcastable to (B,H,q,k)
     else:
         raise ValueError(f"Unsupported attn_mask rank: {attn_mask.dim()}")
@@ -101,13 +107,17 @@ class MultiHeadSelfAttention(nn.Module):
         self.wqkv = nn.Linear(self.dim, 3 * self.n_heads * self.head_dim, bias=bias)
         self.wo = nn.Linear(self.n_heads * self.head_dim, self.dim, bias=bias)
 
-    def _shape_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def _shape_qkv(
+        self, qkv: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         bsz, seqlen, _ = qkv.shape
         qkv = qkv.view(bsz, seqlen, 3, self.n_heads, self.head_dim)
         q, k, v = qkv.unbind(dim=2)  # each: (B, T, H, D)
         return q, k, v
 
-    def _apply_rope(self, q: torch.Tensor, k: torch.Tensor, freqs_cis: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def _apply_rope(
+        self, q: torch.Tensor, k: torch.Tensor, freqs_cis: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         if self.rope_dim == 0:
             return q, k
         q_pe, q_rest = q[..., : self.rope_dim], q[..., self.rope_dim :]
@@ -152,15 +162,156 @@ class MultiHeadSelfAttention(nn.Module):
         sdpa_mask: torch.Tensor | None = None
 
         if attn_mask is not None:
-            sdpa_mask = _normalize_attn_mask(attn_mask, q_len=q_len, k_len=k_len, device=x.device, dtype=x.dtype)
+            sdpa_mask = _normalize_attn_mask(
+                attn_mask, q_len=q_len, k_len=k_len, device=x.device, dtype=x.dtype
+            )
 
         out = F.scaled_dot_product_attention(
-            q_, k_, v_,
+            q_,
+            k_,
+            v_,
             attn_mask=sdpa_mask,
             dropout_p=self.attn_dropout if self.training else 0.0,
             is_causal=False,
         )
-        out = out.transpose(1, 2).contiguous().view(bsz, q_len, self.n_heads * self.head_dim)
+        out = (
+            out.transpose(1, 2)
+            .contiguous()
+            .view(bsz, q_len, self.n_heads * self.head_dim)
+        )
+        return self.wo(out)
+
+
+class GroupedQuerySelfAttention(nn.Module):
+    """
+    Pure PyTorch Grouped Query Self-Attention using SDPA.
+
+    Query heads use ``n_heads`` while key/value heads use ``n_kv_heads``.
+    The public forward interface matches ``MultiHeadSelfAttention`` so blocks
+    can switch between MHA and GQA without changing call sites.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        n_heads: int,
+        n_kv_heads: int,
+        *,
+        head_dim: int | None = None,
+        rope_dim: int | None = None,
+        attn_dropout: float = 0.0,
+        bias: bool = False,
+    ) -> None:
+        super().__init__()
+        if n_heads <= 0:
+            raise ValueError(f"n_heads must be positive, got {n_heads}")
+        if n_kv_heads <= 0:
+            raise ValueError(f"n_kv_heads must be positive, got {n_kv_heads}")
+        if n_heads % n_kv_heads != 0:
+            raise ValueError(
+                f"n_heads={n_heads} must be divisible by n_kv_heads={n_kv_heads}"
+            )
+        if head_dim is None:
+            if dim % n_heads != 0:
+                raise ValueError(f"dim={dim} must be divisible by n_heads={n_heads}")
+            head_dim = dim // n_heads
+        if rope_dim is None:
+            rope_dim = head_dim
+        if rope_dim % 2 != 0:
+            raise ValueError(f"rope_dim must be even, got {rope_dim}")
+        if rope_dim > head_dim:
+            raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
+
+        self.dim = int(dim)
+        self.n_heads = int(n_heads)
+        self.n_kv_heads = int(n_kv_heads)
+        self.head_dim = int(head_dim)
+        self.rope_dim = int(rope_dim)
+        self.attn_dropout = float(attn_dropout)
+
+        self.wq = nn.Linear(self.dim, self.n_heads * self.head_dim, bias=bias)
+        self.wk = nn.Linear(self.dim, self.n_kv_heads * self.head_dim, bias=bias)
+        self.wv = nn.Linear(self.dim, self.n_kv_heads * self.head_dim, bias=bias)
+        self.wo = nn.Linear(self.n_heads * self.head_dim, self.dim, bias=bias)
+
+    def _shape_query(self, tensor: torch.Tensor) -> torch.Tensor:
+        bsz, seqlen, _ = tensor.shape
+        return tensor.view(bsz, seqlen, self.n_heads, self.head_dim)
+
+    def _shape_kv(self, tensor: torch.Tensor) -> torch.Tensor:
+        bsz, seqlen, _ = tensor.shape
+        return tensor.view(bsz, seqlen, self.n_kv_heads, self.head_dim)
+
+    def _apply_rope(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        freqs_cis: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.rope_dim == 0:
+            return query, key
+        query_pe, query_rest = query[..., : self.rope_dim], query[..., self.rope_dim :]
+        key_pe, key_rest = key[..., : self.rope_dim], key[..., self.rope_dim :]
+        query_pe = apply_rotary_emb(query_pe, freqs_cis, interleaved=True)
+        key_pe = apply_rotary_emb(key_pe, freqs_cis, interleaved=True)
+        query = torch.cat([query_pe, query_rest], dim=-1)
+        key = torch.cat([key_pe, key_rest], dim=-1)
+        return query, key
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        freqs_cis: torch.Tensor | None = None,
+        attn_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """
+        Args:
+            x: (B, T, dim)
+            freqs_cis: complex cis frequencies for RoPE. Supports `(T, rope_dim//2)`
+                or batched `(B, T, rope_dim//2)`.
+            attn_mask: optional user mask; see module docstring
+
+        Returns:
+            (B, T, dim)
+        """
+        bsz, q_len, _ = x.shape
+        query = self._shape_query(self.wq(x))
+        key = self._shape_kv(self.wk(x))
+        value = self._shape_kv(self.wv(x))
+
+        if freqs_cis is not None:
+            query, key = self._apply_rope(query, key, freqs_cis)
+
+        k_len = q_len
+        query = query.transpose(1, 2)
+        key = key.transpose(1, 2)
+        value = value.transpose(1, 2)
+
+        sdpa_mask: torch.Tensor | None = None
+        if attn_mask is not None:
+            sdpa_mask = _normalize_attn_mask(
+                attn_mask,
+                q_len=q_len,
+                k_len=k_len,
+                device=x.device,
+                dtype=x.dtype,
+            )
+
+        out = F.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask=sdpa_mask,
+            dropout_p=self.attn_dropout if self.training else 0.0,
+            is_causal=False,
+            enable_gqa=self.n_kv_heads != self.n_heads,
+        )
+        out = (
+            out.transpose(1, 2)
+            .contiguous()
+            .view(bsz, q_len, self.n_heads * self.head_dim)
+        )
         return self.wo(out)
 
 
@@ -288,7 +439,11 @@ class MultiHeadCrossAttention(nn.Module):
             dropout_p=self.attn_dropout if self.training else 0.0,
             is_causal=False,
         )
-        out = out.transpose(1, 2).contiguous().view(bsz, q_len, self.n_heads * self.head_dim)
+        out = (
+            out.transpose(1, 2)
+            .contiguous()
+            .view(bsz, q_len, self.n_heads * self.head_dim)
+        )
         return self.wo(out)
 
 

--- a/src/utils/models/components/block.py
+++ b/src/utils/models/components/block.py
@@ -7,6 +7,7 @@ import torch
 from torch import nn
 
 from src.utils.models.components.attention import (
+    GroupedQuerySelfAttention,
     MultiHeadCrossAttention,
     MultiHeadSelfAttention,
 )
@@ -25,6 +26,8 @@ class TransformerBlockConfig:
         head_dim: Per-head dimension (defaults to dim // n_heads).
         rope_dim: Rotary dimension per head for 1D RoPE.
         attn_dropout: Dropout probability for attention.
+        attention_type: Self-attention implementation to use.
+        n_kv_heads: Number of key/value heads for GQA.
         rope_base: Base theta for 1D RoPE.
         ffn_type: FFN implementation to use.
     """
@@ -36,6 +39,8 @@ class TransformerBlockConfig:
     head_dim: int | None = None
     rope_dim: int | None = None
     attn_dropout: float = 0.0
+    attention_type: Literal["mha", "gqa"] = "mha"
+    n_kv_heads: int | None = None
     # RoPE
     rope_base: float = 10000.0
     # FFN
@@ -52,13 +57,27 @@ class TransformerBlock(nn.Module):
         self.cfg = cfg
 
         self.attn_norm = RMSNorm(cfg.dim)
-        self.attn = MultiHeadSelfAttention(
-            dim=cfg.dim,
-            n_heads=cfg.n_heads,
-            head_dim=cfg.head_dim,
-            rope_dim=cfg.rope_dim,
-            attn_dropout=cfg.attn_dropout,
-        )
+        if cfg.attention_type == "mha":
+            self.attn = MultiHeadSelfAttention(
+                dim=cfg.dim,
+                n_heads=cfg.n_heads,
+                head_dim=cfg.head_dim,
+                rope_dim=cfg.rope_dim,
+                attn_dropout=cfg.attn_dropout,
+            )
+        elif cfg.attention_type == "gqa":
+            if cfg.n_kv_heads is None:
+                raise ValueError("n_kv_heads must be set when attention_type='gqa'")
+            self.attn = GroupedQuerySelfAttention(
+                dim=cfg.dim,
+                n_heads=cfg.n_heads,
+                n_kv_heads=cfg.n_kv_heads,
+                head_dim=cfg.head_dim,
+                rope_dim=cfg.rope_dim,
+                attn_dropout=cfg.attn_dropout,
+            )
+        else:
+            raise ValueError(f"Unsupported attention_type={cfg.attention_type}")
 
         self.ffn_norm = RMSNorm(cfg.dim)
         ffn_dim = default_ffn_dim(cfg.dim) if cfg.ffn_dim is None else int(cfg.ffn_dim)

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -144,6 +144,15 @@ SMOKE_TASK_SPECS = (
                 ),
             ),
             SmokeVariant(
+                name="multiview_axial_gqa",
+                overrides=(
+                    "model=multiview_axial",
+                    "data=multiview",
+                    "model.attention_type=gqa",
+                    "model.num_kv_heads=2",
+                ),
+            ),
+            SmokeVariant(
                 name="multiview_axial_num_court_kp_12",
                 overrides=(
                     "model=multiview_axial",
@@ -650,7 +659,9 @@ def _assert_common_artifacts(output_dir: Path, *, expect_qualitative: bool) -> N
         assert not qualitative_dir.exists()
 
 
-def _assert_gan_training(case: SmokeCase, callbacks: list[Any], lightning_module: Any) -> None:
+def _assert_gan_training(
+    case: SmokeCase, callbacks: list[Any], lightning_module: Any
+) -> None:
     if not case.expect_gan_training:
         return
 
@@ -720,7 +731,12 @@ def test_scene_training_smoke_contracts(case: SmokeCase, tmp_path: Path) -> None
         trainer.test(lightning_module, datamodule=datamodule)
     else:
         with pytest.raises(
-            (AttributeError, MisconfigurationException, NotImplementedError, RuntimeError)
+            (
+                AttributeError,
+                MisconfigurationException,
+                NotImplementedError,
+                RuntimeError,
+            )
         ):
             trainer.test(lightning_module, datamodule=datamodule)
 


### PR DESCRIPTION
## 概要

BLCS multi-view axial で self-attention を MHA/GQA から選択できるようにし、GQA 比較検証を実施しました。既定は MHA のまま維持し、`model.attention_type=gqa` と `model.num_kv_heads` で GQA に切り替えます。

## 変更内容

- `GroupedQuerySelfAttention` を追加し、`TransformerBlockConfig` から MHA/GQA を選択可能にしました。
- `BLCSMultiViewAxialModel` と `multiview_axial.yaml` に `attention_type` / `num_kv_heads` を追加しました。
- resume checkpoint 読み込み時に full-state checkpoint を扱えるよう、信頼済みローカル resume 中だけ `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1` を設定しました。
- GQA の契約確認を単独テストから BLCS training smoke の `blcs_multiview_axial_gqa` variant へ統合しました。

## 検証

- `.venv/bin/python -m ruff check src/tasks/base/training/runner.py src/tasks/blcs/models/blcs_multiview_axial_model.py src/utils/models/components/attention.py src/utils/models/components/block.py tests/tasks/test_training_smoke_contracts.py`
- `.venv/bin/python -m ruff format --check src/tasks/base/training/runner.py src/tasks/blcs/models/blcs_multiview_axial_model.py src/utils/models/components/attention.py src/utils/models/components/block.py tests/tasks/test_training_smoke_contracts.py`
- `.venv/bin/python -m pytest tests/tasks/test_training_smoke_contracts.py -k blcs_multiview_axial_gqa`
- `.venv/bin/python -m pytest tests/tasks/test_training_smoke_contracts.py -k blcs`
- `src/tasks/blcs/configs/train.yaml` を用いた MHA/GQA A/B 学習を `num_views_range=[4,4]`, `batch_size=4`, GAN off, early stopping off, 50 epoch で実行しました。結果は issue コメントに記録済みです。

## 関連Issue

- Closes #451

## 補足

- GQA は初回実行で epoch 41 付近に status 137 で停止したため、`last.ckpt` から resume して 50 epoch まで完了しました。
- A/B 結果コメント: https://github.com/Motoki0705/tennis-lab/issues/451#issuecomment-4406427230
