### PR TITLE
BLCS TargetedVelocitySamplerを軽量化する

### DIFF
--- a/src/tasks/blcs/configs/targeted_velocity/default.yaml
+++ b/src/tasks/blcs/configs/targeted_velocity/default.yaml
@@ -1,27 +1,9 @@
-azimuth_noise_deg: 5.0
-elevation_noise_deg: 3.0
-speed_variation: 0.15
-min_elevation_deg: 3.0
-max_elevation_deg: 70.0
 drive_elevation_range_deg: [5.0, 25.0]
 lob_elevation_range_deg: [35.0, 70.0]
 lob_probability: 0.25
-min_speed: 12.0
-max_speed: 40.0
 gravity: 9.81
-speed_solve_max_iters: 32
-speed_solve_tol: 0.001
 
-# Refinement disabled (single-shot sampling, no retry)
-refine_enabled: true
-refine_iters: 10
-refine_speed_scale_min: 0.7
-refine_speed_scale_max: 1.4
-refine_max_azimuth_adjust_deg: 15.0
-refine_max_frames: 1200
-
-# Net clearance enabled by default
-net_clearance_enabled: true
-net_clearance_min: 0.1
-net_clearance_max_attempts: 12
-net_clearance_max_frames: 600
+# Net-hit resampling. Each attempt simulates only until net crossing/hit.
+net_retry_max_attempts: 12
+net_check_max_frames: 600
+net_elevation_step_deg: 2.0

--- a/src/tasks/blcs/generate_dataset/config.py
+++ b/src/tasks/blcs/generate_dataset/config.py
@@ -84,29 +84,15 @@ def build_generator_config(cfg: DictConfig) -> GeneratorConfig:
     )
 
     targeted_velocity_config = TargetedVelocityConfig(
-        azimuth_noise_deg=float(cfg.targeted_velocity.azimuth_noise_deg),
-        elevation_noise_deg=float(cfg.targeted_velocity.elevation_noise_deg),
-        speed_variation=float(cfg.targeted_velocity.speed_variation),
-        min_elevation_deg=float(cfg.targeted_velocity.min_elevation_deg),
-        max_elevation_deg=float(cfg.targeted_velocity.max_elevation_deg),
-        drive_elevation_range_deg=tuple(cfg.targeted_velocity.drive_elevation_range_deg),
+        drive_elevation_range_deg=tuple(
+            cfg.targeted_velocity.drive_elevation_range_deg
+        ),
         lob_elevation_range_deg=tuple(cfg.targeted_velocity.lob_elevation_range_deg),
         lob_probability=float(cfg.targeted_velocity.lob_probability),
-        min_speed=float(cfg.targeted_velocity.min_speed),
-        max_speed=float(cfg.targeted_velocity.max_speed),
         gravity=float(cfg.targeted_velocity.gravity),
-        speed_solve_max_iters=int(cfg.targeted_velocity.speed_solve_max_iters),
-        speed_solve_tol=float(cfg.targeted_velocity.speed_solve_tol),
-        refine_enabled=bool(cfg.targeted_velocity.refine_enabled),
-        refine_iters=int(cfg.targeted_velocity.refine_iters),
-        refine_speed_scale_min=float(cfg.targeted_velocity.refine_speed_scale_min),
-        refine_speed_scale_max=float(cfg.targeted_velocity.refine_speed_scale_max),
-        refine_max_azimuth_adjust_deg=float(cfg.targeted_velocity.refine_max_azimuth_adjust_deg),
-        refine_max_frames=int(cfg.targeted_velocity.refine_max_frames),
-        net_clearance_enabled=bool(cfg.targeted_velocity.net_clearance_enabled),
-        net_clearance_min=float(cfg.targeted_velocity.net_clearance_min),
-        net_clearance_max_attempts=int(cfg.targeted_velocity.net_clearance_max_attempts),
-        net_clearance_max_frames=int(cfg.targeted_velocity.net_clearance_max_frames),
+        net_retry_max_attempts=int(cfg.targeted_velocity.net_retry_max_attempts),
+        net_check_max_frames=int(cfg.targeted_velocity.net_check_max_frames),
+        net_elevation_step_deg=float(cfg.targeted_velocity.net_elevation_step_deg),
     )
 
     return GeneratorConfig(

--- a/src/tasks/blcs/generate_dataset/simulation/targeted_velocity_sampler.py
+++ b/src/tasks/blcs/generate_dataset/simulation/targeted_velocity_sampler.py
@@ -1,16 +1,9 @@
 """Targeted velocity sampler for cell-to-cell shots.
 
-Computes initial velocity to aim at specific target cells while
-adding realistic variation. Uses simplified projectile motion
-(gravity only) for speed, with drag/magnus effects adding natural noise.
-
-The calculation is approximate because:
-1. We use gravity-only projectile equations for speed estimation
-2. The actual simulation includes drag and magnus forces
-3. This discrepancy creates natural variation in landing positions
-
-Additional noise parameters are applied to azimuth, elevation, and speed
-to further increase variation.
+Computes an initial velocity that roughly aims at a target cell. The speed is
+derived analytically from gravity-only projectile motion, then a short physics
+check verifies that the ball reaches the net without hitting it. If it clips the
+net, the sampler raises the elevation and recomputes the speed.
 """
 
 from __future__ import annotations
@@ -22,73 +15,50 @@ from typing import TYPE_CHECKING
 import torch
 from torch import Tensor
 
-from src.utils.schema.court import HALF_DOUBLES_WIDTH, NET_HEIGHT_CENTER, NET_HEIGHT_POST
+from src.utils.schema.court import (
+    HALF_DOUBLES_WIDTH,
+    NET_HEIGHT_CENTER,
+    NET_HEIGHT_POST,
+)
 
 if TYPE_CHECKING:
-    from src.tasks.blcs.generate_dataset.simulation.cell_manager import CellManager
     from src.tasks.blcs.generate_dataset.simulation.ball_physics import BallPhysics
+    from src.tasks.blcs.generate_dataset.simulation.cell_manager import CellManager
 
 
 @dataclass
 class TargetedVelocityConfig:
     """Configuration for targeted velocity sampling."""
 
-    # Azimuth noise (degrees, added to computed azimuth)
-    azimuth_noise_deg: float = 5.0
-
-    # Elevation noise (degrees, added to computed elevation)
-    elevation_noise_deg: float = 3.0
-
-    # Speed variation factor (multiplier range: 1 ± speed_variation)
-    speed_variation: float = 0.15
-
-    # Minimum/maximum elevation constraints (degrees)
-    min_elevation_deg: float = 3.0
-    max_elevation_deg: float = 35.0
-
     # Elevation ranges for profile sampling (degrees)
     drive_elevation_range_deg: tuple[float, float] = (5.0, 25.0)
     lob_elevation_range_deg: tuple[float, float] = (35.0, 70.0)
     lob_probability: float = 0.0
 
-    # Minimum/maximum speed constraints (m/s)
-    min_speed: float = 12.0
-    max_speed: float = 40.0
-
     # Gravity for projectile calculation (m/s²)
     gravity: float = 9.81
 
-    # Speed solve configuration (gravity-only approximation)
-    speed_solve_max_iters: int = 32
-    speed_solve_tol: float = 1e-3
+    # Net-hit resampling
+    net_retry_max_attempts: int = 12
+    net_check_max_frames: int = 600
+    net_elevation_step_deg: float = 2.0
 
-    # Optional refinement using drag/magnus simulation
-    # NOTE: Disabled by default in favour of single-shot sampling
-    refine_enabled: bool = False
-    refine_iters: int = 1
-    refine_speed_scale_min: float = 0.7
-    refine_speed_scale_max: float = 1.4
-    refine_max_azimuth_adjust_deg: float = 15.0
-    refine_max_frames: int = 1200
 
-    # Net clearance constraint (optional)
-    # NOTE: Enabled by default to avoid low-clearance net-fault-heavy samples
-    net_clearance_enabled: bool = True
-    net_clearance_min: float = 0.1
-    net_clearance_max_attempts: int = 12
-    net_clearance_max_frames: int = 600
+@dataclass(frozen=True)
+class _NetCheckResult:
+    """Result of the short net-only physics check."""
+
+    passed: bool
+    hit_pos: Tensor | None = None
 
 
 class TargetedVelocitySampler:
     """Samples velocity to aim at specific target cells.
 
-    Uses projectile motion approximation (ignoring drag/magnus) to
-    compute initial velocity that lands ball near target, then adds
-    realistic variation.
-
-    The drag and magnus forces in the actual physics simulation will
-    cause the ball to deviate from the idealized trajectory, creating
-    natural variation in landing positions.
+    Uses projectile motion approximation (ignoring drag/magnus) to compute a
+    velocity toward a target cell. It does not refine against the final landing
+    point; it only resamples elevation when a short physics check detects a net
+    hit.
     """
 
     def __init__(
@@ -119,7 +89,7 @@ class TargetedVelocitySampler:
         from_side: str,
         elevation_deg: float | None = None,
         profile: str | None = None,
-        physics: "BallPhysics | None" = None,
+        physics: BallPhysics | None = None,
         spin: Tensor | None = None,
     ) -> Tensor:
         """Compute velocity to reach target using projectile approximation.
@@ -134,55 +104,49 @@ class TargetedVelocitySampler:
             from_side: "near" or "far" - determines base direction.
             elevation_deg: Optional elevation angle override (degrees).
             profile: Optional elevation profile ("drive" or "lob").
-            physics: Optional physics simulator for refinement.
-            spin: Optional spin vector for refinement (rad/s).
+            physics: Optional physics simulator for net-hit checking.
+            spin: Optional spin vector for net-hit checking (rad/s).
 
         Returns:
             Tensor: Velocity [3] in m/s.
 
         """
-        cfg = self.config
-
-        max_attempts = 1
-        if cfg.net_clearance_enabled:
-            max_attempts = max(1, cfg.net_clearance_max_attempts)
-
+        horizontal_dist = float(
+            torch.linalg.norm(target_pos[:2] - start_pos[:2]).item()
+        )
+        elevation_rad = self._sample_elevation_rad(elevation_deg, profile)
+        elevation_step_rad = math.radians(self.config.net_elevation_step_deg)
+        max_attempts = max(1, self.config.net_retry_max_attempts)
         last_velocity: Tensor | None = None
 
-        for _ in range(max_attempts):
+        for attempt in range(max_attempts):
             velocity = self._compute_velocity_to_target_once(
                 start_pos=start_pos,
                 target_pos=target_pos,
                 from_side=from_side,
-                elevation_deg=elevation_deg,
-                profile=profile,
-                physics=physics,
-                spin=spin,
+                elevation_rad=elevation_rad,
             )
             last_velocity = velocity
 
-            if not cfg.net_clearance_enabled:
-                return velocity
-
-            if self._passes_net_clearance(
+            net_check = self._check_net_passage(
                 start_pos=start_pos,
                 velocity=velocity,
                 physics=physics,
                 spin=spin,
-            ):
+            )
+            if net_check.passed:
                 return velocity
 
-        if last_velocity is None:
-            last_velocity = self._compute_velocity_to_target_once(
-                start_pos=start_pos,
-                target_pos=target_pos,
-                from_side=from_side,
-                elevation_deg=elevation_deg,
-                profile=profile,
-                physics=physics,
-                spin=spin,
-            )
+            if attempt < max_attempts - 1:
+                elevation_rad = self._raise_elevation_after_net_hit(
+                    elevation_rad=elevation_rad,
+                    hit_pos=net_check.hit_pos,
+                    start_pos=start_pos,
+                    horizontal_dist=horizontal_dist,
+                    default_step_rad=elevation_step_rad,
+                )
 
+        assert last_velocity is not None
         return last_velocity
 
     def _compute_velocity_to_target_once(
@@ -190,13 +154,8 @@ class TargetedVelocitySampler:
         start_pos: Tensor,
         target_pos: Tensor,
         from_side: str,
-        elevation_deg: float | None = None,
-        profile: str | None = None,
-        physics: "BallPhysics | None" = None,
-        spin: Tensor | None = None,
+        elevation_rad: float,
     ) -> Tensor:
-        cfg = self.config
-
         # Horizontal displacement
         dx = (target_pos[0] - start_pos[0]).item()
         dy = (target_pos[1] - start_pos[1]).item()
@@ -211,60 +170,20 @@ class TargetedVelocitySampler:
         # Compute azimuth (angle in x-y plane from y-axis)
         azimuth_rad = math.atan2(dx, dy * base_dir if dy != 0 else abs(dy) + 1e-6)
 
-        # Add noise to azimuth
-        azimuth_noise = (
-            (torch.rand(1).item() - 0.5) * 2 * math.radians(cfg.azimuth_noise_deg)
-        )
-        azimuth_rad += azimuth_noise
-
-        best_elevation = self._sample_elevation_rad(elevation_deg, profile)
-        best_speed = self._solve_speed_for_target(
-            horizontal_dist, z0, best_elevation
-        )
-
-        if best_speed is None:
-            best_elevation, best_speed = self._fallback_speed_and_elevation(
-                horizontal_dist, z0
-            )
-
-        # Add noise to elevation before final clamp
-        elevation_noise = (
-            (torch.rand(1).item() - 0.5) * 2 * math.radians(cfg.elevation_noise_deg)
-        )
-        best_elevation = max(
-            math.radians(cfg.min_elevation_deg),
-            min(math.radians(cfg.max_elevation_deg), best_elevation + elevation_noise),
-        )
-
-        # Add noise to speed
-        speed_factor = 1.0 + (torch.rand(1).item() - 0.5) * 2 * cfg.speed_variation
-        best_speed = max(
-            cfg.min_speed, min(cfg.max_speed, best_speed * speed_factor)
-        )
+        speed = self._solve_speed_for_target(horizontal_dist, z0, elevation_rad)
 
         # Convert to velocity components
         # vx: horizontal component in x direction
         # vy: horizontal component in y direction (toward opponent)
         # vz: vertical component (upward)
-        cos_elev = math.cos(best_elevation)
-        sin_elev = math.sin(best_elevation)
+        cos_elev = math.cos(elevation_rad)
+        sin_elev = math.sin(elevation_rad)
 
-        vx = best_speed * cos_elev * math.sin(azimuth_rad)
-        vy = best_speed * cos_elev * math.cos(azimuth_rad) * base_dir
-        vz = best_speed * sin_elev
+        vx = speed * cos_elev * math.sin(azimuth_rad)
+        vy = speed * cos_elev * math.cos(azimuth_rad) * base_dir
+        vz = speed * sin_elev
 
-        velocity = torch.tensor([vx, vy, vz], device=self.device, dtype=torch.float32)
-
-        if cfg.refine_enabled and physics is not None:
-            velocity = self._refine_velocity_to_target(
-                start_pos=start_pos,
-                target_pos=target_pos,
-                velocity=velocity,
-                spin=spin,
-                physics=physics,
-            )
-
-        return velocity
+        return torch.tensor([vx, vy, vz], device=self.device, dtype=torch.float32)
 
     def sample_velocity_for_target_cell(
         self,
@@ -273,7 +192,7 @@ class TargetedVelocitySampler:
         target_side: str,
         from_side: str,
         profile: str | None = None,
-        physics: "BallPhysics | None" = None,
+        physics: BallPhysics | None = None,
         spin: Tensor | None = None,
     ) -> Tensor:
         """Sample velocity aimed at a specific target cell.
@@ -315,7 +234,7 @@ class TargetedVelocitySampler:
         target_cell: int,
         target_side: str,
         from_side: str,
-        physics: "BallPhysics | None" = None,
+        physics: BallPhysics | None = None,
         spin: Tensor | None = None,
     ) -> Tensor:
         """Sample velocity aimed at a service box cell.
@@ -351,7 +270,9 @@ class TargetedVelocitySampler:
         )
 
     def _validate_cell_id(self, cell_id: int) -> None:
-        from src.tasks.blcs.generate_dataset.simulation.cell_manager import NUM_CELLS_PER_SIDE
+        from src.tasks.blcs.generate_dataset.simulation.cell_manager import (
+            NUM_CELLS_PER_SIDE,
+        )
 
         if not 0 <= cell_id < NUM_CELLS_PER_SIDE:
             raise ValueError(
@@ -379,7 +300,6 @@ class TargetedVelocitySampler:
         else:
             elev = elevation_deg
 
-        elev = max(cfg.min_elevation_deg, min(cfg.max_elevation_deg, elev))
         return math.radians(elev)
 
     def _solve_speed_for_target(
@@ -387,192 +307,68 @@ class TargetedVelocitySampler:
         horizontal_dist: float,
         z0: float,
         elevation_rad: float,
-    ) -> float | None:
+    ) -> float:
         cfg = self.config
+        if horizontal_dist <= 1e-8:
+            return 0.0
 
-        def range_for_speed(speed: float) -> float:
-            sin_elev = math.sin(elevation_rad)
-            cos_elev = math.cos(elevation_rad)
-            v_sin = speed * sin_elev
-            t = (v_sin + math.sqrt(max(0.0, v_sin**2 + 2 * cfg.gravity * z0))) / cfg.gravity
-            return speed * cos_elev * t
+        cos_elev = math.cos(elevation_rad)
+        tan_elev = math.tan(elevation_rad)
+        denominator = 2.0 * cos_elev**2 * (z0 + horizontal_dist * tan_elev)
+        if denominator <= 0.0:
+            return 0.0
+        return math.sqrt(cfg.gravity * horizontal_dist**2 / denominator)
 
-        r_min = range_for_speed(cfg.min_speed)
-        r_max = range_for_speed(cfg.max_speed)
-        lower = min(r_min, r_max)
-        upper = max(r_min, r_max)
-        if not (lower <= horizontal_dist <= upper):
-            return None
-
-        lo = cfg.min_speed
-        hi = cfg.max_speed
-        for _ in range(cfg.speed_solve_max_iters):
-            mid = 0.5 * (lo + hi)
-            r_mid = range_for_speed(mid)
-            if abs(r_mid - horizontal_dist) <= cfg.speed_solve_tol:
-                return mid
-            if r_mid < horizontal_dist:
-                lo = mid
-            else:
-                hi = mid
-
-        return 0.5 * (lo + hi)
-
-    def _fallback_speed_and_elevation(
-        self,
-        horizontal_dist: float,
-        z0: float,
-    ) -> tuple[float, float]:
-        cfg = self.config
-        best_elevation = math.radians(15.0)  # default
-        best_speed = 25.0  # default
-
-        for elev_deg in [8, 12, 15, 18, 22, 26, 30]:
-            elev_rad = math.radians(elev_deg)
-            sin_2elev = math.sin(2 * elev_rad)
-            if sin_2elev < 0.1:
-                continue
-
-            speed_base = math.sqrt(horizontal_dist * cfg.gravity / sin_2elev)
-            height_factor = 1.0 - 0.1 * z0 / max(horizontal_dist, 1.0)
-            speed = speed_base * max(0.8, height_factor)
-
-            if cfg.min_speed <= speed <= cfg.max_speed:
-                best_elevation = elev_rad
-                best_speed = speed
-                break
-
-        return best_elevation, best_speed
-
-    def _refine_velocity_to_target(
-        self,
-        start_pos: Tensor,
-        target_pos: Tensor,
-        velocity: Tensor,
-        spin: Tensor | None,
-        physics: "BallPhysics",
-    ) -> Tensor:
-        cfg = self.config
-        spin_vec = spin if spin is not None else torch.zeros_like(velocity)
-        refined = velocity.clone()
-
-        for _ in range(cfg.refine_iters):
-            landing = self._simulate_to_first_bounce(
-                start_pos=start_pos,
-                velocity=refined,
-                spin=spin_vec,
-                physics=physics,
-            )
-            if landing is None:
-                break
-
-            desired = target_pos[:2] - start_pos[:2]
-            current = landing[:2] - start_pos[:2]
-            desired_dist = float(torch.linalg.norm(desired).item())
-            current_dist = float(torch.linalg.norm(current).item())
-            if current_dist < 1e-6 or desired_dist < 1e-6:
-                break
-
-            scale = desired_dist / current_dist
-            scale = max(cfg.refine_speed_scale_min, min(cfg.refine_speed_scale_max, scale))
-
-            desired_angle = math.atan2(desired[0].item(), desired[1].item())
-            current_angle = math.atan2(current[0].item(), current[1].item())
-            delta = desired_angle - current_angle
-            max_delta = math.radians(cfg.refine_max_azimuth_adjust_deg)
-            delta = max(-max_delta, min(max_delta, delta))
-
-            vx, vy, vz = refined.tolist()
-            horiz_speed = math.hypot(vx, vy) * scale
-            angle = math.atan2(vx, vy) + delta
-
-            vx = horiz_speed * math.sin(angle)
-            vy = horiz_speed * math.cos(angle)
-
-            total_speed = math.sqrt(vx**2 + vy**2 + vz**2)
-            if total_speed > cfg.max_speed:
-                factor = cfg.max_speed / max(total_speed, 1e-6)
-                vx *= factor
-                vy *= factor
-                vz *= factor
-            elif total_speed < cfg.min_speed:
-                factor = cfg.min_speed / max(total_speed, 1e-6)
-                vx *= factor
-                vy *= factor
-                vz *= factor
-
-            refined = torch.tensor(
-                [vx, vy, vz], device=refined.device, dtype=refined.dtype
-            )
-
-        return refined
-
-    def _passes_net_clearance(
+    def _check_net_passage(
         self,
         start_pos: Tensor,
         velocity: Tensor,
-        physics: "BallPhysics | None",
+        physics: BallPhysics | None,
         spin: Tensor | None,
-    ) -> bool:
-        clearance = self._estimate_net_clearance(
-            start_pos=start_pos,
-            velocity=velocity,
-            physics=physics,
-            spin=spin,
-        )
-        if clearance is None:
-            return False
-        return clearance >= self.config.net_clearance_min
-
-    def _estimate_net_clearance(
-        self,
-        start_pos: Tensor,
-        velocity: Tensor,
-        physics: "BallPhysics | None",
-        spin: Tensor | None,
-    ) -> float | None:
+    ) -> _NetCheckResult:
         if physics is None:
-            return self._estimate_net_clearance_gravity(start_pos, velocity)
-        return self._estimate_net_clearance_with_physics(
+            return self._check_net_passage_gravity(start_pos, velocity)
+        return self._check_net_passage_with_physics(
             start_pos=start_pos,
             velocity=velocity,
             spin=spin,
             physics=physics,
         )
 
-    def _estimate_net_clearance_gravity(
+    def _check_net_passage_gravity(
         self,
         start_pos: Tensor,
         velocity: Tensor,
-    ) -> float | None:
-        cfg = self.config
+    ) -> _NetCheckResult:
         vy = float(velocity[1].item())
         if abs(vy) < 1e-6:
-            return None
+            return _NetCheckResult(passed=False)
 
         t = -float(start_pos[1].item()) / vy
-        if t <= 0:
-            return None
+        if t <= 0.0:
+            return _NetCheckResult(passed=False)
 
         x_at_net = float(start_pos[0].item()) + float(velocity[0].item()) * t
-        if abs(x_at_net) > HALF_DOUBLES_WIDTH:
-            return float("inf")
-
         z_at_net = (
             float(start_pos[2].item())
             + float(velocity[2].item()) * t
-            - 0.5 * cfg.gravity * t**2
+            - 0.5 * self.config.gravity * t**2
         )
+        hit_pos = torch.tensor(
+            [x_at_net, 0.0, z_at_net], device=self.device, dtype=torch.float32
+        )
+        if abs(x_at_net) > HALF_DOUBLES_WIDTH:
+            return _NetCheckResult(passed=True, hit_pos=hit_pos)
         net_height = self._net_height_at_x(x_at_net)
-        return z_at_net - net_height
+        return _NetCheckResult(passed=z_at_net > net_height, hit_pos=hit_pos)
 
-    def _estimate_net_clearance_with_physics(
+    def _check_net_passage_with_physics(
         self,
         start_pos: Tensor,
         velocity: Tensor,
         spin: Tensor | None,
-        physics: "BallPhysics",
-    ) -> float | None:
+        physics: BallPhysics,
+    ) -> _NetCheckResult:
         from src.tasks.blcs.generate_dataset.simulation.ball_physics import BallState
 
         spin_vec = spin if spin is not None else torch.zeros_like(velocity)
@@ -582,49 +378,46 @@ class TargetedVelocitySampler:
             spin=spin_vec.clone(),
         )
 
-        for _ in range(self.config.net_clearance_max_frames):
+        for _ in range(self.config.net_check_max_frames):
             prev_pos = state.position.clone()
             state = physics.step(state)
 
+            hit_net, net_pos = physics.check_net_collision(prev_pos, state.position)
+            if hit_net:
+                return _NetCheckResult(passed=False, hit_pos=net_pos)
+
             clearance = physics.compute_net_clearance(prev_pos, state.position)
             if clearance is not None:
-                return clearance
+                return _NetCheckResult(passed=clearance > 0.0)
 
             state, bounced = physics.handle_bounce(state)
             if bounced:
-                return None
+                return _NetCheckResult(passed=False)
 
-        return None
+        return _NetCheckResult(passed=False)
+
+    def _raise_elevation_after_net_hit(
+        self,
+        elevation_rad: float,
+        hit_pos: Tensor | None,
+        start_pos: Tensor,
+        horizontal_dist: float,
+        default_step_rad: float,
+    ) -> float:
+        if hit_pos is None or horizontal_dist <= 1e-8:
+            return elevation_rad + default_step_rad
+
+        x_at_net = float(hit_pos[0].item())
+        z_at_net = float(hit_pos[2].item())
+        deficit = self._net_height_at_x(x_at_net) - z_at_net
+        if deficit <= 0.0:
+            return elevation_rad + default_step_rad
+
+        dist_to_net = float(torch.linalg.norm(hit_pos[:2] - start_pos[:2]).item())
+        scale_dist = max(dist_to_net, horizontal_dist * 0.25, 1.0)
+        deficit_step = math.atan(deficit / scale_dist)
+        return elevation_rad + max(default_step_rad, deficit_step)
 
     def _net_height_at_x(self, x_at_net: float) -> float:
         x_ratio = min(abs(x_at_net) / HALF_DOUBLES_WIDTH, 1.0)
         return NET_HEIGHT_CENTER + x_ratio * (NET_HEIGHT_POST - NET_HEIGHT_CENTER)
-
-    def _simulate_to_first_bounce(
-        self,
-        start_pos: Tensor,
-        velocity: Tensor,
-        spin: Tensor,
-        physics: "BallPhysics",
-    ) -> Tensor | None:
-        from src.tasks.blcs.generate_dataset.simulation.ball_physics import BallState
-
-        state = BallState(
-            position=start_pos.clone(),
-            velocity=velocity.clone(),
-            spin=spin.clone(),
-        )
-
-        for _ in range(self.config.refine_max_frames):
-            prev_pos = state.position.clone()
-            state = physics.step(state)
-
-            hit_net, _ = physics.check_net_collision(prev_pos, state.position)
-            if hit_net:
-                return None
-
-            state, bounced = physics.handle_bounce(state)
-            if bounced:
-                return state.position.clone()
-
-        return None


### PR DESCRIPTION
## 概要

BLCS generate_dataset の `TargetedVelocitySampler` を、着地点 refine ではなくネット通過確認を中心にした軽量実装へ再設計しました。
速度計算は二分探索から解析式の直接計算に変更し、サンプリング時の重い反復シミュレーションを削減しています。

## 変更内容

- `_solve_speed_for_target()` を重力近似の解析式で speed を直接返す実装に変更
- azimuth / elevation / speed ノイズ、speed / elevation clamp、着地点 refine 系 config / method を削除
- ネットまでの短い physics check を追加し、ネットに当たる場合のみ elevation を上げて再計算するよう変更
- `targeted_velocity/default.yaml` と `build_generator_config()` を新しい config 構成へ更新

## 検証

- `.venv/bin/ruff check src/tasks/blcs/generate_dataset/simulation/targeted_velocity_sampler.py src/tasks/blcs/generate_dataset/config.py`
- `.venv/bin/python -m py_compile src/tasks/blcs/generate_dataset/simulation/targeted_velocity_sampler.py src/tasks/blcs/generate_dataset/config.py`
- `BLCSSceneGenerator` smoke: `frames=151`, `rally_length=2`, `cameras=8`
- `.venv/bin/pytest tests/tasks/test_dataset_generation_contracts.py -q` -> `7 passed`
- ベンチ: `sample_velocity_for_target_cell()` 200 calls が `282.011 ms/call` から `78.462 ms/call` に改善、約 `3.594x` 高速化

## 関連Issue

- Closes #466

## 補足

実装前後の計測結果は issue コメントにも記録しています。
