### PR TITLE
モデル validation 抽出リファクタ

### DIFF
--- a/src/tasks/ball_detection/models/dino_pseudo3d.py
+++ b/src/tasks/ball_detection/models/dino_pseudo3d.py
@@ -138,17 +138,11 @@ class DINOPseudo3DBallDetector(nn.Module):
         expand_ratio: float = 4.0,
     ) -> None:
         super().__init__()
-        if in_channels != 3:
-            raise ValueError(
-                "DINOPseudo3DBallDetector requires 3-channel RGB input, "
-                f"got in_channels={in_channels}."
-            )
-        if num_classes <= 0:
-            raise ValueError("num_classes must be positive.")
-        if tuple(return_interm_indices) != (0, 1, 2, 3):
-            raise ValueError(
-                "DINOPseudo3DBallDetector expects return_interm_indices=(0, 1, 2, 3)."
-            )
+        self._validate_init_args(
+            in_channels=in_channels,
+            num_classes=num_classes,
+            return_interm_indices=return_interm_indices,
+        )
 
         self.in_channels = int(in_channels)
         self.num_classes = int(num_classes)
@@ -166,14 +160,10 @@ class DINOPseudo3DBallDetector(nn.Module):
             strict=backbone_strict,
         )
         self.backbone = loaded_backbone.module
-        if backbone_strict and (
-            loaded_backbone.load_result.missing_keys or loaded_backbone.load_result.unexpected_keys
-        ):
-            raise RuntimeError(
-                "Unexpected DINO backbone load result: "
-                f"missing={loaded_backbone.load_result.missing_keys}, "
-                f"unexpected={loaded_backbone.load_result.unexpected_keys}"
-            )
+        self._validate_backbone_load_result(
+            loaded_backbone,
+            strict=backbone_strict,
+        )
         if self.freeze_backbone:
             for parameter in self.backbone.parameters():
                 parameter.requires_grad = False
@@ -209,6 +199,37 @@ class DINOPseudo3DBallDetector(nn.Module):
         )
         self.final_conv = nn.Conv3d(64, self.num_classes, kernel_size=1)
 
+    @staticmethod
+    def _validate_init_args(
+        *,
+        in_channels: int,
+        num_classes: int,
+        return_interm_indices: tuple[int, ...],
+    ) -> None:
+        if in_channels != 3:
+            raise ValueError(
+                "DINOPseudo3DBallDetector requires 3-channel RGB input, "
+                f"got in_channels={in_channels}."
+            )
+        if num_classes <= 0:
+            raise ValueError("num_classes must be positive.")
+        if tuple(return_interm_indices) != (0, 1, 2, 3):
+            raise ValueError(
+                "DINOPseudo3DBallDetector expects return_interm_indices=(0, 1, 2, 3)."
+            )
+
+    @staticmethod
+    def _validate_backbone_load_result(loaded_backbone, *, strict: bool) -> None:
+        if strict and (
+            loaded_backbone.load_result.missing_keys
+            or loaded_backbone.load_result.unexpected_keys
+        ):
+            raise RuntimeError(
+                "Unexpected DINO backbone load result: "
+                f"missing={loaded_backbone.load_result.missing_keys}, "
+                f"unexpected={loaded_backbone.load_result.unexpected_keys}"
+            )
+
     @classmethod
     def from_config(cls, config: DictConfig) -> DINOPseudo3DBallDetector:
         """Create the model from a composed Hydra config."""
@@ -223,14 +244,17 @@ class DINOPseudo3DBallDetector(nn.Module):
             backbone_name=str(model_cfg.get("backbone_name", "resnet50")),
             backbone_dilation=bool(model_cfg.get("backbone_dilation", False)),
             return_interm_indices=tuple(
-                int(index) for index in model_cfg.get("return_interm_indices", [0, 1, 2, 3])
+                int(index)
+                for index in model_cfg.get("return_interm_indices", [0, 1, 2, 3])
             ),
             backbone_pretrain_img_size=(
                 None
                 if model_cfg.get("backbone_pretrain_img_size") is None
                 else int(model_cfg.get("backbone_pretrain_img_size"))
             ),
-            backbone_use_checkpoint=bool(model_cfg.get("backbone_use_checkpoint", False)),
+            backbone_use_checkpoint=bool(
+                model_cfg.get("backbone_use_checkpoint", False)
+            ),
             backbone_strict=bool(model_cfg.get("backbone_strict", True)),
             freeze_backbone=bool(model_cfg.get("freeze_backbone", True)),
             expand_ratio=float(model_cfg.get("decoder_expand_ratio", 4.0)),
@@ -238,22 +262,18 @@ class DINOPseudo3DBallDetector(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the DINO backbone and pseudo-3D decoder."""
-        if x.ndim != 5:
-            raise ValueError(
-                "DINOPseudo3DBallDetector expects input with shape (B, C, T, H, W), "
-                f"got ndim={x.ndim}."
-            )
-        if x.shape[1] != self.in_channels:
-            raise ValueError(
-                f"Expected {self.in_channels} input channels but received {x.shape[1]}."
-            )
+        self._validate_forward_input(x)
 
         batch_size, channels, timesteps, height, width = x.shape
-        backbone_input = x.permute(0, 2, 1, 3, 4).contiguous().view(
-            batch_size * timesteps,
-            channels,
-            height,
-            width,
+        backbone_input = (
+            x.permute(0, 2, 1, 3, 4)
+            .contiguous()
+            .view(
+                batch_size * timesteps,
+                channels,
+                height,
+                width,
+            )
         )
         features = self.backbone(backbone_input)
         level1 = self._to_5d(features["0"], batch_size, timesteps)
@@ -273,13 +293,26 @@ class DINOPseudo3DBallDetector(nn.Module):
         )
         return self.final_conv(self.final_refine(full_res))
 
+    def _validate_forward_input(self, x: torch.Tensor) -> None:
+        if x.ndim != 5:
+            raise ValueError(
+                "DINOPseudo3DBallDetector expects input with shape (B, C, T, H, W), "
+                f"got ndim={x.ndim}."
+            )
+        if x.shape[1] != self.in_channels:
+            raise ValueError(
+                f"Expected {self.in_channels} input channels but received {x.shape[1]}."
+            )
+
     @staticmethod
     def _to_5d(feature: torch.Tensor, batch_size: int, timesteps: int) -> torch.Tensor:
         """Convert flattened `(B*T, C, H, W)` backbone features into 5D tensors."""
         _, channels, height, width = feature.shape
-        return feature.view(batch_size, timesteps, channels, height, width).permute(
-            0, 2, 1, 3, 4
-        ).contiguous()
+        return (
+            feature.view(batch_size, timesteps, channels, height, width)
+            .permute(0, 2, 1, 3, 4)
+            .contiguous()
+        )
 
     @staticmethod
     def _upsample_to(x: torch.Tensor, target: torch.Tensor) -> torch.Tensor:

--- a/src/tasks/ball_detection/models/spatiotemporal_unet.py
+++ b/src/tasks/ball_detection/models/spatiotemporal_unet.py
@@ -91,15 +91,19 @@ class EncoderBlock(nn.Module):
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """Encode one resolution level and return 3D and 2D skip tensors."""
         bsz, channels, timesteps, height, width = x.shape
-        x_2d = x.permute(0, 2, 1, 3, 4).contiguous().view(
-            bsz * timesteps, channels, height, width
+        x_2d = (
+            x.permute(0, 2, 1, 3, 4)
+            .contiguous()
+            .view(bsz * timesteps, channels, height, width)
         )
         x_2d = self.block_2d(x_2d)
         skip_2d = x_2d
         _, out_channels, out_h, out_w = skip_2d.shape
-        x_3d = skip_2d.view(bsz, timesteps, out_channels, out_h, out_w).permute(
-            0, 2, 1, 3, 4
-        ).contiguous()
+        x_3d = (
+            skip_2d.view(bsz, timesteps, out_channels, out_h, out_w)
+            .permute(0, 2, 1, 3, 4)
+            .contiguous()
+        )
         skip_3d = self.block_3d(x_3d)
         return skip_3d, skip_2d
 
@@ -115,14 +119,18 @@ class BottleneckBlock(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Apply the bottleneck block to the pooled feature tensor."""
         bsz, channels, timesteps, height, width = x.shape
-        x_2d = x.permute(0, 2, 1, 3, 4).contiguous().view(
-            bsz * timesteps, channels, height, width
+        x_2d = (
+            x.permute(0, 2, 1, 3, 4)
+            .contiguous()
+            .view(bsz * timesteps, channels, height, width)
         )
         x_2d = self.block_2(self.block_1(x_2d))
         _, out_channels, out_h, out_w = x_2d.shape
-        return x_2d.view(bsz, timesteps, out_channels, out_h, out_w).permute(
-            0, 2, 1, 3, 4
-        ).contiguous()
+        return (
+            x_2d.view(bsz, timesteps, out_channels, out_h, out_w)
+            .permute(0, 2, 1, 3, 4)
+            .contiguous()
+        )
 
 
 class DecoderBlock(nn.Module):
@@ -142,14 +150,18 @@ class DecoderBlock(nn.Module):
         """Fuse the decoder state with 3D and 2D skip tensors."""
         x_3d = self.block_3d(torch.cat([x, skip_3d], dim=1))
         bsz, channels, timesteps, height, width = x_3d.shape
-        x_2d = x_3d.permute(0, 2, 1, 3, 4).contiguous().view(
-            bsz * timesteps, channels, height, width
+        x_2d = (
+            x_3d.permute(0, 2, 1, 3, 4)
+            .contiguous()
+            .view(bsz * timesteps, channels, height, width)
         )
         x_2d = self.block_2d(torch.cat([x_2d, skip_2d], dim=1))
         _, out_channels, out_h, out_w = x_2d.shape
-        return x_2d.view(bsz, timesteps, out_channels, out_h, out_w).permute(
-            0, 2, 1, 3, 4
-        ).contiguous()
+        return (
+            x_2d.view(bsz, timesteps, out_channels, out_h, out_w)
+            .permute(0, 2, 1, 3, 4)
+            .contiguous()
+        )
 
 
 class SpatioTemporalUNet(nn.Module):
@@ -164,10 +176,7 @@ class SpatioTemporalUNet(nn.Module):
 
     def __init__(self, in_channels: int = 3, num_classes: int = 1) -> None:
         super().__init__()
-        if in_channels <= 0:
-            raise ValueError("in_channels must be positive.")
-        if num_classes <= 0:
-            raise ValueError("num_classes must be positive.")
+        self._validate_init_args(in_channels=in_channels, num_classes=num_classes)
 
         self.in_channels = int(in_channels)
         self.num_classes = int(num_classes)
@@ -192,8 +201,17 @@ class SpatioTemporalUNet(nn.Module):
         self.dec2 = DecoderBlock(256, 128, 128)
         self.dec1 = DecoderBlock(128, 64, 64)
         self.pool = nn.MaxPool3d(kernel_size=2, stride=2)
-        self.upsample = nn.Upsample(scale_factor=2, mode="trilinear", align_corners=False)
+        self.upsample = nn.Upsample(
+            scale_factor=2, mode="trilinear", align_corners=False
+        )
         self.final_conv = nn.Conv3d(64, self.num_classes, kernel_size=1)
+
+    @staticmethod
+    def _validate_init_args(*, in_channels: int, num_classes: int) -> None:
+        if in_channels <= 0:
+            raise ValueError("in_channels must be positive.")
+        if num_classes <= 0:
+            raise ValueError("num_classes must be positive.")
 
     @classmethod
     def from_config(cls, config: DictConfig) -> SpatioTemporalUNet:
@@ -206,21 +224,7 @@ class SpatioTemporalUNet(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the spatio-temporal U-Net."""
-        if x.ndim != 5:
-            raise ValueError(
-                "SpatioTemporalUNet expects input with shape (B, C, T, H, W), "
-                f"got ndim={x.ndim}."
-            )
-        if x.shape[1] != self.in_channels:
-            raise ValueError(
-                f"Expected {self.in_channels} input channels but received {x.shape[1]}."
-            )
-        if x.shape[2] < 8:
-            raise ValueError(
-                "SpatioTemporalUNet expects at least 8 frames because the temporal axis "
-                "is pooled three times. "
-                f"Received T={x.shape[2]}."
-            )
+        self._validate_forward_input(x)
 
         x = self.stem(x)
         s3d_1, s2d_1 = self.enc1(x)
@@ -237,6 +241,23 @@ class SpatioTemporalUNet(nn.Module):
         x = self.upsample(x)
         x = self.dec1(x, s3d_1, s2d_1)
         return self.final_conv(x)
+
+    def _validate_forward_input(self, x: torch.Tensor) -> None:
+        if x.ndim != 5:
+            raise ValueError(
+                "SpatioTemporalUNet expects input with shape (B, C, T, H, W), "
+                f"got ndim={x.ndim}."
+            )
+        if x.shape[1] != self.in_channels:
+            raise ValueError(
+                f"Expected {self.in_channels} input channels but received {x.shape[1]}."
+            )
+        if x.shape[2] < 8:
+            raise ValueError(
+                "SpatioTemporalUNet expects at least 8 frames because the temporal axis "
+                "is pooled three times. "
+                f"Received T={x.shape[2]}."
+            )
 
 
 __all__ = ["SpatioTemporalUNet"]

--- a/src/tasks/blcs/models/blcs_model.py
+++ b/src/tasks/blcs/models/blcs_model.py
@@ -106,8 +106,7 @@ class BLCSModel(nn.Module):
         self.num_court_tokens = int(num_court_tokens)
         self.max_tokens = int(self.num_court_tokens + self.max_seq_len)
 
-        if hidden_dim % num_heads != 0:
-            raise ValueError(f"hidden_dim={hidden_dim} must be divisible by num_heads={num_heads}")
+        self._validate_init_args(hidden_dim=hidden_dim, num_heads=num_heads)
         head_dim = hidden_dim // num_heads
 
         rope_dim = head_dim if rope_dim is None else rope_dim
@@ -180,6 +179,13 @@ class BLCSModel(nn.Module):
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
+    @staticmethod
+    def _validate_init_args(*, hidden_dim: int, num_heads: int) -> None:
+        if hidden_dim % num_heads != 0:
+            raise ValueError(
+                f"hidden_dim={hidden_dim} must be divisible by num_heads={num_heads}"
+            )
+
     @classmethod
     def from_config(cls, config: DictConfig) -> BLCSModel:
         """Create model from configuration.
@@ -204,11 +210,11 @@ class BLCSModel(nn.Module):
             rope_theta_time=model_cfg.get("rope_theta_time", None),
             rope_theta_camera=model_cfg.get("rope_theta_camera", None),
             rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
-            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
-            predict_velocity=model_cfg.get("predict_velocity", False),
-            max_seq_len=model_cfg.get(
-                "max_seq_len", data_cfg.get("max_seq_len", 120)
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
             ),
+            predict_velocity=model_cfg.get("predict_velocity", False),
+            max_seq_len=model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120)),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             num_court_tokens=int(data_cfg.get("num_court_kp", NUM_COURT_KP)),
         )
@@ -261,24 +267,13 @@ class BLCSModel(nn.Module):
         # Tokenize court and ball
         court_tok = self.court_embed(court_kp, court_vis)  # (B, K, D)
         ball_tok = self.ball_embed(ball_uv, ball_vis)  # (B, T, D)
-        if court_tok.shape[1] != self.num_court_tokens:
-            raise ValueError(
-                f"Expected {self.num_court_tokens} court tokens, got {court_tok.shape[1]}"
-            )
+        self._validate_court_tokens(court_tok)
 
         K = court_tok.shape[1]
         x = torch.cat([court_tok, ball_tok], dim=1)  # (B, S, D)
         S = x.shape[1]
 
-        freqs_cis = cast(Tensor, self.freqs_cis)
-        if freqs_cis.shape[0] < S:
-            raise ValueError(
-                f"Sequence length S={S} exceeds cached freqs_cis length {freqs_cis.shape[0]}. "
-                "Increase max_seq_len."
-            )
-        freqs_cis = freqs_cis[:S]
-        if freqs_cis.device != x.device:
-            freqs_cis = freqs_cis.to(x.device)
+        freqs_cis = self._freqs_for_sequence(x=x, seq_len=S)
         attn_mask: Tensor | None = None
         if ball_mask is not None:
             court_valid = torch.ones(B, K, device=x.device, dtype=torch.bool)
@@ -302,6 +297,24 @@ class BLCSModel(nn.Module):
             out["velocity"] = self.velocity_head(ball_out)  # (B, T, 3)
 
         return out
+
+    def _validate_court_tokens(self, court_tokens: Tensor) -> None:
+        if court_tokens.shape[1] != self.num_court_tokens:
+            raise ValueError(
+                f"Expected {self.num_court_tokens} court tokens, got {court_tokens.shape[1]}"
+            )
+
+    def _freqs_for_sequence(self, *, x: Tensor, seq_len: int) -> Tensor:
+        freqs_cis = cast(Tensor, self.freqs_cis)
+        if freqs_cis.shape[0] < seq_len:
+            raise ValueError(
+                f"Sequence length S={seq_len} exceeds cached freqs_cis length {freqs_cis.shape[0]}. "
+                "Increase max_seq_len."
+            )
+        freqs_cis = freqs_cis[:seq_len]
+        if freqs_cis.device != x.device:
+            freqs_cis = freqs_cis.to(x.device)
+        return freqs_cis
 
     def get_num_params(self) -> int:
         """Get total number of trainable parameters."""

--- a/src/tasks/blcs/models/blcs_multiview_axial_model.py
+++ b/src/tasks/blcs/models/blcs_multiview_axial_model.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal
 
 import torch
 from torch import Tensor, nn
@@ -47,16 +47,13 @@ class BLCSMultiViewAxialModel(nn.Module):
         super().__init__()
         self.hidden_dim = int(hidden_dim)
 
-        if self.hidden_dim % num_heads != 0:
-            raise ValueError(
-                f"hidden_dim={self.hidden_dim} must be divisible by num_heads={num_heads}"
-            )
-        if max_seq_len <= 0:
-            raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
-        if max_num_cameras <= 0:
-            raise ValueError(f"max_num_cameras must be positive, got {max_num_cameras}")
-        if num_layers < 0:
-            raise ValueError(f"num_layers must be non-negative, got {num_layers}")
+        self._validate_init_args(
+            hidden_dim=self.hidden_dim,
+            num_heads=num_heads,
+            max_seq_len=max_seq_len,
+            max_num_cameras=max_num_cameras,
+            num_layers=num_layers,
+        )
 
         self.max_seq_len = int(max_seq_len)
         self.max_num_cameras = int(max_num_cameras)
@@ -65,10 +62,7 @@ class BLCSMultiViewAxialModel(nn.Module):
 
         head_dim = self.hidden_dim // num_heads
         rope_dim = head_dim if rope_dim is None else int(rope_dim)
-        if rope_dim % 2 != 0:
-            raise ValueError(f"rope_dim must be even, got {rope_dim}")
-        if rope_dim > head_dim:
-            raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
+        self._validate_rope_dim(rope_dim=rope_dim, head_dim=head_dim)
 
         self.rope_dim = int(rope_dim)
         self.rope_bases = (
@@ -157,6 +151,33 @@ class BLCSMultiViewAxialModel(nn.Module):
             base=self.rope_bases,
         )
         self.register_buffer("token_freqs_cis", token_freqs, persistent=False)
+
+    @staticmethod
+    def _validate_init_args(
+        *,
+        hidden_dim: int,
+        num_heads: int,
+        max_seq_len: int,
+        max_num_cameras: int,
+        num_layers: int,
+    ) -> None:
+        if hidden_dim % num_heads != 0:
+            raise ValueError(
+                f"hidden_dim={hidden_dim} must be divisible by num_heads={num_heads}"
+            )
+        if max_seq_len <= 0:
+            raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
+        if max_num_cameras <= 0:
+            raise ValueError(f"max_num_cameras must be positive, got {max_num_cameras}")
+        if num_layers < 0:
+            raise ValueError(f"num_layers must be non-negative, got {num_layers}")
+
+    @staticmethod
+    def _validate_rope_dim(*, rope_dim: int, head_dim: int) -> None:
+        if rope_dim % 2 != 0:
+            raise ValueError(f"rope_dim must be even, got {rope_dim}")
+        if rope_dim > head_dim:
+            raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
 
     @classmethod
     def from_config(cls, config: DictConfig) -> BLCSMultiViewAxialModel:
@@ -257,69 +278,21 @@ class BLCSMultiViewAxialModel(nn.Module):
         court_vis: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Forward pass for multi-view BLCS inputs."""
-        if ball_uv.dim() != 4:
-            raise ValueError(
-                f"ball_uv must have shape (B, N, T, 2), got {tuple(ball_uv.shape)}"
-            )
-
-        batch_size, n_cams, seq_len_in, _ = ball_uv.shape
-        if seq_len_in > self.max_seq_len:
-            raise ValueError(
-                f"seq_len={seq_len_in} exceeds max_seq_len={self.max_seq_len}. "
-                "Increase model.max_seq_len."
-            )
-        if n_cams > self.max_num_cameras:
-            raise ValueError(
-                f"n_cams={n_cams} exceeds max_num_cameras={self.max_num_cameras}."
-            )
-
-        if court_kp.dim() == 4:
-            court_kp = court_kp.unsqueeze(2).expand(-1, -1, seq_len_in, -1, -1)
-        if court_kp.dim() != 5:
-            raise ValueError(
-                "court_kp must have shape "
-                f"(B, N, T, {self.num_court_tokens}, 2) or "
-                f"(B, N, {self.num_court_tokens}, 2), "
-                f"got {tuple(court_kp.shape)}"
-            )
-        if court_kp.shape[-2] != self.num_court_tokens:
-            raise ValueError(
-                f"Expected court_kp with K={self.num_court_tokens}, got K={court_kp.shape[-2]}."
-            )
-
-        if court_vis is not None:
-            if court_vis.dim() == 3:
-                court_vis = court_vis.unsqueeze(2).expand(-1, -1, seq_len_in, -1)
-            if court_vis.dim() != 4:
-                raise ValueError(
-                    "court_vis must have shape "
-                    f"(B, N, T, {self.num_court_tokens}) or "
-                    f"(B, N, {self.num_court_tokens}), "
-                    f"got {tuple(court_vis.shape)}"
-                )
-            if court_vis.shape[-1] != self.num_court_tokens:
-                raise ValueError(
-                    f"Expected court_vis with K={self.num_court_tokens}, got K={court_vis.shape[-1]}."
-                )
-
-        if ball_vis is None:
-            raise ValueError(
-                "ball_vis is required for BLCSMultiViewAxialModel forward."
-            )
-        if ball_mask is None:
-            raise ValueError(
-                "ball_mask is required for BLCSMultiViewAxialModel forward."
-            )
-        if ball_vis.shape != (batch_size, n_cams, seq_len_in):
-            raise ValueError(
-                f"ball_vis must have shape {(batch_size, n_cams, seq_len_in)}, "
-                f"got {tuple(ball_vis.shape)}"
-            )
-        if ball_mask.shape != (batch_size, n_cams, seq_len_in):
-            raise ValueError(
-                f"ball_mask must have shape {(batch_size, n_cams, seq_len_in)}, "
-                f"got {tuple(ball_mask.shape)}"
-            )
+        (
+            court_kp,
+            ball_vis,
+            ball_mask,
+            court_vis,
+            batch_size,
+            n_cams,
+            seq_len_in,
+        ) = self._prepare_forward_inputs(
+            ball_uv=ball_uv,
+            court_kp=court_kp,
+            ball_vis=ball_vis,
+            ball_mask=ball_mask,
+            court_vis=court_vis,
+        )
 
         court_flat = court_kp.reshape(
             batch_size * n_cams * seq_len_in, self.num_court_tokens, 2
@@ -388,3 +361,77 @@ class BLCSMultiViewAxialModel(nn.Module):
         if self.predict_velocity and self.velocity_head is not None:
             out["velocity"] = self.velocity_head(x)
         return out
+
+    def _prepare_forward_inputs(
+        self,
+        *,
+        ball_uv: Tensor,
+        court_kp: Tensor,
+        ball_vis: Tensor | None,
+        ball_mask: Tensor | None,
+        court_vis: Tensor | None,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor | None, int, int, int]:
+        if ball_uv.dim() != 4:
+            raise ValueError(
+                f"ball_uv must have shape (B, N, T, 2), got {tuple(ball_uv.shape)}"
+            )
+
+        batch_size, n_cams, seq_len_in, _ = ball_uv.shape
+        if seq_len_in > self.max_seq_len:
+            raise ValueError(
+                f"seq_len={seq_len_in} exceeds max_seq_len={self.max_seq_len}. "
+                "Increase model.max_seq_len."
+            )
+        if n_cams > self.max_num_cameras:
+            raise ValueError(
+                f"n_cams={n_cams} exceeds max_num_cameras={self.max_num_cameras}."
+            )
+
+        if court_kp.dim() == 4:
+            court_kp = court_kp.unsqueeze(2).expand(-1, -1, seq_len_in, -1, -1)
+        if court_kp.dim() != 5:
+            raise ValueError(
+                "court_kp must have shape "
+                f"(B, N, T, {self.num_court_tokens}, 2) or "
+                f"(B, N, {self.num_court_tokens}, 2), "
+                f"got {tuple(court_kp.shape)}"
+            )
+        if court_kp.shape[-2] != self.num_court_tokens:
+            raise ValueError(
+                f"Expected court_kp with K={self.num_court_tokens}, got K={court_kp.shape[-2]}."
+            )
+
+        if court_vis is not None:
+            if court_vis.dim() == 3:
+                court_vis = court_vis.unsqueeze(2).expand(-1, -1, seq_len_in, -1)
+            if court_vis.dim() != 4:
+                raise ValueError(
+                    "court_vis must have shape "
+                    f"(B, N, T, {self.num_court_tokens}) or "
+                    f"(B, N, {self.num_court_tokens}), "
+                    f"got {tuple(court_vis.shape)}"
+                )
+            if court_vis.shape[-1] != self.num_court_tokens:
+                raise ValueError(
+                    f"Expected court_vis with K={self.num_court_tokens}, got K={court_vis.shape[-1]}."
+                )
+
+        if ball_vis is None:
+            raise ValueError(
+                "ball_vis is required for BLCSMultiViewAxialModel forward."
+            )
+        if ball_mask is None:
+            raise ValueError(
+                "ball_mask is required for BLCSMultiViewAxialModel forward."
+            )
+        if ball_vis.shape != (batch_size, n_cams, seq_len_in):
+            raise ValueError(
+                f"ball_vis must have shape {(batch_size, n_cams, seq_len_in)}, "
+                f"got {tuple(ball_vis.shape)}"
+            )
+        if ball_mask.shape != (batch_size, n_cams, seq_len_in):
+            raise ValueError(
+                f"ball_mask must have shape {(batch_size, n_cams, seq_len_in)}, "
+                f"got {tuple(ball_mask.shape)}"
+            )
+        return court_kp, ball_vis, ball_mask, court_vis, batch_size, n_cams, seq_len_in

--- a/src/tasks/blcs/models/blcs_multiview_model.py
+++ b/src/tasks/blcs/models/blcs_multiview_model.py
@@ -61,20 +61,13 @@ class BLCSMultiViewModel(nn.Module):
         super().__init__()
         self.hidden_dim = int(hidden_dim)
 
-        if self.hidden_dim % num_heads != 0:
-            raise ValueError(
-                f"hidden_dim={self.hidden_dim} must be divisible by num_heads={num_heads}"
-            )
-        if max_seq_len <= 0:
-            raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
-        if max_num_cameras <= 0:
-            raise ValueError(
-                f"max_num_cameras must be positive, got {max_num_cameras}"
-            )
-        if num_layers < 0:
-            raise ValueError(
-                f"num_layers must be non-negative, got {num_layers}"
-            )
+        self._validate_init_args(
+            hidden_dim=self.hidden_dim,
+            num_heads=num_heads,
+            max_seq_len=max_seq_len,
+            max_num_cameras=max_num_cameras,
+            num_layers=num_layers,
+        )
 
         self.max_seq_len = int(max_seq_len)
         self.max_num_cameras = int(max_num_cameras)
@@ -83,10 +76,7 @@ class BLCSMultiViewModel(nn.Module):
 
         head_dim = self.hidden_dim // num_heads
         rope_dim = head_dim if rope_dim is None else int(rope_dim)
-        if rope_dim % 2 != 0:
-            raise ValueError(f"rope_dim must be even, got {rope_dim}")
-        if rope_dim > head_dim:
-            raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
+        self._validate_rope_dim(rope_dim=rope_dim, head_dim=head_dim)
         self.rope_dim = int(rope_dim)
         self.rope_theta = float(rope_theta)
         self.rope_bases = (
@@ -114,7 +104,9 @@ class BLCSMultiViewModel(nn.Module):
             invisible_token=self.invisible_token,
         )
 
-        self.query_base = nn.Parameter(torch.randn(1, 1, self.hidden_dim) * query_init_std)
+        self.query_base = nn.Parameter(
+            torch.randn(1, 1, self.hidden_dim) * query_init_std
+        )
 
         self.query_to_frame_cross_layers = nn.ModuleList(
             [
@@ -185,6 +177,33 @@ class BLCSMultiViewModel(nn.Module):
         self.register_buffer("query_freqs_cis", query_freqs, persistent=False)
         self.register_buffer("frame_freqs_cis", frame_freqs, persistent=False)
 
+    @staticmethod
+    def _validate_init_args(
+        *,
+        hidden_dim: int,
+        num_heads: int,
+        max_seq_len: int,
+        max_num_cameras: int,
+        num_layers: int,
+    ) -> None:
+        if hidden_dim % num_heads != 0:
+            raise ValueError(
+                f"hidden_dim={hidden_dim} must be divisible by num_heads={num_heads}"
+            )
+        if max_seq_len <= 0:
+            raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
+        if max_num_cameras <= 0:
+            raise ValueError(f"max_num_cameras must be positive, got {max_num_cameras}")
+        if num_layers < 0:
+            raise ValueError(f"num_layers must be non-negative, got {num_layers}")
+
+    @staticmethod
+    def _validate_rope_dim(*, rope_dim: int, head_dim: int) -> None:
+        if rope_dim % 2 != 0:
+            raise ValueError(f"rope_dim must be even, got {rope_dim}")
+        if rope_dim > head_dim:
+            raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
+
     @classmethod
     def from_config(cls, config: DictConfig) -> BLCSMultiViewModel:
         """Create model from Hydra/OmegaConf config."""
@@ -195,18 +214,30 @@ class BLCSMultiViewModel(nn.Module):
             hidden_dim=int(model_cfg.get("hidden_dim", 256)),
             num_heads=int(model_cfg.get("num_heads", 8)),
             ffn_dim=model_cfg.get("ffn_dim", None),
-            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
+            ),
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_dim=model_cfg.get("rope_dim", None),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
             rope_theta_time=model_cfg.get("rope_theta_time", None),
             rope_theta_camera=model_cfg.get("rope_theta_camera", None),
             rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
-            num_layers=int(model_cfg.get("num_layers", model_cfg.get("num_stage2_layers", 4))),
+            num_layers=int(
+                model_cfg.get("num_layers", model_cfg.get("num_stage2_layers", 4))
+            ),
             predict_velocity=bool(model_cfg.get("predict_velocity", False)),
-            max_seq_len=int(model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))),
-            max_num_cameras=int(model_cfg.get("max_num_cameras", model_cfg.get("max_views", 8))),
-            num_court_tokens=int(model_cfg.get("num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP))),
+            max_seq_len=int(
+                model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))
+            ),
+            max_num_cameras=int(
+                model_cfg.get("max_num_cameras", model_cfg.get("max_views", 8))
+            ),
+            num_court_tokens=int(
+                model_cfg.get(
+                    "num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP)
+                )
+            ),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             query_init_std=float(model_cfg.get("query_init_std", 0.02)),
         )
@@ -276,7 +307,9 @@ class BLCSMultiViewModel(nn.Module):
         if fully_masked.any():
             valid_fixed = valid_fixed.clone()
             valid_fixed[fully_masked, 0] = True
-        attn_mask = valid_fixed[:, None, :].expand(valid_fixed.shape[0], valid_fixed.shape[1], valid_fixed.shape[1])
+        attn_mask = valid_fixed[:, None, :].expand(
+            valid_fixed.shape[0], valid_fixed.shape[1], valid_fixed.shape[1]
+        )
         return attn_mask, valid_fixed
 
     def _build_frame_tokens(
@@ -309,7 +342,9 @@ class BLCSMultiViewModel(nn.Module):
         court_valid_expanded = court_valid[:, :, None, None].expand(
             batch_size, n_cams, seq_len_in, self.num_court_tokens
         )
-        per_cam_valid = torch.cat([court_valid_expanded, ball_valid.unsqueeze(3)], dim=3)
+        per_cam_valid = torch.cat(
+            [court_valid_expanded, ball_valid.unsqueeze(3)], dim=3
+        )
 
         frame_tokens = per_cam_tokens.permute(0, 2, 1, 3, 4).reshape(
             batch_size,
@@ -342,8 +377,131 @@ class BLCSMultiViewModel(nn.Module):
         Returns:
             dict: Dictionary with 'position' (B, T, 3) and optionally 'velocity'.
         """
+        (
+            court_kp,
+            ball_vis,
+            ball_mask,
+            court_vis,
+            batch_size,
+            n_cams,
+            seq_len_in,
+        ) = self._prepare_forward_inputs(
+            ball_uv=ball_uv,
+            court_kp=court_kp,
+            ball_vis=ball_vis,
+            ball_mask=ball_mask,
+            court_vis=court_vis,
+        )
+
+        ball_uv_bn = ball_uv.reshape(batch_size * n_cams, seq_len_in, 2)
+        ball_vis_bn = ball_vis.reshape(batch_size * n_cams, seq_len_in)
+        ball_tok = self.ball_embed(ball_uv_bn, ball_vis_bn).reshape(
+            batch_size, n_cams, seq_len_in, self.hidden_dim
+        )
+
+        court_kp_flat = court_kp.reshape(
+            batch_size * n_cams * seq_len_in, self.num_court_tokens, 2
+        )
+        court_vis_flat = (
+            court_vis.reshape(batch_size * n_cams * seq_len_in, self.num_court_tokens)
+            if court_vis is not None
+            else None
+        )
+        court_tok = self.court_embed(court_kp_flat, court_vis_flat).reshape(
+            batch_size, n_cams, seq_len_in, self.num_court_tokens, self.hidden_dim
+        )
+
+        ball_valid = ball_mask > 0
+        query_valid = ball_valid.any(dim=1)
+        # Court validity is camera-level padding validity, derived from ball validity.
+        # Shape: (B, N)
+        court_valid = ball_valid.any(dim=2)
+
+        freqs_time = self.query_freqs_cis[:seq_len_in]
+        frame_freqs = self.frame_freqs_cis[
+            :seq_len_in, : n_cams * (self.num_court_tokens + 1)
+        ]
+
+        frame_tokens, frame_token_valid = self._build_frame_tokens(
+            ball_tok=ball_tok,
+            court_tok=court_tok,
+            ball_valid=ball_valid,
+            court_valid=court_valid,
+        )
+
+        query_x = self.query_base.expand(batch_size, seq_len_in, -1)
+        query_mask, query_valid_fixed = self._build_self_attn_mask(query_valid)
+
+        for cross_layer, temporal_layer in zip(
+            self.query_to_frame_cross_layers,
+            self.query_temporal_layers,
+            strict=True,
+        ):
+            query_bt = query_x.reshape(batch_size * seq_len_in, 1, self.hidden_dim)
+            frame_bt = frame_tokens.reshape(
+                batch_size * seq_len_in,
+                n_cams * (self.num_court_tokens + 1),
+                self.hidden_dim,
+            )
+            key_valid = frame_token_valid.reshape(
+                batch_size * seq_len_in, n_cams * (self.num_court_tokens + 1)
+            )
+            query_freqs_bt = freqs_time.unsqueeze(0).expand(
+                batch_size, seq_len_in, self.rope_dim // 2
+            )
+            query_freqs_bt = query_freqs_bt.reshape(
+                batch_size * seq_len_in, 1, self.rope_dim // 2
+            )
+            frame_freqs_bt = (
+                frame_freqs.unsqueeze(0)
+                .expand(
+                    batch_size,
+                    seq_len_in,
+                    n_cams * (self.num_court_tokens + 1),
+                    self.rope_dim // 2,
+                )
+                .reshape(
+                    batch_size * seq_len_in,
+                    n_cams * (self.num_court_tokens + 1),
+                    self.rope_dim // 2,
+                )
+            )
+            query_bt = cross_layer(
+                query_bt,
+                frame_bt,
+                key_valid=key_valid,
+                freqs_q_cis=query_freqs_bt,
+                freqs_k_cis=frame_freqs_bt,
+            )
+            query_x = query_bt.reshape(batch_size, seq_len_in, self.hidden_dim)
+
+            query_x = query_x * query_valid_fixed.unsqueeze(-1).to(dtype=query_x.dtype)
+            query_x = temporal_layer(
+                query_x,
+                freqs_cis=freqs_time,
+                attn_mask=query_mask,
+            )
+
+        query_x = self.final_norm(query_x)
+
+        out: dict[str, Tensor] = {"position": self.position_head(query_x)}
+        if self.predict_velocity and self.velocity_head is not None:
+            out["velocity"] = self.velocity_head(query_x)
+        return out
+
+    def _prepare_forward_inputs(
+        self,
+        *,
+        ball_uv: Tensor,
+        court_kp: Tensor,
+        ball_vis: Tensor | None,
+        ball_mask: Tensor | None,
+        court_vis: Tensor | None,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor | None, int, int, int]:
         if ball_uv.dim() != 4:
-            raise ValueError(f"ball_uv must have shape (B, N, T, 2), got {tuple(ball_uv.shape)}")
+            raise ValueError(
+                f"ball_uv must have shape (B, N, T, 2), got {tuple(ball_uv.shape)}"
+            )
 
         batch_size, n_cams, seq_len_in, _ = ball_uv.shape
         if seq_len_in > self.max_seq_len:
@@ -398,89 +556,4 @@ class BLCSMultiViewModel(nn.Module):
                 f"ball_mask must have shape {(batch_size, n_cams, seq_len_in)}, "
                 f"got {tuple(ball_mask.shape)}"
             )
-
-        ball_uv_bn = ball_uv.reshape(batch_size * n_cams, seq_len_in, 2)
-        ball_vis_bn = ball_vis.reshape(batch_size * n_cams, seq_len_in)
-        ball_tok = self.ball_embed(ball_uv_bn, ball_vis_bn).reshape(
-            batch_size, n_cams, seq_len_in, self.hidden_dim
-        )
-
-        court_kp_flat = court_kp.reshape(batch_size * n_cams * seq_len_in, self.num_court_tokens, 2)
-        court_vis_flat = (
-            court_vis.reshape(batch_size * n_cams * seq_len_in, self.num_court_tokens)
-            if court_vis is not None
-            else None
-        )
-        court_tok = self.court_embed(court_kp_flat, court_vis_flat).reshape(
-            batch_size, n_cams, seq_len_in, self.num_court_tokens, self.hidden_dim
-        )
-
-        ball_valid = ball_mask > 0
-        query_valid = ball_valid.any(dim=1)
-        # Court validity is camera-level padding validity, derived from ball validity.
-        # Shape: (B, N)
-        court_valid = ball_valid.any(dim=2)
-
-        freqs_time = self.query_freqs_cis[:seq_len_in]
-        frame_freqs = self.frame_freqs_cis[
-            :seq_len_in, : n_cams * (self.num_court_tokens + 1)
-        ]
-
-        frame_tokens, frame_token_valid = self._build_frame_tokens(
-            ball_tok=ball_tok,
-            court_tok=court_tok,
-            ball_valid=ball_valid,
-            court_valid=court_valid,
-        )
-
-        query_x = self.query_base.expand(batch_size, seq_len_in, -1)
-        query_mask, query_valid_fixed = self._build_self_attn_mask(query_valid)
-
-        for cross_layer, temporal_layer in zip(
-            self.query_to_frame_cross_layers,
-            self.query_temporal_layers,
-            strict=True,
-        ):
-            query_bt = query_x.reshape(batch_size * seq_len_in, 1, self.hidden_dim)
-            frame_bt = frame_tokens.reshape(
-                batch_size * seq_len_in,
-                n_cams * (self.num_court_tokens + 1),
-                self.hidden_dim,
-            )
-            key_valid = frame_token_valid.reshape(
-                batch_size * seq_len_in, n_cams * (self.num_court_tokens + 1)
-            )
-            query_freqs_bt = freqs_time.unsqueeze(0).expand(batch_size, seq_len_in, self.rope_dim // 2)
-            query_freqs_bt = query_freqs_bt.reshape(batch_size * seq_len_in, 1, self.rope_dim // 2)
-            frame_freqs_bt = frame_freqs.unsqueeze(0).expand(
-                batch_size,
-                seq_len_in,
-                n_cams * (self.num_court_tokens + 1),
-                self.rope_dim // 2,
-            ).reshape(
-                batch_size * seq_len_in,
-                n_cams * (self.num_court_tokens + 1),
-                self.rope_dim // 2,
-            )
-            query_bt = cross_layer(
-                query_bt,
-                frame_bt,
-                key_valid=key_valid,
-                freqs_q_cis=query_freqs_bt,
-                freqs_k_cis=frame_freqs_bt,
-            )
-            query_x = query_bt.reshape(batch_size, seq_len_in, self.hidden_dim)
-
-            query_x = query_x * query_valid_fixed.unsqueeze(-1).to(dtype=query_x.dtype)
-            query_x = temporal_layer(
-                query_x,
-                freqs_cis=freqs_time,
-                attn_mask=query_mask,
-            )
-
-        query_x = self.final_norm(query_x)
-
-        out: dict[str, Tensor] = {"position": self.position_head(query_x)}
-        if self.predict_velocity and self.velocity_head is not None:
-            out["velocity"] = self.velocity_head(query_x)
-        return out
+        return court_kp, ball_vis, ball_mask, court_vis, batch_size, n_cams, seq_len_in

--- a/src/tasks/court_detection/models/court_fpn.py
+++ b/src/tasks/court_detection/models/court_fpn.py
@@ -35,8 +35,7 @@ class CourtFPN(nn.Module):
         decoder_channels: tuple[int, ...] = (64, 128, 256, 512),
     ) -> None:
         super().__init__()
-        if num_classes <= 0:
-            raise ValueError("num_classes must be positive.")
+        self._validate_init_args(num_classes=num_classes)
 
         self.in_channels = int(in_channels)
         self.num_classes = int(num_classes)
@@ -58,7 +57,14 @@ class CourtFPN(nn.Module):
             encoder_channels=self.encoder.feature_channels,
             decoder_channels=self.decoder_channels,
         )
-        self.final_conv = nn.Conv2d(self.decoder.output_channels, self.num_classes, kernel_size=1)
+        self.final_conv = nn.Conv2d(
+            self.decoder.output_channels, self.num_classes, kernel_size=1
+        )
+
+    @staticmethod
+    def _validate_init_args(*, num_classes: int) -> None:
+        if num_classes <= 0:
+            raise ValueError("num_classes must be positive.")
 
     @classmethod
     def from_config(cls, config: DictConfig) -> CourtFPN:
@@ -93,17 +99,22 @@ class CourtFPN(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if x.ndim != 4:
-            raise ValueError(
-                "CourtFPN expects input with shape (B, C, H, W), "
-                f"got ndim={x.ndim}."
-            )
+        self._validate_forward_input(x)
 
         input_hw = x.shape[-2:]
         decoded = self.decoder(self.encoder(x))
         if decoded.shape[-2:] != input_hw:
-            decoded = F.interpolate(decoded, size=input_hw, mode="bilinear", align_corners=False)
+            decoded = F.interpolate(
+                decoded, size=input_hw, mode="bilinear", align_corners=False
+            )
         return self.final_conv(decoded)
+
+    @staticmethod
+    def _validate_forward_input(x: torch.Tensor) -> None:
+        if x.ndim != 4:
+            raise ValueError(
+                f"CourtFPN expects input with shape (B, C, H, W), got ndim={x.ndim}."
+            )
 
 
 __all__ = ["CourtFPN"]

--- a/src/tasks/court_detection/models/decoder.py
+++ b/src/tasks/court_detection/models/decoder.py
@@ -23,18 +23,10 @@ class CourtFPNDecoder(nn.Module):
         super().__init__()
         self.encoder_channels = tuple(int(channel) for channel in encoder_channels)
         self.decoder_channels = tuple(int(channel) for channel in decoder_channels)
-        if len(self.encoder_channels) != 4:
-            raise ValueError(
-                "CourtFPNDecoder expects four encoder feature levels, "
-                f"got {len(self.encoder_channels)}."
-            )
-        if len(self.decoder_channels) != 4:
-            raise ValueError(
-                "CourtFPNDecoder expects four decoder channels, "
-                f"got {len(self.decoder_channels)}."
-            )
-        if any(channel <= 0 for channel in self.decoder_channels):
-            raise ValueError("decoder_channels must contain positive integers.")
+        self._validate_init_args(
+            encoder_channels=self.encoder_channels,
+            decoder_channels=self.decoder_channels,
+        )
 
         self.output_channels = self.decoder_channels[0]
         self.lateral_blocks = nn.ModuleList(
@@ -61,12 +53,27 @@ class CourtFPNDecoder(nn.Module):
             for level in range(len(self.decoder_channels) - 2, -1, -1)
         )
 
-    def forward(self, feats: Sequence[torch.Tensor]) -> torch.Tensor:
-        if len(feats) != len(self.encoder_channels):
+    @staticmethod
+    def _validate_init_args(
+        *,
+        encoder_channels: Sequence[int],
+        decoder_channels: Sequence[int],
+    ) -> None:
+        if len(encoder_channels) != 4:
             raise ValueError(
-                "CourtFPNDecoder expects four feature levels, "
-                f"got {len(feats)}."
+                "CourtFPNDecoder expects four encoder feature levels, "
+                f"got {len(encoder_channels)}."
             )
+        if len(decoder_channels) != 4:
+            raise ValueError(
+                "CourtFPNDecoder expects four decoder channels, "
+                f"got {len(decoder_channels)}."
+            )
+        if any(channel <= 0 for channel in decoder_channels):
+            raise ValueError("decoder_channels must contain positive integers.")
+
+    def forward(self, feats: Sequence[torch.Tensor]) -> torch.Tensor:
+        self._validate_forward_inputs(feats)
 
         projected_feats = [
             lateral_block(feat)
@@ -77,10 +84,21 @@ class CourtFPNDecoder(nn.Module):
         for block_index, level in enumerate(range(len(projected_feats) - 2, -1, -1)):
             lateral_feat = projected_feats[level]
             if x.shape[-2:] != lateral_feat.shape[-2:]:
-                x = F.interpolate(x, size=lateral_feat.shape[-2:], mode="bilinear", align_corners=False)
+                x = F.interpolate(
+                    x,
+                    size=lateral_feat.shape[-2:],
+                    mode="bilinear",
+                    align_corners=False,
+                )
             x = torch.cat([x, lateral_feat], dim=1)
             x = self.fusion_blocks[block_index](x)
         return x
+
+    def _validate_forward_inputs(self, feats: Sequence[torch.Tensor]) -> None:
+        if len(feats) != len(self.encoder_channels):
+            raise ValueError(
+                f"CourtFPNDecoder expects four feature levels, got {len(feats)}."
+            )
 
 
 __all__ = ["CourtFPNDecoder"]

--- a/src/tasks/court_detection/models/encoders.py
+++ b/src/tasks/court_detection/models/encoders.py
@@ -26,7 +26,14 @@ class CourtDefaultEncoder(nn.Module):
         self.in_channels = int(in_channels)
 
         self.stem = nn.Sequential(
-            nn.Conv2d(self.in_channels, self.in_channels, kernel_size=3, stride=2, padding=1, bias=False),
+            nn.Conv2d(
+                self.in_channels,
+                self.in_channels,
+                kernel_size=3,
+                stride=2,
+                padding=1,
+                bias=False,
+            ),
             nn.BatchNorm2d(self.in_channels),
             nn.ReLU(inplace=True),
         )
@@ -37,16 +44,10 @@ class CourtDefaultEncoder(nn.Module):
         self.bottleneck_2 = Conv2dWiseWiseBlock(512, 512)
         self.pool = nn.MaxPool2d(kernel_size=2, stride=2)
 
-    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        if x.ndim != 4:
-            raise ValueError(
-                "CourtDefaultEncoder expects input with shape (B, C, H, W), "
-                f"got ndim={x.ndim}."
-            )
-        if x.shape[1] != self.in_channels:
-            raise ValueError(
-                f"Expected {self.in_channels} input channels but received {x.shape[1]}."
-            )
+    def forward(
+        self, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        self._validate_forward_input(x)
 
         x = self.stem(x)
 
@@ -61,6 +62,17 @@ class CourtDefaultEncoder(nn.Module):
 
         feat4 = self.bottleneck_2(self.bottleneck_1(x))
         return (feat1, feat2, feat3, feat4)
+
+    def _validate_forward_input(self, x: torch.Tensor) -> None:
+        if x.ndim != 4:
+            raise ValueError(
+                "CourtDefaultEncoder expects input with shape (B, C, H, W), "
+                f"got ndim={x.ndim}."
+            )
+        if x.shape[1] != self.in_channels:
+            raise ValueError(
+                f"Expected {self.in_channels} input channels but received {x.shape[1]}."
+            )
 
 
 class CourtDINOEncoder(nn.Module):
@@ -80,13 +92,10 @@ class CourtDINOEncoder(nn.Module):
         freeze_backbone: bool = True,
     ) -> None:
         super().__init__()
-        if in_channels != 3:
-            raise ValueError(
-                "CourtDINOEncoder requires 3-channel RGB input, "
-                f"got in_channels={in_channels}."
-            )
-        if tuple(return_interm_indices) != (0, 1, 2, 3):
-            raise ValueError("CourtDINOEncoder expects return_interm_indices=(0, 1, 2, 3).")
+        self._validate_init_args(
+            in_channels=in_channels,
+            return_interm_indices=return_interm_indices,
+        )
 
         self.in_channels = int(in_channels)
         self.backbone_name = str(backbone_name)
@@ -104,19 +113,48 @@ class CourtDINOEncoder(nn.Module):
         self.backbone = loaded_backbone.module
         self.feature_channels = loaded_backbone.metadata.feature_channels
 
+        self._validate_backbone_load_result(loaded_backbone, strict=strict)
+        if freeze_backbone:
+            for parameter in self.backbone.parameters():
+                parameter.requires_grad = False
+
+    @staticmethod
+    def _validate_init_args(
+        *,
+        in_channels: int,
+        return_interm_indices: tuple[int, ...],
+    ) -> None:
+        if in_channels != 3:
+            raise ValueError(
+                "CourtDINOEncoder requires 3-channel RGB input, "
+                f"got in_channels={in_channels}."
+            )
+        if tuple(return_interm_indices) != (0, 1, 2, 3):
+            raise ValueError(
+                "CourtDINOEncoder expects return_interm_indices=(0, 1, 2, 3)."
+            )
+
+    @staticmethod
+    def _validate_backbone_load_result(loaded_backbone, *, strict: bool) -> None:
         if strict and (
-            loaded_backbone.load_result.missing_keys or loaded_backbone.load_result.unexpected_keys
+            loaded_backbone.load_result.missing_keys
+            or loaded_backbone.load_result.unexpected_keys
         ):
             raise RuntimeError(
                 "Unexpected DINO backbone load result: "
                 f"missing={loaded_backbone.load_result.missing_keys}, "
                 f"unexpected={loaded_backbone.load_result.unexpected_keys}"
             )
-        if freeze_backbone:
-            for parameter in self.backbone.parameters():
-                parameter.requires_grad = False
 
-    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    def forward(
+        self, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        self._validate_forward_input(x)
+
+        features = self.backbone(x)
+        return tuple(features[str(index)] for index in self.return_interm_indices)
+
+    def _validate_forward_input(self, x: torch.Tensor) -> None:
         if x.ndim != 4:
             raise ValueError(
                 "CourtDINOEncoder expects input with shape (B, C, H, W), "
@@ -126,12 +164,6 @@ class CourtDINOEncoder(nn.Module):
             raise ValueError(
                 f"Expected {self.in_channels} input channels but received {x.shape[1]}."
             )
-
-        features = self.backbone(x)
-        return tuple(
-            features[str(index)]
-            for index in self.return_interm_indices
-        )
 
 
 def build_court_encoder(
@@ -148,7 +180,9 @@ def build_court_encoder(
 ) -> nn.Module:
     """Build the requested court encoder."""
 
-    resolved_encoder_name = _DINO_ENCODER_ALIASES.get(str(encoder_name), str(encoder_name))
+    resolved_encoder_name = _DINO_ENCODER_ALIASES.get(
+        str(encoder_name), str(encoder_name)
+    )
     if resolved_encoder_name == "default":
         return CourtDefaultEncoder(in_channels=in_channels)
     return CourtDINOEncoder(

--- a/src/tasks/event_detection/models/traj3d_event_model.py
+++ b/src/tasks/event_detection/models/traj3d_event_model.py
@@ -43,8 +43,7 @@ class Traj3DEventModel(nn.Module):
         self.max_seq_len = int(max_seq_len)
         self.num_events = int(num_events)
 
-        if self.hidden_dim % num_heads != 0:
-            raise ValueError("hidden_dim must be divisible by num_heads.")
+        self._validate_init_args(hidden_dim=self.hidden_dim, num_heads=num_heads)
         head_dim = self.hidden_dim // int(num_heads)
         rope_dim = head_dim
         rope_base = float(rope_theta if rope_theta_time is None else rope_theta_time)
@@ -75,7 +74,9 @@ class Traj3DEventModel(nn.Module):
             ]
         )
         self.final_norm = RMSNorm(self.hidden_dim)
-        self.head = EventLogitsHead(input_dim=self.hidden_dim, num_events=self.num_events, dropout=dropout)
+        self.head = EventLogitsHead(
+            input_dim=self.hidden_dim, num_events=self.num_events, dropout=dropout
+        )
 
         freqs_cis = precompute_freqs_cis(
             dim=rope_dim,
@@ -84,6 +85,11 @@ class Traj3DEventModel(nn.Module):
             device=None,
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+
+    @staticmethod
+    def _validate_init_args(*, hidden_dim: int, num_heads: int) -> None:
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads.")
 
     @classmethod
     def from_config(cls, config: DictConfig) -> Traj3DEventModel:
@@ -99,7 +105,9 @@ class Traj3DEventModel(nn.Module):
             max_seq_len=int(model_cfg.get("max_seq_len", 256)),
             num_events=int(model_cfg.get("num_events", 2)),
             ffn_dim=model_cfg.get("ffn_dim"),
-            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
+            ),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
         )
 
@@ -141,7 +149,9 @@ class Traj3DEventModel(nn.Module):
 
 
 if __name__ == "__main__":
-    model = Traj3DEventModel(hidden_dim=64, num_layers=2, num_heads=4, max_seq_len=32, num_events=2)
+    model = Traj3DEventModel(
+        hidden_dim=64, num_layers=2, num_heads=4, max_seq_len=32, num_events=2
+    )
     ball_pos = torch.randn(2, 32, 3)
     seq_len = torch.tensor([32, 16])
     logits = model(ball_pos, seq_len=seq_len)

--- a/src/tasks/event_detection/models/uv_event_model.py
+++ b/src/tasks/event_detection/models/uv_event_model.py
@@ -58,8 +58,7 @@ class UVEventModel(nn.Module):
         self.num_events = int(num_events)
         self.num_court_tokens = int(num_court_tokens)
 
-        if self.hidden_dim % num_heads != 0:
-            raise ValueError("hidden_dim must be divisible by num_heads.")
+        self._validate_init_args(hidden_dim=self.hidden_dim, num_heads=num_heads)
         head_dim = self.hidden_dim // int(num_heads)
         rope_dim = head_dim
         self.rope_theta = float(rope_theta)
@@ -101,7 +100,9 @@ class UVEventModel(nn.Module):
             ]
         )
         self.final_norm = RMSNorm(self.hidden_dim)
-        self.head = EventLogitsHead(input_dim=self.hidden_dim, num_events=self.num_events, dropout=dropout)
+        self.head = EventLogitsHead(
+            input_dim=self.hidden_dim, num_events=self.num_events, dropout=dropout
+        )
 
         freqs_cis = precompute_freqs_cis_nd(
             dim=rope_dim,
@@ -109,6 +110,11 @@ class UVEventModel(nn.Module):
             base=self.rope_bases,
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+
+    @staticmethod
+    def _validate_init_args(*, hidden_dim: int, num_heads: int) -> None:
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads.")
 
     @classmethod
     def from_config(cls, config: DictConfig) -> UVEventModel:
@@ -127,7 +133,9 @@ class UVEventModel(nn.Module):
             max_seq_len=int(model_cfg.get("max_seq_len", 256)),
             num_events=int(model_cfg.get("num_events", 2)),
             ffn_dim=model_cfg.get("ffn_dim"),
-            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
+            ),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             num_court_tokens=int(data_cfg.get("num_court_kp", NUM_COURT_KP)),
         )
@@ -177,21 +185,16 @@ class UVEventModel(nn.Module):
             Logits (B, T, E)
         """
         B, T, _ = ball_uv.shape
-        if self.max_seq_len < T:
-            ball_uv = ball_uv[:, : self.max_seq_len]
-            if ball_vis is not None:
-                ball_vis = ball_vis[:, : self.max_seq_len]
-            if ball_mask is not None:
-                ball_mask = ball_mask[:, : self.max_seq_len]
-            if seq_len is not None:
-                seq_len = torch.clamp(seq_len, max=self.max_seq_len)
-            T = self.max_seq_len
+        ball_uv, ball_vis, ball_mask, seq_len, T = self._clip_sequence_inputs(
+            ball_uv=ball_uv,
+            ball_vis=ball_vis,
+            ball_mask=ball_mask,
+            seq_len=seq_len,
+            seq_len_in=T,
+        )
 
         court_tokens = self.court_embed(court_kp, court_vis)  # (B, K, D)
-        if court_tokens.shape[1] != self.num_court_tokens:
-            raise ValueError(
-                f"Expected {self.num_court_tokens} court tokens, got {court_tokens.shape[1]}"
-            )
+        self._validate_court_tokens(court_tokens)
         ball_tokens = self.ball_embed(ball_uv, ball_vis)  # (B, T, D)
 
         K = self.num_court_tokens
@@ -207,12 +210,7 @@ class UVEventModel(nn.Module):
             ball_valid = ball_mask > 0
             key_padding_mask = torch.cat([court_valid, ball_valid], dim=1)  # (B, S)
 
-        freqs_cis = cast(Tensor, self.freqs_cis)
-        if freqs_cis.shape[0] < S:
-            raise ValueError("Sequence length exceeds max_seq_len; increase model.max_seq_len.")
-        freqs_cis = freqs_cis[:S]
-        if freqs_cis.device != x.device:
-            freqs_cis = freqs_cis.to(x.device)
+        freqs_cis = self._freqs_for_sequence(x=x, seq_len=S)
 
         attn_mask: Tensor | None = None
         if key_padding_mask is not None:
@@ -229,6 +227,43 @@ class UVEventModel(nn.Module):
 
         ball_h = x[:, K:, :]
         return cast(Tensor, self.head(ball_h))
+
+    def _clip_sequence_inputs(
+        self,
+        *,
+        ball_uv: Tensor,
+        ball_vis: Tensor | None,
+        ball_mask: Tensor | None,
+        seq_len: Tensor | None,
+        seq_len_in: int,
+    ) -> tuple[Tensor, Tensor | None, Tensor | None, Tensor | None, int]:
+        if self.max_seq_len < seq_len_in:
+            ball_uv = ball_uv[:, : self.max_seq_len]
+            if ball_vis is not None:
+                ball_vis = ball_vis[:, : self.max_seq_len]
+            if ball_mask is not None:
+                ball_mask = ball_mask[:, : self.max_seq_len]
+            if seq_len is not None:
+                seq_len = torch.clamp(seq_len, max=self.max_seq_len)
+            seq_len_in = self.max_seq_len
+        return ball_uv, ball_vis, ball_mask, seq_len, seq_len_in
+
+    def _validate_court_tokens(self, court_tokens: Tensor) -> None:
+        if court_tokens.shape[1] != self.num_court_tokens:
+            raise ValueError(
+                f"Expected {self.num_court_tokens} court tokens, got {court_tokens.shape[1]}"
+            )
+
+    def _freqs_for_sequence(self, *, x: Tensor, seq_len: int) -> Tensor:
+        freqs_cis = cast(Tensor, self.freqs_cis)
+        if freqs_cis.shape[0] < seq_len:
+            raise ValueError(
+                "Sequence length exceeds max_seq_len; increase model.max_seq_len."
+            )
+        freqs_cis = freqs_cis[:seq_len]
+        if freqs_cis.device != x.device:
+            freqs_cis = freqs_cis.to(x.device)
+        return freqs_cis
 
 
 if __name__ == "__main__":
@@ -247,6 +282,13 @@ if __name__ == "__main__":
     court_kp = torch.rand(2, num_court_tokens, 2)
     court_vis = torch.ones(2, num_court_tokens)
     seq_len = torch.tensor([32, 16])
-    logits = model(ball_uv, court_kp, ball_vis=ball_vis, ball_mask=ball_mask, court_vis=court_vis, seq_len=seq_len)
+    logits = model(
+        ball_uv,
+        court_kp,
+        ball_vis=ball_vis,
+        ball_mask=ball_mask,
+        court_vis=court_vis,
+        seq_len=seq_len,
+    )
     assert logits.shape == (2, 32, 2)
     print("uv model smoke ok")

--- a/src/tasks/event_detection/models/uv_event_nocourt_model.py
+++ b/src/tasks/event_detection/models/uv_event_nocourt_model.py
@@ -45,8 +45,7 @@ class UVEventNoCourtModel(nn.Module):
         self.max_seq_len = int(max_seq_len)
         self.num_events = int(num_events)
 
-        if self.hidden_dim % num_heads != 0:
-            raise ValueError("hidden_dim must be divisible by num_heads.")
+        self._validate_init_args(hidden_dim=self.hidden_dim, num_heads=num_heads)
         head_dim = self.hidden_dim // int(num_heads)
         rope_dim = head_dim
         rope_base = float(rope_theta if rope_theta_time is None else rope_theta_time)
@@ -78,7 +77,9 @@ class UVEventNoCourtModel(nn.Module):
             ]
         )
         self.final_norm = RMSNorm(self.hidden_dim)
-        self.head = EventLogitsHead(input_dim=self.hidden_dim, num_events=self.num_events, dropout=dropout)
+        self.head = EventLogitsHead(
+            input_dim=self.hidden_dim, num_events=self.num_events, dropout=dropout
+        )
 
         freqs_cis = precompute_freqs_cis(
             dim=rope_dim,
@@ -87,6 +88,11 @@ class UVEventNoCourtModel(nn.Module):
             device=None,
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+
+    @staticmethod
+    def _validate_init_args(*, hidden_dim: int, num_heads: int) -> None:
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads.")
 
     @classmethod
     def from_config(cls, config: DictConfig) -> UVEventNoCourtModel:
@@ -102,7 +108,9 @@ class UVEventNoCourtModel(nn.Module):
             max_seq_len=int(model_cfg.get("max_seq_len", 256)),
             num_events=int(model_cfg.get("num_events", 2)),
             ffn_dim=model_cfg.get("ffn_dim"),
-            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
+            ),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
         )
 

--- a/src/tasks/plcs/models/plcs_model.py
+++ b/src/tasks/plcs/models/plcs_model.py
@@ -137,8 +137,7 @@ class PLCSModel(nn.Module):
             ffn_dim = int((8 * hidden_dim) / 3)
             ffn_dim = (ffn_dim + 63) // 64 * 64  # Round to multiple of 64
 
-        if self.num_register_tokens < 0:
-            raise ValueError(f"num_register_tokens must be >= 0, got {self.num_register_tokens}")
+        self._validate_init_args(num_register_tokens=self.num_register_tokens)
 
         # Token embeddings
         self.invisible_token = InvisibleTokenEmbedding(
@@ -161,7 +160,9 @@ class PLCSModel(nn.Module):
 
         # Register tokens (prefix tokens; no RoPE applied)
         if self.num_register_tokens > 0:
-            self.register_tokens = nn.Parameter(torch.zeros(1, self.num_register_tokens, hidden_dim))
+            self.register_tokens = nn.Parameter(
+                torch.zeros(1, self.num_register_tokens, hidden_dim)
+            )
             nn.init.trunc_normal_(self.register_tokens, std=0.02)
 
         # Optional KP-ID embeddings
@@ -220,6 +221,13 @@ class PLCSModel(nn.Module):
             )
             self.register_buffer("freqs_cis_body", freqs_cis, persistent=False)
 
+    @staticmethod
+    def _validate_init_args(*, num_register_tokens: int) -> None:
+        if num_register_tokens < 0:
+            raise ValueError(
+                f"num_register_tokens must be >= 0, got {num_register_tokens}"
+            )
+
     @classmethod
     def from_config(cls, config: DictConfig) -> PLCSModel:
         """Create model from configuration.
@@ -248,7 +256,9 @@ class PLCSModel(nn.Module):
             num_register_tokens=int(model_cfg.get("num_register_tokens", 4)),
             use_kp_id_embedding=bool(model_cfg.get("use_kp_id_embedding", True)),
             use_rope=bool(model_cfg.get("use_rope", True)),
-            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
+            ),
             predict_canonical_pose=bool(model_cfg.get("predict_canonical_pose", False)),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             num_court_tokens=int(data_cfg.get("num_court_kp", NUM_COURT_KP)),
@@ -353,7 +363,10 @@ class PLCSModel(nn.Module):
                 freqs_cis_body = freqs_cis_body.to(x.device)
 
             prefix_freqs = torch.ones(
-                prefix_len, freqs_cis_body.shape[1], device=x.device, dtype=freqs_cis_body.dtype
+                prefix_len,
+                freqs_cis_body.shape[1],
+                device=x.device,
+                dtype=freqs_cis_body.dtype,
             )
             freqs_cis = torch.cat([prefix_freqs, freqs_cis_body], dim=0)
 
@@ -406,6 +419,45 @@ class PLCSModel(nn.Module):
         - ``court_vis``: ``(B,20)``, optional
         - ``human_mask``: ``(B,)`` or ``None`` (unused by frame model)
         """
+        self._validate_forward_inputs(
+            human_kp=human_kp,
+            court_kp=court_kp,
+            human_vis=human_vis,
+            human_mask=human_mask,
+            court_vis=court_vis,
+        )
+
+        x, _ = self._encode_tokens(
+            human_kp=human_kp,
+            court_kp=court_kp,
+            human_vis=human_vis,
+            court_vis=court_vis,
+        )
+
+        # Extract CLS token
+        cls_out = x[:, 0, :]  # (B, D)
+
+        # Apply output heads
+        position = self.position_head(cls_out)  # (B, 3)
+        rotation = self.rotation_head(cls_out)  # (B, 2)
+
+        out = {
+            "position": position,
+            "rotation": rotation,
+        }
+        if self.predict_canonical_pose and self.canonical_pose_head is not None:
+            out["canonical_pose"] = self.canonical_pose_head(cls_out)
+        return out
+
+    @staticmethod
+    def _validate_forward_inputs(
+        *,
+        human_kp: Tensor,
+        court_kp: Tensor,
+        human_vis: Tensor | None,
+        human_mask: Tensor | None,
+        court_vis: Tensor | None,
+    ) -> None:
         if human_kp.dim() not in {2, 3}:
             raise ValueError(
                 "PLCSModel expects human_kp as (B,17,2) or (B,34), "
@@ -432,28 +484,6 @@ class PLCSModel(nn.Module):
                 f"got shape {tuple(human_mask.shape)}"
             )
 
-        x, _ = self._encode_tokens(
-            human_kp=human_kp,
-            court_kp=court_kp,
-            human_vis=human_vis,
-            court_vis=court_vis,
-        )
-
-        # Extract CLS token
-        cls_out = x[:, 0, :]  # (B, D)
-
-        # Apply output heads
-        position = self.position_head(cls_out)  # (B, 3)
-        rotation = self.rotation_head(cls_out)  # (B, 2)
-
-        out = {
-            "position": position,
-            "rotation": rotation,
-        }
-        if self.predict_canonical_pose and self.canonical_pose_head is not None:
-            out["canonical_pose"] = self.canonical_pose_head(cls_out)
-        return out
-
     def get_num_params(self) -> int:
         """Get total number of trainable parameters."""
         return sum(p.numel() for p in self.parameters() if p.requires_grad)
@@ -476,7 +506,12 @@ if __name__ == "__main__":
     court_vis = (torch.rand(B, NUM_COURT_KP) > 0.1).to(torch.float32)
 
     with torch.no_grad():
-        out = model(human_kp=human_kp, court_kp=court_kp, human_vis=human_vis, court_vis=court_vis)
+        out = model(
+            human_kp=human_kp,
+            court_kp=court_kp,
+            human_vis=human_vis,
+            court_vis=court_vis,
+        )
 
     print("PLCSModel:")
     for key, value in out.items():

--- a/src/tasks/plcs/models/plcs_multiview_axial_model.py
+++ b/src/tasks/plcs/models/plcs_multiview_axial_model.py
@@ -19,7 +19,10 @@ from src.utils.models import (
     TransformerBlockConfig,
     precompute_freqs_cis_nd,
 )
-from src.utils.models.embeddings import CourtPlayerGroupEmbedding, InvisibleTokenEmbedding
+from src.utils.models.embeddings import (
+    CourtPlayerGroupEmbedding,
+    InvisibleTokenEmbedding,
+)
 from src.utils.schema.court import NUM_COURT_KP
 from src.utils.schema.player import NUM_HUMAN_KP
 
@@ -56,23 +59,17 @@ class PLCSMultiViewAxialModel(nn.Module):
         self.max_seq_len = int(max_seq_len)
         self.num_court_tokens = int(num_court_tokens)
 
-        if self.hidden_dim % num_heads != 0:
-            raise ValueError(
-                f"hidden_dim={self.hidden_dim} must be divisible by num_heads={num_heads}"
-            )
-        if num_layers < 0:
-            raise ValueError(f"num_layers must be non-negative, got {num_layers}")
-        if self.max_views <= 0:
-            raise ValueError(f"max_views must be positive, got {max_views}")
-        if self.max_seq_len <= 0:
-            raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
+        self._validate_init_args(
+            hidden_dim=self.hidden_dim,
+            num_heads=num_heads,
+            num_layers=num_layers,
+            max_views=self.max_views,
+            max_seq_len=self.max_seq_len,
+        )
 
         head_dim = self.hidden_dim // num_heads
         rope_dim = head_dim if rope_dim is None else int(rope_dim)
-        if rope_dim % 2 != 0:
-            raise ValueError(f"rope_dim must be even, got {rope_dim}")
-        if rope_dim > head_dim:
-            raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
+        self._validate_rope_dim(rope_dim=rope_dim, head_dim=head_dim)
 
         self.rope_dim = int(rope_dim)
         self.rope_bases = (
@@ -163,6 +160,33 @@ class PLCSMultiViewAxialModel(nn.Module):
         )
         self.register_buffer("token_freqs_cis", token_freqs, persistent=False)
 
+    @staticmethod
+    def _validate_init_args(
+        *,
+        hidden_dim: int,
+        num_heads: int,
+        num_layers: int,
+        max_views: int,
+        max_seq_len: int,
+    ) -> None:
+        if hidden_dim % num_heads != 0:
+            raise ValueError(
+                f"hidden_dim={hidden_dim} must be divisible by num_heads={num_heads}"
+            )
+        if num_layers < 0:
+            raise ValueError(f"num_layers must be non-negative, got {num_layers}")
+        if max_views <= 0:
+            raise ValueError(f"max_views must be positive, got {max_views}")
+        if max_seq_len <= 0:
+            raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
+
+    @staticmethod
+    def _validate_rope_dim(*, rope_dim: int, head_dim: int) -> None:
+        if rope_dim % 2 != 0:
+            raise ValueError(f"rope_dim must be even, got {rope_dim}")
+        if rope_dim > head_dim:
+            raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
+
     @classmethod
     def from_config(cls, config: DictConfig) -> PLCSMultiViewAxialModel:
         """Create model from hydra config."""
@@ -179,12 +203,20 @@ class PLCSMultiViewAxialModel(nn.Module):
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
             rope_theta_time=model_cfg.get("rope_theta_time", None),
             rope_theta_camera=model_cfg.get("rope_theta_camera", None),
-            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
+            ),
             predict_canonical_pose=bool(model_cfg.get("predict_canonical_pose", False)),
             max_views=int(model_cfg.get("max_views", 8)),
-            max_seq_len=int(model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))),
+            max_seq_len=int(
+                model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))
+            ),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
-            num_court_tokens=int(model_cfg.get("num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP))),
+            num_court_tokens=int(
+                model_cfg.get(
+                    "num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP)
+                )
+            ),
         )
 
     @staticmethod
@@ -215,21 +247,29 @@ class PLCSMultiViewAxialModel(nn.Module):
 
     def _camera_freqs(self, *, batch_size: int, seq_len: int, n_cams: int) -> Tensor:
         freqs = self.token_freqs_cis[:seq_len, :n_cams]
-        return freqs.unsqueeze(0).expand(
-            batch_size,
-            seq_len,
-            n_cams,
-            self.rope_dim // 2,
-        ).reshape(batch_size * seq_len, n_cams, self.rope_dim // 2)
+        return (
+            freqs.unsqueeze(0)
+            .expand(
+                batch_size,
+                seq_len,
+                n_cams,
+                self.rope_dim // 2,
+            )
+            .reshape(batch_size * seq_len, n_cams, self.rope_dim // 2)
+        )
 
     def _time_freqs(self, *, batch_size: int, seq_len: int, n_cams: int) -> Tensor:
         freqs = self.token_freqs_cis[:seq_len, :n_cams].permute(1, 0, 2)
-        return freqs.unsqueeze(0).expand(
-            batch_size,
-            n_cams,
-            seq_len,
-            self.rope_dim // 2,
-        ).reshape(batch_size * n_cams, seq_len, self.rope_dim // 2)
+        return (
+            freqs.unsqueeze(0)
+            .expand(
+                batch_size,
+                n_cams,
+                seq_len,
+                self.rope_dim // 2,
+            )
+            .reshape(batch_size * n_cams, seq_len, self.rope_dim // 2)
+        )
 
     def forward(
         self,
@@ -240,6 +280,109 @@ class PLCSMultiViewAxialModel(nn.Module):
         court_vis: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Forward pass for multiview PLCS inputs."""
+        batch_size, n_cams, seq_len_in = self._validate_forward_inputs(
+            human_kp=human_kp,
+            court_kp=court_kp,
+            human_vis=human_vis,
+            human_mask=human_mask,
+            court_vis=court_vis,
+        )
+
+        if human_vis is not None:
+            human_kp = human_kp * (human_vis > 0).unsqueeze(-1).to(dtype=human_kp.dtype)
+        if court_vis is not None:
+            court_kp = court_kp * (court_vis > 0).unsqueeze(-1).to(dtype=court_kp.dtype)
+
+        if human_mask is not None:
+            token_valid = human_mask > 0
+        else:
+            token_valid = torch.ones(
+                batch_size,
+                n_cams,
+                seq_len_in,
+                dtype=torch.bool,
+                device=human_kp.device,
+            )
+
+        court_flat = court_kp.reshape(
+            batch_size * n_cams * seq_len_in, self.num_court_tokens, 2
+        )
+        human_flat = human_kp.reshape(batch_size * n_cams * seq_len_in, NUM_HUMAN_KP, 2)
+        group_vis = token_valid.reshape(batch_size * n_cams * seq_len_in)
+        x = (
+            self.group_embed(court_flat, human_flat, group_vis)
+            .reshape(
+                batch_size,
+                n_cams,
+                seq_len_in,
+                self.hidden_dim,
+            )
+            .permute(0, 2, 1, 3)
+        )
+
+        token_valid_t = token_valid.permute(0, 2, 1)
+        camera_valid = token_valid_t.reshape(batch_size * seq_len_in, n_cams)
+        time_valid = token_valid_t.permute(0, 2, 1).reshape(
+            batch_size * n_cams, seq_len_in
+        )
+        camera_mask, _ = self._build_self_attn_mask(camera_valid)
+        time_mask, _ = self._build_self_attn_mask(time_valid)
+        camera_freqs = self._camera_freqs(
+            batch_size=batch_size,
+            seq_len=seq_len_in,
+            n_cams=n_cams,
+        )
+        time_freqs = self._time_freqs(
+            batch_size=batch_size,
+            seq_len=seq_len_in,
+            n_cams=n_cams,
+        )
+
+        for camera_layer, time_layer in zip(
+            self.camera_layers,
+            self.time_layers,
+            strict=True,
+        ):
+            x_camera = x.reshape(batch_size * seq_len_in, n_cams, self.hidden_dim)
+            x_camera = camera_layer(
+                x_camera,
+                freqs_cis=camera_freqs,
+                attn_mask=camera_mask,
+            )
+            x = x_camera.reshape(batch_size, seq_len_in, n_cams, self.hidden_dim)
+
+            x_time = x.permute(0, 2, 1, 3).reshape(
+                batch_size * n_cams, seq_len_in, self.hidden_dim
+            )
+            x_time = time_layer(
+                x_time,
+                freqs_cis=time_freqs,
+                attn_mask=time_mask,
+            )
+            x = x_time.reshape(batch_size, n_cams, seq_len_in, self.hidden_dim).permute(
+                0, 2, 1, 3
+            )
+
+        x = x[:, :, 0, :]
+        x = self.final_norm(x)
+
+        out = {
+            "position": self.position_head(x),
+            "rotation": self.rotation_head(x),
+        }
+        if self.predict_canonical_pose and self.canonical_pose_head is not None:
+            out["canonical_pose"] = self.canonical_pose_head(x)
+        return out
+
+    def _validate_forward_inputs(
+        self,
+        *,
+        human_kp: Tensor,
+        court_kp: Tensor,
+        human_vis: Tensor | None,
+        human_mask: Tensor | None,
+        court_vis: Tensor | None,
+    ) -> tuple[int, int, int]:
         if human_kp.dim() != 5:
             raise ValueError(
                 "PLCSMultiViewAxialModel expects human_kp as (B,N,T,17,2), "
@@ -273,87 +416,19 @@ class PLCSMultiViewAxialModel(nn.Module):
 
         batch_size, n_cams, seq_len_in = human_kp.shape[:3]
         if n_cams > self.max_views:
-            raise ValueError(f"Number of views N={n_cams} exceeds max_views={self.max_views}.")
+            raise ValueError(
+                f"Number of views N={n_cams} exceeds max_views={self.max_views}."
+            )
         if seq_len_in > self.max_seq_len:
             raise ValueError(
                 f"Sequence length T={seq_len_in} exceeds max_seq_len={self.max_seq_len}."
             )
-
-        if human_vis is not None:
-            human_kp = human_kp * (human_vis > 0).unsqueeze(-1).to(dtype=human_kp.dtype)
-        if court_vis is not None:
-            court_kp = court_kp * (court_vis > 0).unsqueeze(-1).to(dtype=court_kp.dtype)
-
-        if human_mask is not None:
-            if human_mask.dim() != 3 or human_mask.shape != (batch_size, n_cams, seq_len_in):
-                raise ValueError(
-                    "human_mask for multiview models must be (B,N,T), "
-                    f"got {tuple(human_mask.shape)}"
-                )
-            token_valid = human_mask > 0
-        else:
-            token_valid = torch.ones(
-                batch_size,
-                n_cams,
-                seq_len_in,
-                dtype=torch.bool,
-                device=human_kp.device,
-            )
-
-        court_flat = court_kp.reshape(batch_size * n_cams * seq_len_in, self.num_court_tokens, 2)
-        human_flat = human_kp.reshape(batch_size * n_cams * seq_len_in, NUM_HUMAN_KP, 2)
-        group_vis = token_valid.reshape(batch_size * n_cams * seq_len_in)
-        x = self.group_embed(court_flat, human_flat, group_vis).reshape(
-            batch_size,
-            n_cams,
-            seq_len_in,
-            self.hidden_dim,
-        ).permute(0, 2, 1, 3)
-
-        token_valid_t = token_valid.permute(0, 2, 1)
-        camera_valid = token_valid_t.reshape(batch_size * seq_len_in, n_cams)
-        time_valid = token_valid_t.permute(0, 2, 1).reshape(batch_size * n_cams, seq_len_in)
-        camera_mask, _ = self._build_self_attn_mask(camera_valid)
-        time_mask, _ = self._build_self_attn_mask(time_valid)
-        camera_freqs = self._camera_freqs(
-            batch_size=batch_size,
-            seq_len=seq_len_in,
-            n_cams=n_cams,
-        )
-        time_freqs = self._time_freqs(
-            batch_size=batch_size,
-            seq_len=seq_len_in,
-            n_cams=n_cams,
-        )
-
-        for camera_layer, time_layer in zip(
-            self.camera_layers,
-            self.time_layers,
-            strict=True,
+        if human_mask is not None and (
+            human_mask.dim() != 3
+            or human_mask.shape != (batch_size, n_cams, seq_len_in)
         ):
-            x_camera = x.reshape(batch_size * seq_len_in, n_cams, self.hidden_dim)
-            x_camera = camera_layer(
-                x_camera,
-                freqs_cis=camera_freqs,
-                attn_mask=camera_mask,
+            raise ValueError(
+                "human_mask for multiview models must be (B,N,T), "
+                f"got {tuple(human_mask.shape)}"
             )
-            x = x_camera.reshape(batch_size, seq_len_in, n_cams, self.hidden_dim)
-
-            x_time = x.permute(0, 2, 1, 3).reshape(batch_size * n_cams, seq_len_in, self.hidden_dim)
-            x_time = time_layer(
-                x_time,
-                freqs_cis=time_freqs,
-                attn_mask=time_mask,
-            )
-            x = x_time.reshape(batch_size, n_cams, seq_len_in, self.hidden_dim).permute(0, 2, 1, 3)
-
-        x = x[:, :, 0, :]
-        x = self.final_norm(x)
-
-        out = {
-            "position": self.position_head(x),
-            "rotation": self.rotation_head(x),
-        }
-        if self.predict_canonical_pose and self.canonical_pose_head is not None:
-            out["canonical_pose"] = self.canonical_pose_head(x)
-        return out
+        return batch_size, n_cams, seq_len_in

--- a/src/tasks/plcs/models/plcs_multiview_model.py
+++ b/src/tasks/plcs/models/plcs_multiview_model.py
@@ -62,12 +62,20 @@ class RoPETransformerBlock(nn.Module):
         )
 
         self.ffn_norm = RMSNorm(dim)
+        self.ffn = self._build_ffn(dim=dim, ffn_dim=ffn_dim, ffn_type=ffn_type)
+
+    @staticmethod
+    def _build_ffn(
+        *,
+        dim: int,
+        ffn_dim: int,
+        ffn_type: Literal["swiglu", "mlp"],
+    ) -> nn.Module:
         if ffn_type == "swiglu":
-            self.ffn: nn.Module = SwiGLU(dim, ffn_dim)
-        elif ffn_type == "mlp":
-            self.ffn = MLP(dim, ffn_dim)
-        else:
-            raise ValueError(f"Unsupported ffn_type={ffn_type}")
+            return SwiGLU(dim, ffn_dim)
+        if ffn_type == "mlp":
+            return MLP(dim, ffn_dim)
+        raise ValueError(f"Unsupported ffn_type={ffn_type}")
 
     def forward(
         self,
@@ -127,13 +135,14 @@ class PLCSMultiViewModel(nn.Module):
             float(rope_theta_type),
         )
 
-        if self.rope_dim % 2 != 0:
-            raise ValueError(f"RoPE requires an even rope_dim, got {self.rope_dim}")
+        self._validate_init_args(rope_dim=self.rope_dim)
 
         if ffn_dim is None:
             ffn_dim = default_ffn_dim(hidden_dim)
 
-        self.invisible_token = InvisibleTokenEmbedding(dim=hidden_dim, init_std=invisible_init_std)
+        self.invisible_token = InvisibleTokenEmbedding(
+            dim=hidden_dim, init_std=invisible_init_std
+        )
         self.court_embed = CourtKPUVEmbedding(
             dim=hidden_dim,
             dropout=dropout,
@@ -188,6 +197,11 @@ class PLCSMultiViewModel(nn.Module):
                 dropout=dropout,
             )
 
+    @staticmethod
+    def _validate_init_args(*, rope_dim: int) -> None:
+        if rope_dim % 2 != 0:
+            raise ValueError(f"RoPE requires an even rope_dim, got {rope_dim}")
+
     @classmethod
     def from_config(cls, config: DictConfig) -> PLCSMultiViewModel:
         """Create model from hydra config."""
@@ -205,7 +219,9 @@ class PLCSMultiViewModel(nn.Module):
             rope_theta_time=model_cfg.get("rope_theta_time", None),
             rope_theta_camera=model_cfg.get("rope_theta_camera", None),
             rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
-            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
+            ),
             predict_canonical_pose=bool(model_cfg.get("predict_canonical_pose", False)),
             max_views=model_cfg.get("max_views", 8),
             max_seq_len=model_cfg.get("max_seq_len", 120),
@@ -223,21 +239,32 @@ class PLCSMultiViewModel(nn.Module):
         """Build `(S, 3)` coordinates with axes: (time, camera, type)."""
         per_cam: list[Tensor] = []
         for cam_idx in range(n_cameras):
-            court_time = torch.zeros(self.num_court_tokens, device=device, dtype=torch.long)
-            court_cam = torch.full((self.num_court_tokens,), cam_idx, device=device, dtype=torch.long)
-            court_type = torch.zeros(self.num_court_tokens, device=device, dtype=torch.long)
+            court_time = torch.zeros(
+                self.num_court_tokens, device=device, dtype=torch.long
+            )
+            court_cam = torch.full(
+                (self.num_court_tokens,), cam_idx, device=device, dtype=torch.long
+            )
+            court_type = torch.zeros(
+                self.num_court_tokens, device=device, dtype=torch.long
+            )
             court_pos = torch.stack([court_time, court_cam, court_type], dim=-1)
 
-            frame_time = torch.arange(seq_len, device=device, dtype=torch.long).repeat_interleave(
-                self.frame_block_tokens
-            ) + 1
+            frame_time = (
+                torch.arange(
+                    seq_len, device=device, dtype=torch.long
+                ).repeat_interleave(self.frame_block_tokens)
+                + 1
+            )
             frame_cam = torch.full(
                 (seq_len * self.frame_block_tokens,),
                 cam_idx,
                 device=device,
                 dtype=torch.long,
             )
-            frame_type = torch.ones(seq_len * self.frame_block_tokens, device=device, dtype=torch.long)
+            frame_type = torch.ones(
+                seq_len * self.frame_block_tokens, device=device, dtype=torch.long
+            )
             frame_pos = torch.stack([frame_time, frame_cam, frame_type], dim=-1)
             per_cam.append(torch.cat([court_pos, frame_pos], dim=0))
 
@@ -283,52 +310,16 @@ class PLCSMultiViewModel(nn.Module):
                 - position: (B, T, 3)
                 - rotation: (B, T, 2)
         """
-        if human_kp.dim() != 5:
-            raise ValueError(
-                "PLCSMultiViewModel expects human_kp as (B,N,T,17,2), "
-                f"got shape {tuple(human_kp.shape)}"
-            )
-        if court_kp.dim() != 5:
-            raise ValueError(
-                "PLCSMultiViewModel expects court_kp as "
-                f"(B,N,T,{self.num_court_tokens},2), "
-                f"got shape {tuple(court_kp.shape)}"
-            )
-        if court_kp.shape[-2] != self.num_court_tokens:
-            raise ValueError(
-                f"Expected court_kp with K={self.num_court_tokens}, got K={court_kp.shape[-2]}."
-            )
-        if human_vis is not None and human_vis.dim() != 4:
-            raise ValueError(
-                "PLCSMultiViewModel expects human_vis as (B,N,T,17), "
-                f"got shape {tuple(human_vis.shape)}"
-            )
-        if court_vis is not None and court_vis.dim() != 4:
-            raise ValueError(
-                "PLCSMultiViewModel expects court_vis as "
-                f"(B,N,T,{self.num_court_tokens}), "
-                f"got shape {tuple(court_vis.shape)}"
-            )
-        if court_vis is not None and court_vis.shape[-1] != self.num_court_tokens:
-            raise ValueError(
-                f"Expected court_vis with K={self.num_court_tokens}, got K={court_vis.shape[-1]}."
-            )
-
-        # (B, N, T, K, 2)
-        B, N, T = human_kp.shape[:3]
+        B, N, T = self._validate_forward_inputs(
+            human_kp=human_kp,
+            court_kp=court_kp,
+            human_vis=human_vis,
+            human_mask=human_mask,
+            court_vis=court_vis,
+        )
         device = human_kp.device
 
-        if self.max_views < N:
-            raise ValueError(f"Number of views N={N} exceeds max_views={self.max_views}.")
-        if self.max_seq_len < T:
-            raise ValueError(f"Sequence length T={T} exceeds max_seq_len={self.max_seq_len}.")
-
         if human_mask is not None:
-            if human_mask.dim() != 3 or human_mask.shape != (B, N, T):
-                raise ValueError(
-                    "human_mask for multiview models must be (B,N,T), "
-                    f"got {tuple(human_mask.shape)}"
-                )
             token_mask = human_mask > 0
             view_valid = token_mask.any(dim=2)
             seq_valid = token_mask.any(dim=1)
@@ -339,8 +330,6 @@ class PLCSMultiViewModel(nn.Module):
         # court is camera-level (use first frame per camera)
         court_scene = court_kp[:, :, 0, :, :]  # (B,N,K,2)
         K = court_scene.shape[2]
-        if self.num_court_tokens != K:
-            raise ValueError(f"Expected {self.num_court_tokens} court tokens, got {K}.")
         court_scene_flat = court_scene.reshape(B * N, K, 2)
 
         court_vis_scene: Tensor | None = None
@@ -363,7 +352,9 @@ class PLCSMultiViewModel(nn.Module):
         cls_po = self.cls_po_token.expand(B, N, T, -1, -1)
         cls_ro = self.cls_ro_token.expand(B, N, T, -1, -1)
         frame_tok = torch.cat([cls_po, cls_ro, player_tok], dim=3)  # (B,N,T,19,D)
-        frame_tok = frame_tok.reshape(B, N, T * self.frame_block_tokens, self.hidden_dim)
+        frame_tok = frame_tok.reshape(
+            B, N, T * self.frame_block_tokens, self.hidden_dim
+        )
 
         camera_block_tokens = K + T * self.frame_block_tokens
         tokens_per_camera = torch.cat([court_tok, frame_tok], dim=2)  # (B,N,L_cam,D)
@@ -412,13 +403,23 @@ class PLCSMultiViewModel(nn.Module):
         x = self.final_norm(x)
         x = x * token_valid.unsqueeze(-1).to(dtype=x.dtype)
 
-        time_offsets = K + torch.arange(T, device=device, dtype=torch.long) * self.frame_block_tokens
-        cam_offsets = torch.arange(N, device=device, dtype=torch.long).view(N, 1) * camera_block_tokens
+        time_offsets = (
+            K
+            + torch.arange(T, device=device, dtype=torch.long) * self.frame_block_tokens
+        )
+        cam_offsets = (
+            torch.arange(N, device=device, dtype=torch.long).view(N, 1)
+            * camera_block_tokens
+        )
         po_idx = (cam_offsets + time_offsets.view(1, T)).reshape(-1)
         ro_idx = po_idx + 1
 
-        po_feat = x.gather(1, po_idx.view(1, N * T, 1).expand(B, N * T, self.hidden_dim))
-        ro_feat = x.gather(1, ro_idx.view(1, N * T, 1).expand(B, N * T, self.hidden_dim))
+        po_feat = x.gather(
+            1, po_idx.view(1, N * T, 1).expand(B, N * T, self.hidden_dim)
+        )
+        ro_feat = x.gather(
+            1, ro_idx.view(1, N * T, 1).expand(B, N * T, self.hidden_dim)
+        )
         po_feat = po_feat.view(B, N, T, self.hidden_dim)
         ro_feat = ro_feat.view(B, N, T, self.hidden_dim)
 
@@ -441,3 +442,62 @@ class PLCSMultiViewModel(nn.Module):
         if self.predict_canonical_pose and self.canonical_pose_head is not None:
             out["canonical_pose"] = self.canonical_pose_head(pose_latent)
         return out
+
+    def _validate_forward_inputs(
+        self,
+        *,
+        human_kp: Tensor,
+        court_kp: Tensor,
+        human_vis: Tensor | None,
+        human_mask: Tensor | None,
+        court_vis: Tensor | None,
+    ) -> tuple[int, int, int]:
+        if human_kp.dim() != 5:
+            raise ValueError(
+                "PLCSMultiViewModel expects human_kp as (B,N,T,17,2), "
+                f"got shape {tuple(human_kp.shape)}"
+            )
+        if court_kp.dim() != 5:
+            raise ValueError(
+                "PLCSMultiViewModel expects court_kp as "
+                f"(B,N,T,{self.num_court_tokens},2), "
+                f"got shape {tuple(court_kp.shape)}"
+            )
+        if court_kp.shape[-2] != self.num_court_tokens:
+            raise ValueError(
+                f"Expected court_kp with K={self.num_court_tokens}, got K={court_kp.shape[-2]}."
+            )
+        if human_vis is not None and human_vis.dim() != 4:
+            raise ValueError(
+                "PLCSMultiViewModel expects human_vis as (B,N,T,17), "
+                f"got shape {tuple(human_vis.shape)}"
+            )
+        if court_vis is not None and court_vis.dim() != 4:
+            raise ValueError(
+                "PLCSMultiViewModel expects court_vis as "
+                f"(B,N,T,{self.num_court_tokens}), "
+                f"got shape {tuple(court_vis.shape)}"
+            )
+        if court_vis is not None and court_vis.shape[-1] != self.num_court_tokens:
+            raise ValueError(
+                f"Expected court_vis with K={self.num_court_tokens}, got K={court_vis.shape[-1]}."
+            )
+
+        batch_size, n_cams, seq_len = human_kp.shape[:3]
+        if self.max_views < n_cams:
+            raise ValueError(
+                f"Number of views N={n_cams} exceeds max_views={self.max_views}."
+            )
+        if self.max_seq_len < seq_len:
+            raise ValueError(
+                f"Sequence length T={seq_len} exceeds max_seq_len={self.max_seq_len}."
+            )
+
+        if human_mask is not None and (
+            human_mask.dim() != 3 or human_mask.shape != (batch_size, n_cams, seq_len)
+        ):
+            raise ValueError(
+                "human_mask for multiview models must be (B,N,T), "
+                f"got {tuple(human_mask.shape)}"
+            )
+        return batch_size, n_cams, seq_len

--- a/src/tasks/trajectory_completion/models/uv_completion_model.py
+++ b/src/tasks/trajectory_completion/models/uv_completion_model.py
@@ -69,19 +69,15 @@ class UVTrajectoryCompletionModel(nn.Module):
         self.max_seq_len = int(max_seq_len)
         self.num_court_tokens = int(num_court_tokens)
 
-        if self.hidden_dim % int(num_heads) != 0:
-            raise ValueError("hidden_dim must be divisible by num_heads.")
-        if num_ball_layers < 0:
-            raise ValueError("num_ball_layers must be non-negative.")
-        if num_query_layers < 0:
-            raise ValueError("num_query_layers must be non-negative.")
-
-        head_dim = self.hidden_dim // int(num_heads)
-        rope_dim_value = head_dim if rope_dim is None else int(rope_dim)
-        if rope_dim_value % 2 != 0:
-            raise ValueError("rope_dim must be even.")
-        if rope_dim_value > head_dim:
-            raise ValueError("rope_dim must be <= head_dim.")
+        self._validate_depths(
+            num_ball_layers=num_ball_layers,
+            num_query_layers=num_query_layers,
+        )
+        head_dim, rope_dim_value = self._resolve_attention_dims(
+            hidden_dim=self.hidden_dim,
+            num_heads=num_heads,
+            rope_dim=rope_dim,
+        )
         self.rope_dim = int(rope_dim_value)
         self.rope_theta = float(rope_theta)
         self.rope_bases = (
@@ -105,7 +101,9 @@ class UVTrajectoryCompletionModel(nn.Module):
             invisible_token=self.invisible_token,
         )
         self.court_id_embed = nn.Embedding(self.num_court_tokens, self.hidden_dim)
-        self.query_base = nn.Parameter(torch.randn(1, 1, self.hidden_dim) * float(query_init_std))
+        self.query_base = nn.Parameter(
+            torch.randn(1, 1, self.hidden_dim) * float(query_init_std)
+        )
 
         self.ball_to_court_cross_layers = nn.ModuleList(
             [
@@ -199,6 +197,30 @@ class UVTrajectoryCompletionModel(nn.Module):
         )
         self.register_buffer("court_freqs_cis", court_freqs_cis, persistent=False)
 
+    @staticmethod
+    def _validate_depths(*, num_ball_layers: int, num_query_layers: int) -> None:
+        if num_ball_layers < 0:
+            raise ValueError("num_ball_layers must be non-negative.")
+        if num_query_layers < 0:
+            raise ValueError("num_query_layers must be non-negative.")
+
+    @staticmethod
+    def _resolve_attention_dims(
+        *,
+        hidden_dim: int,
+        num_heads: int,
+        rope_dim: int | None,
+    ) -> tuple[int, int]:
+        if hidden_dim % int(num_heads) != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads.")
+        head_dim = hidden_dim // int(num_heads)
+        rope_dim_value = head_dim if rope_dim is None else int(rope_dim)
+        if rope_dim_value % 2 != 0:
+            raise ValueError("rope_dim must be even.")
+        if rope_dim_value > head_dim:
+            raise ValueError("rope_dim must be <= head_dim.")
+        return head_dim, rope_dim_value
+
     @classmethod
     def from_config(cls, config: DictConfig) -> UVTrajectoryCompletionModel:
         model_cfg = config.get("model", {}) or {}
@@ -213,7 +235,9 @@ class UVTrajectoryCompletionModel(nn.Module):
             hidden_dim=hidden_dim,
             num_heads=int(model_cfg.get("num_heads", 8)),
             dropout=float(model_cfg.get("dropout", 0.1)),
-            max_seq_len=int(model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 256))),
+            max_seq_len=int(
+                model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 256))
+            ),
             num_ball_layers=int(num_ball_layers),
             num_query_layers=int(num_query_layers),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
@@ -222,10 +246,16 @@ class UVTrajectoryCompletionModel(nn.Module):
             rope_theta_type=model_cfg.get("rope_theta_type", 100.0),
             rope_dim=model_cfg.get("rope_dim", None),
             ffn_dim=model_cfg.get("ffn_dim"),
-            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
+            ),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
             query_init_std=float(model_cfg.get("query_init_std", 0.02)),
-            num_court_tokens=int(model_cfg.get("num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP))),
+            num_court_tokens=int(
+                model_cfg.get(
+                    "num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP)
+                )
+            ),
         )
 
     def _build_court_positions(self) -> Tensor:
@@ -273,7 +303,12 @@ class UVTrajectoryCompletionModel(nn.Module):
         *,
         return_intermediate_ball_hidden: bool = False,
         return_in_frame_logits: bool = False,
-    ) -> Tensor | tuple[Tensor, list[Tensor]] | tuple[Tensor, Tensor] | tuple[Tensor, list[Tensor], Tensor]:
+    ) -> (
+        Tensor
+        | tuple[Tensor, list[Tensor]]
+        | tuple[Tensor, Tensor]
+        | tuple[Tensor, list[Tensor], Tensor]
+    ):
         """Forward.
 
         Args:
@@ -294,22 +329,20 @@ class UVTrajectoryCompletionModel(nn.Module):
             with shape ``(B, T)``.
         """
         B, T, _ = ball_uv.shape
-        if self.max_seq_len < T:
-            ball_uv = ball_uv[:, : self.max_seq_len]
-            if ball_vis is not None:
-                ball_vis = ball_vis[:, : self.max_seq_len]
-            if ball_mask is not None:
-                ball_mask = ball_mask[:, : self.max_seq_len]
-            T = self.max_seq_len
+        ball_uv, ball_vis, ball_mask, T = self._clip_sequence_inputs(
+            ball_uv=ball_uv,
+            ball_vis=ball_vis,
+            ball_mask=ball_mask,
+            seq_len_in=T,
+        )
 
         court_tok = self.court_embed(court_kp, court_vis)
-        if court_tok.shape[1] != self.num_court_tokens:
-            raise ValueError(
-                f"Expected {self.num_court_tokens} court tokens, got {court_tok.shape[1]}"
-            )
+        self._validate_court_tokens(court_tok)
         ball_tok = self.ball_embed(ball_uv, ball_vis)
 
-        court_ids = torch.arange(self.num_court_tokens, device=ball_uv.device, dtype=torch.long)
+        court_ids = torch.arange(
+            self.num_court_tokens, device=ball_uv.device, dtype=torch.long
+        )
         court_tokens = court_tok + self.court_id_embed(court_ids).unsqueeze(0)
 
         ball_valid = torch.ones(B, T, device=ball_uv.device, dtype=torch.bool)
@@ -317,7 +350,9 @@ class UVTrajectoryCompletionModel(nn.Module):
             ball_valid = ball_mask > 0
 
         ball_attn_mask, ball_valid = self._build_self_attn_mask(ball_valid)
-        court_valid = torch.ones(B, self.num_court_tokens, device=ball_uv.device, dtype=torch.bool)
+        court_valid = torch.ones(
+            B, self.num_court_tokens, device=ball_uv.device, dtype=torch.bool
+        )
 
         freqs_ball_tokens = precompute_freqs_cis_nd(
             dim=self.rope_dim,
@@ -401,9 +436,38 @@ class UVTrajectoryCompletionModel(nn.Module):
             return pred, in_frame_logits
         return pred
 
+    def _clip_sequence_inputs(
+        self,
+        *,
+        ball_uv: Tensor,
+        ball_vis: Tensor | None,
+        ball_mask: Tensor | None,
+        seq_len_in: int,
+    ) -> tuple[Tensor, Tensor | None, Tensor | None, int]:
+        if self.max_seq_len < seq_len_in:
+            ball_uv = ball_uv[:, : self.max_seq_len]
+            if ball_vis is not None:
+                ball_vis = ball_vis[:, : self.max_seq_len]
+            if ball_mask is not None:
+                ball_mask = ball_mask[:, : self.max_seq_len]
+            seq_len_in = self.max_seq_len
+        return ball_uv, ball_vis, ball_mask, seq_len_in
+
+    def _validate_court_tokens(self, court_tokens: Tensor) -> None:
+        if court_tokens.shape[1] != self.num_court_tokens:
+            raise ValueError(
+                f"Expected {self.num_court_tokens} court tokens, got {court_tokens.shape[1]}"
+            )
+
 
 if __name__ == "__main__":
-    model = UVTrajectoryCompletionModel(hidden_dim=64, num_ball_layers=2, num_query_layers=2, num_heads=4, max_seq_len=32)
+    model = UVTrajectoryCompletionModel(
+        hidden_dim=64,
+        num_ball_layers=2,
+        num_query_layers=2,
+        num_heads=4,
+        max_seq_len=32,
+    )
     ball_uv = torch.rand(2, 32, 2)
     ball_vis = torch.randint(0, 2, (2, 32)).float()
     court_kp = torch.rand(2, 20, 2)

--- a/src/tasks/trajectory_completion/models/uv_completion_nocourt_model.py
+++ b/src/tasks/trajectory_completion/models/uv_completion_nocourt_model.py
@@ -44,17 +44,12 @@ class UVTrajectoryCompletionNoCourtModel(nn.Module):
         self.hidden_dim = int(hidden_dim)
         self.max_seq_len = int(max_seq_len)
 
-        if self.hidden_dim % int(num_heads) != 0:
-            raise ValueError("hidden_dim must be divisible by num_heads.")
-        if num_layers < 0:
-            raise ValueError("num_layers must be non-negative.")
-
-        head_dim = self.hidden_dim // int(num_heads)
-        rope_dim_value = head_dim if rope_dim is None else int(rope_dim)
-        if rope_dim_value % 2 != 0:
-            raise ValueError("rope_dim must be even.")
-        if rope_dim_value > head_dim:
-            raise ValueError("rope_dim must be <= head_dim.")
+        self._validate_depth(num_layers=num_layers)
+        head_dim, rope_dim_value = self._resolve_attention_dims(
+            hidden_dim=self.hidden_dim,
+            num_heads=num_heads,
+            rope_dim=rope_dim,
+        )
         rope_base = float(rope_theta if rope_theta_time is None else rope_theta_time)
 
         self.invisible_token = InvisibleTokenEmbedding(
@@ -105,6 +100,28 @@ class UVTrajectoryCompletionNoCourtModel(nn.Module):
         )
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
+    @staticmethod
+    def _validate_depth(*, num_layers: int) -> None:
+        if num_layers < 0:
+            raise ValueError("num_layers must be non-negative.")
+
+    @staticmethod
+    def _resolve_attention_dims(
+        *,
+        hidden_dim: int,
+        num_heads: int,
+        rope_dim: int | None,
+    ) -> tuple[int, int]:
+        if hidden_dim % int(num_heads) != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads.")
+        head_dim = hidden_dim // int(num_heads)
+        rope_dim_value = head_dim if rope_dim is None else int(rope_dim)
+        if rope_dim_value % 2 != 0:
+            raise ValueError("rope_dim must be even.")
+        if rope_dim_value > head_dim:
+            raise ValueError("rope_dim must be <= head_dim.")
+        return head_dim, rope_dim_value
+
     @classmethod
     def from_config(cls, config: DictConfig) -> UVTrajectoryCompletionNoCourtModel:
         model_cfg = config.get("model", {}) or {}
@@ -117,12 +134,16 @@ class UVTrajectoryCompletionNoCourtModel(nn.Module):
             num_layers=int(model_cfg.get("num_layers", 6)),
             num_heads=int(model_cfg.get("num_heads", 8)),
             dropout=float(model_cfg.get("dropout", 0.1)),
-            max_seq_len=int(model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 256))),
+            max_seq_len=int(
+                model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 256))
+            ),
             rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
             rope_theta_time=model_cfg.get("rope_theta_time", None),
             rope_dim=model_cfg.get("rope_dim", None),
             ffn_dim=model_cfg.get("ffn_dim"),
-            ffn_type=cast(Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))),
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
+            ),
             invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
         )
 
@@ -146,7 +167,12 @@ class UVTrajectoryCompletionNoCourtModel(nn.Module):
         *,
         return_intermediate_ball_hidden: bool = False,
         return_in_frame_logits: bool = False,
-    ) -> Tensor | tuple[Tensor, list[Tensor]] | tuple[Tensor, Tensor] | tuple[Tensor, list[Tensor], Tensor]:
+    ) -> (
+        Tensor
+        | tuple[Tensor, list[Tensor]]
+        | tuple[Tensor, Tensor]
+        | tuple[Tensor, list[Tensor], Tensor]
+    ):
         """Forward pass for no-court trajectory completion."""
         _, T, _ = ball_uv.shape
         if self.max_seq_len < T:
@@ -159,7 +185,9 @@ class UVTrajectoryCompletionNoCourtModel(nn.Module):
 
         ball_tokens = self.ball_embed(ball_uv, ball_vis)
 
-        ball_valid = torch.ones(ball_uv.shape[0], T, device=ball_uv.device, dtype=torch.bool)
+        ball_valid = torch.ones(
+            ball_uv.shape[0], T, device=ball_uv.device, dtype=torch.bool
+        )
         if ball_mask is not None:
             ball_valid = ball_mask > 0
         ball_attn_mask, _ = self._build_self_attn_mask(ball_valid)


### PR DESCRIPTION
## 概要

- 各タスクのモデルアーキテクチャ実装について、`__init__` と `forward` に直接書かれていた validation を private helper に切り出しました。
- layer 構築や tensor 処理の流れを追いやすくするため、初期化引数チェック、入力 shape チェック、RoPE/cache/token 数チェックを `_validate_*` / `_prepare_*` / `_resolve_*` に整理しています。

## 変更内容

- ball/court/event/trajectory_completion/blcs/plcs の `src/tasks/*/models` 配下にある対象モデルの validation を抽出
- multi-view 系モデルの forward 冒頭にある入力正規化と shape validation を `_prepare_forward_inputs` / `_validate_forward_inputs` に集約
- DINO backbone load result や Transformer/RoPE dimension validation を専用 helper に分離

## 検証

- `.venv/bin/python -m ruff format $(git diff --name-only -- src/tasks)`
- `.venv/bin/python -m ruff check $(git diff --name-only -- src/tasks)`
- AST 監査で `src/tasks/**/models/**/*.py` の `__init__` / `forward` に直接の `raise` / `assert` が残っていないことを確認
- `.venv/bin/python -m pytest tests/tasks/test_training_smoke_contracts.py` で 35 passed

## 関連Issue

- なし
