### PR TITLE
BLCS axial model に stage ごとの camera/time layer schedule を導入

### DIFF
--- a/src/tasks/blcs/configs/model/multiview_axial.yaml
+++ b/src/tasks/blcs/configs/model/multiview_axial.yaml
@@ -7,7 +7,11 @@ io:
 
 hidden_dim: 512
 
+# `num_layers` is the number of camera/time stages.
 num_layers: 8
+camera_layers_per_stage: [1, 1, 1, 1, 1, 1, 1, 1]
+time_layers_per_stage: [1, 1, 1, 1, 1, 1, 1, 1]
+time_global_stage_mask: [false, false, false, false, false, false, false, false]
 num_heads: 8
 attention_type: mha
 num_kv_heads: null
@@ -19,7 +23,6 @@ rope_theta: 10000.0
 rope_theta_time: 10000.0
 rope_theta_camera: 1000.0
 time_window_radius: 16
-time_global_every: 0
 max_seq_len: 10240
 max_views: 8
 predict_velocity: true

--- a/src/tasks/blcs/models/blcs_multiview_axial_model.py
+++ b/src/tasks/blcs/models/blcs_multiview_axial_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
 import torch
@@ -45,10 +46,27 @@ class BLCSMultiViewAxialModel(nn.Module):
         invisible_init_std: float = 0.02,
         num_court_tokens: int = NUM_COURT_KP,
         time_window_radius: int = 16,
-        time_global_every: int = 0,
+        camera_layers_per_stage: Sequence[int] | None = None,
+        time_layers_per_stage: Sequence[int] | None = None,
+        time_global_stage_mask: Sequence[bool] | None = None,
     ) -> None:
         super().__init__()
         self.hidden_dim = int(hidden_dim)
+        num_layers = int(num_layers)
+        camera_layers_per_stage = self._normalize_stage_ints(
+            camera_layers_per_stage,
+            num_layers=num_layers,
+            default_value=1,
+        )
+        time_layers_per_stage = self._normalize_stage_ints(
+            time_layers_per_stage,
+            num_layers=num_layers,
+            default_value=1,
+        )
+        time_global_stage_mask = self._normalize_stage_mask(
+            time_global_stage_mask,
+            num_layers=num_layers,
+        )
 
         self._validate_init_args(
             hidden_dim=self.hidden_dim,
@@ -56,21 +74,23 @@ class BLCSMultiViewAxialModel(nn.Module):
             max_seq_len=max_seq_len,
             max_num_cameras=max_num_cameras,
             num_layers=num_layers,
+            camera_layers_per_stage=camera_layers_per_stage,
+            time_layers_per_stage=time_layers_per_stage,
+            time_global_stage_mask=time_global_stage_mask,
         )
 
+        self.num_layers = num_layers
         self.max_seq_len = int(max_seq_len)
         self.max_num_cameras = int(max_num_cameras)
         self.predict_velocity = bool(predict_velocity)
         self.num_court_tokens = int(num_court_tokens)
         self.time_window_radius = int(time_window_radius)
-        self.time_global_every = int(time_global_every)
+        self.camera_layers_per_stage = camera_layers_per_stage
+        self.time_layers_per_stage = time_layers_per_stage
+        self.time_global_stage_mask = time_global_stage_mask
         if self.time_window_radius < 0:
             raise ValueError(
                 f"time_window_radius must be non-negative, got {self.time_window_radius}"
-            )
-        if self.time_global_every < 0:
-            raise ValueError(
-                f"time_global_every must be non-negative, got {self.time_global_every}"
             )
 
         head_dim = self.hidden_dim // num_heads
@@ -99,40 +119,50 @@ class BLCSMultiViewAxialModel(nn.Module):
 
         self.camera_layers = nn.ModuleList(
             [
-                TransformerBlock(
-                    TransformerBlockConfig(
-                        dim=self.hidden_dim,
-                        n_heads=num_heads,
-                        ffn_dim=ffn_dim,
-                        head_dim=head_dim,
-                        rope_dim=self.rope_dim,
-                        attn_dropout=dropout,
-                        attention_type=attention_type,
-                        n_kv_heads=num_kv_heads,
-                        rope_base=self.rope_bases[1],
-                        ffn_type=ffn_type,
-                    )
+                nn.ModuleList(
+                    [
+                        TransformerBlock(
+                            TransformerBlockConfig(
+                                dim=self.hidden_dim,
+                                n_heads=num_heads,
+                                ffn_dim=ffn_dim,
+                                head_dim=head_dim,
+                                rope_dim=self.rope_dim,
+                                attn_dropout=dropout,
+                                attention_type=attention_type,
+                                n_kv_heads=num_kv_heads,
+                                rope_base=self.rope_bases[1],
+                                ffn_type=ffn_type,
+                            )
+                        )
+                        for _ in range(camera_layer_count)
+                    ]
                 )
-                for _ in range(num_layers)
+                for camera_layer_count in self.camera_layers_per_stage
             ]
         )
         self.time_layers = nn.ModuleList(
             [
-                TransformerBlock(
-                    TransformerBlockConfig(
-                        dim=self.hidden_dim,
-                        n_heads=num_heads,
-                        ffn_dim=ffn_dim,
-                        head_dim=head_dim,
-                        rope_dim=self.rope_dim,
-                        attn_dropout=dropout,
-                        attention_type=attention_type,
-                        n_kv_heads=num_kv_heads,
-                        rope_base=self.rope_bases[0],
-                        ffn_type=ffn_type,
-                    )
+                nn.ModuleList(
+                    [
+                        TransformerBlock(
+                            TransformerBlockConfig(
+                                dim=self.hidden_dim,
+                                n_heads=num_heads,
+                                ffn_dim=ffn_dim,
+                                head_dim=head_dim,
+                                rope_dim=self.rope_dim,
+                                attn_dropout=dropout,
+                                attention_type=attention_type,
+                                n_kv_heads=num_kv_heads,
+                                rope_base=self.rope_bases[0],
+                                ffn_type=ffn_type,
+                            )
+                        )
+                        for _ in range(time_layer_count)
+                    ]
                 )
-                for _ in range(num_layers)
+                for time_layer_count in self.time_layers_per_stage
             ]
         )
 
@@ -173,6 +203,9 @@ class BLCSMultiViewAxialModel(nn.Module):
         max_seq_len: int,
         max_num_cameras: int,
         num_layers: int,
+        camera_layers_per_stage: tuple[int, ...],
+        time_layers_per_stage: tuple[int, ...],
+        time_global_stage_mask: tuple[bool, ...],
     ) -> None:
         if hidden_dim % num_heads != 0:
             raise ValueError(
@@ -184,6 +217,46 @@ class BLCSMultiViewAxialModel(nn.Module):
             raise ValueError(f"max_num_cameras must be positive, got {max_num_cameras}")
         if num_layers < 0:
             raise ValueError(f"num_layers must be non-negative, got {num_layers}")
+        if len(camera_layers_per_stage) != num_layers:
+            raise ValueError(
+                "camera_layers_per_stage length must equal num_layers, got "
+                f"{len(camera_layers_per_stage)} and {num_layers}"
+            )
+        if len(time_layers_per_stage) != num_layers:
+            raise ValueError(
+                "time_layers_per_stage length must equal num_layers, got "
+                f"{len(time_layers_per_stage)} and {num_layers}"
+            )
+        if len(time_global_stage_mask) != num_layers:
+            raise ValueError(
+                "time_global_stage_mask length must equal num_layers, got "
+                f"{len(time_global_stage_mask)} and {num_layers}"
+            )
+        if any(layer_count <= 0 for layer_count in camera_layers_per_stage):
+            raise ValueError("camera_layers_per_stage must contain only positive integers")
+        if any(layer_count <= 0 for layer_count in time_layers_per_stage):
+            raise ValueError("time_layers_per_stage must contain only positive integers")
+
+    @staticmethod
+    def _normalize_stage_ints(
+        values: Sequence[int] | None,
+        *,
+        num_layers: int,
+        default_value: int,
+    ) -> tuple[int, ...]:
+        if values is None:
+            return tuple(default_value for _ in range(num_layers))
+        return tuple(int(value) for value in values)
+
+    @staticmethod
+    def _normalize_stage_mask(
+        values: Sequence[bool] | None,
+        *,
+        num_layers: int,
+    ) -> tuple[bool, ...]:
+        if values is None:
+            return tuple(False for _ in range(num_layers))
+        return tuple(bool(value) for value in values)
 
     @staticmethod
     def _validate_rope_dim(*, rope_dim: int, head_dim: int) -> None:
@@ -225,7 +298,9 @@ class BLCSMultiViewAxialModel(nn.Module):
                 )
             ),
             time_window_radius=int(model_cfg.get("time_window_radius", 16)),
-            time_global_every=int(model_cfg.get("time_global_every", 0)),
+            camera_layers_per_stage=model_cfg.get("camera_layers_per_stage", None),
+            time_layers_per_stage=model_cfg.get("time_layers_per_stage", None),
+            time_global_stage_mask=model_cfg.get("time_global_stage_mask", None),
         )
 
     @staticmethod
@@ -250,10 +325,16 @@ class BLCSMultiViewAxialModel(nn.Module):
     def _build_sliding_attn_mask(valid: Tensor, radius: int) -> Tensor:
         return build_local_attention_keep_mask(valid, radius)
 
-    def _is_global_time_layer(self, layer_index: int) -> bool:
-        return self.time_global_every > 0 and (layer_index + 1) % (
-            self.time_global_every + 1
-        ) == 0
+    def _use_global_time_attention(
+        self,
+        *,
+        stage_index: int,
+        time_layer_index: int,
+        time_layers_in_stage: int,
+    ) -> bool:
+        return self.time_global_stage_mask[stage_index] and (
+            time_layer_index == time_layers_in_stage - 1
+        )
 
     @staticmethod
     def _build_token_positions(*, seq_len: int, n_cams: int) -> Tensor:
@@ -298,7 +379,7 @@ class BLCSMultiViewAxialModel(nn.Module):
         x: Tensor,
         *,
         time_layer: TransformerBlock,
-        layer_index: int,
+        use_global_attention: bool,
         time_full_mask: Tensor,
         sliding_mask: Tensor,
         time_freqs: Tensor,
@@ -307,7 +388,7 @@ class BLCSMultiViewAxialModel(nn.Module):
         x_time = x.permute(0, 2, 1, 3).reshape(
             batch_size * n_cams, seq_len, self.hidden_dim
         )
-        attn_mask = time_full_mask if self._is_global_time_layer(layer_index) else sliding_mask
+        attn_mask = time_full_mask if use_global_attention else sliding_mask
         x_time = time_layer(
             x_time,
             freqs_cis=time_freqs,
@@ -381,27 +462,34 @@ class BLCSMultiViewAxialModel(nn.Module):
             radius=self.time_window_radius,
         )
 
-        for layer_index, (camera_layer, time_layer) in enumerate(zip(
+        for stage_index, (camera_stage_layers, time_stage_layers) in enumerate(zip(
             self.camera_layers,
             self.time_layers,
             strict=True,
         )):
-            x_camera = x.reshape(batch_size * seq_len_in, n_cams, self.hidden_dim)
-            x_camera = camera_layer(
-                x_camera,
-                freqs_cis=camera_freqs,
-                attn_mask=camera_mask,
-            )
-            x = x_camera.reshape(batch_size, seq_len_in, n_cams, self.hidden_dim)
+            for camera_layer in camera_stage_layers:
+                x_camera = x.reshape(batch_size * seq_len_in, n_cams, self.hidden_dim)
+                x_camera = camera_layer(
+                    x_camera,
+                    freqs_cis=camera_freqs,
+                    attn_mask=camera_mask,
+                )
+                x = x_camera.reshape(batch_size, seq_len_in, n_cams, self.hidden_dim)
 
-            x = self._apply_time_attention_layer(
-                x,
-                time_layer=time_layer,
-                layer_index=layer_index,
-                time_full_mask=time_mask,
-                sliding_mask=sliding_mask,
-                time_freqs=time_freqs,
-            )
+            time_layers_in_stage = len(time_stage_layers)
+            for time_layer_index, time_layer in enumerate(time_stage_layers):
+                x = self._apply_time_attention_layer(
+                    x,
+                    time_layer=time_layer,
+                    use_global_attention=self._use_global_time_attention(
+                        stage_index=stage_index,
+                        time_layer_index=time_layer_index,
+                        time_layers_in_stage=time_layers_in_stage,
+                    ),
+                    time_full_mask=time_mask,
+                    sliding_mask=sliding_mask,
+                    time_freqs=time_freqs,
+                )
 
         x = x[:, :, 0, :]
         x = self.final_norm(x)

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -11,6 +11,7 @@ from hydra.core.global_hydra import GlobalHydra
 from lightning_fabric.utilities.exceptions import MisconfigurationException
 from omegaconf import DictConfig
 
+from src.tasks.blcs.models.blcs_multiview_axial_model import BLCSMultiViewAxialModel
 from src.tasks.blcs.training.runner import BLCSTrainingRunner
 from src.tasks.court_detection.training.runner import CourtDetectionTrainingRunner
 from src.tasks.plcs.training.runner import PLCSTrainingRunner
@@ -86,6 +87,18 @@ COMMON_OVERRIDES = (
     "training.qualitative_logging.selected_indices=[0]",
 )
 
+BLCS_AXIAL_STAGE_OVERRIDES = (
+    "model.camera_layers_per_stage=[1,1]",
+    "model.time_layers_per_stage=[1,1]",
+    "model.time_global_stage_mask=[false,false]",
+)
+
+BLCS_AXIAL_STAGE_GLOBAL_OVERRIDES = (
+    "model.camera_layers_per_stage=[1,1]",
+    "model.time_layers_per_stage=[1,1]",
+    "model.time_global_stage_mask=[true,false]",
+)
+
 
 SMOKE_TASK_SPECS = (
     SmokeTaskSpec(
@@ -137,6 +150,7 @@ SMOKE_TASK_SPECS = (
                 overrides=(
                     "model=multiview_axial",
                     "data=multiview",
+                    *BLCS_AXIAL_STAGE_OVERRIDES,
                 ),
             ),
             SmokeVariant(
@@ -144,6 +158,7 @@ SMOKE_TASK_SPECS = (
                 overrides=(
                     "model=multiview_axial",
                     "data=multiview",
+                    *BLCS_AXIAL_STAGE_OVERRIDES,
                     "model.attention_type=gqa",
                     "model.num_kv_heads=2",
                 ),
@@ -153,8 +168,8 @@ SMOKE_TASK_SPECS = (
                 overrides=(
                     "model=multiview_axial",
                     "data=multiview",
+                    *BLCS_AXIAL_STAGE_GLOBAL_OVERRIDES,
                     "model.time_window_radius=4",
-                    "model.time_global_every=2",
                 ),
             ),
             SmokeVariant(
@@ -162,6 +177,7 @@ SMOKE_TASK_SPECS = (
                 overrides=(
                     "model=multiview_axial",
                     "data=multiview",
+                    *BLCS_AXIAL_STAGE_OVERRIDES,
                     "data.num_court_kp=12",
                 ),
             ),
@@ -450,6 +466,49 @@ def _compose_config(case: SmokeCase, output_dir: Path) -> DictConfig:
     overrides.extend(_normalize_override(override) for override in case.overrides)
     with initialize_config_dir(version_base="1.3", config_dir=str(case.config_dir)):
         return compose(config_name=case.config_name, overrides=overrides)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    (
+        (
+            (
+                "model.num_layers=2",
+                "model.camera_layers_per_stage=[2]",
+                "model.time_layers_per_stage=[3,2]",
+                "model.time_global_stage_mask=[true,false]",
+            ),
+            "camera_layers_per_stage length must equal num_layers",
+        ),
+        (
+            (
+                "model.num_layers=2",
+                "model.camera_layers_per_stage=[2,1]",
+                "model.time_layers_per_stage=[3,2]",
+                "model.time_global_stage_mask=[true]",
+            ),
+            "time_global_stage_mask length must equal num_layers",
+        ),
+    ),
+)
+def test_blcs_multiview_axial_stage_schedule_validation(
+    overrides: tuple[str, ...],
+    match: str,
+) -> None:
+    GlobalHydra.instance().clear()
+    config_overrides = [
+        _normalize_override("model=multiview_axial"),
+        _normalize_override("data=multiview"),
+        *(_normalize_override(override) for override in overrides),
+    ]
+    with initialize_config_dir(
+        version_base="1.3",
+        config_dir=str(REPO_ROOT / "src/tasks/blcs/configs"),
+    ):
+        config = compose(config_name="train", overrides=config_overrides)
+
+    with pytest.raises(ValueError, match=match):
+        BLCSMultiViewAxialModel.from_config(config)
 
 
 def _normalize_override(override: str) -> str:


### PR DESCRIPTION
## 概要

- BLCS axial model で stage ごとの camera/time layer schedule を指定できるようにしました。
- issue 460 で比較した staged schedule 構成をそのまま Hydra config から再現できる状態にします。

## 変更内容

- `BLCSMultiViewAxialModel` に `camera_layers_per_stage`、`time_layers_per_stage`、`time_global_stage_mask` を追加し、stage 単位で camera/time block 数と global time attention の適用位置を制御できるようにしました。
- `time_global_every` を廃止し、stage 内の最後の time layer にのみ global attention を適用する実装へ置き換えました。
- BLCS multiview axial の smoke test を新しい stage schedule 設定へ更新し、`num_layers` と各 list 長の不整合を検出する validation test を追加しました。

## 検証

- `.venv/bin/python -m pytest tests/tasks/test_training_smoke_contracts.py -k 'multiview_axial or stage_schedule_validation'`

## 関連Issue

- Closes #460

## 補足

- 学習結果の整理、`outputs/issue460` の可視化、定量考察は issue comment に記載済みです。
- `outputs/` 配下は git 管理外のため、この PR には含めていません。
