### PR TITLE
PLCS/BLCS axial time-local attentionをCUDA対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ python -m src.<task>.scripts.<entrypoint> key=value
 
 VS Code を使う場合は `.devcontainer/devcontainer.json` を利用して devcontainer として開けます。
 
+### Optional CUDA ops
+
+MoE と time-local attention には optional CUDA extension があります。
+PLCS/BLCS の axial multi-view model で local time attention を GPU 上で使う場合は、
+事前に CUDA ops をビルドしてください。
+
+```bash
+TENNIS_LAB_BUILD_CUDA_OPS=1 \
+  uv pip install -e . --no-build-isolation --python .venv/bin/python
+```
+
+詳しい前提条件、確認方法、トラブルシュートは [docs/cuda_ops.md](docs/cuda_ops.md) を参照してください。
+
 ## ライセンス / 引用
 
 このリポジトリは [MIT License](LICENSE) の下で公開されています。

--- a/docs/cuda_ops.md
+++ b/docs/cuda_ops.md
@@ -1,0 +1,147 @@
+# CUDA ops
+
+このリポジトリには、PyTorch の標準演算だけで動く reference 実装に加えて、
+一部のモデル部品を高速化する optional CUDA extension があります。
+
+現在の CUDA ops は次の 2 種類です。
+
+- `src.utils.models.components.ops.moe._C`: MoE dispatch/combine 用
+- `src.utils.models.components.ops.time_local._C`: time-local attention 用
+
+PLCS/BLCS の axial multi-view model では、local time attention を CUDA tensor
+上で実行する場合に `time_local` CUDA extension を使います。
+
+## 前提
+
+- CUDA 対応版 PyTorch が `.venv` にインストールされていること
+- `nvcc` が使えること
+- `CUDA_HOME` が PyTorch から検出できること
+
+確認例:
+
+```bash
+.venv/bin/python - <<'PY'
+import torch
+from torch.utils.cpp_extension import CUDA_HOME
+
+print("torch:", torch.__version__)
+print("torch cuda:", torch.version.cuda)
+print("cuda available:", torch.cuda.is_available())
+print("device count:", torch.cuda.device_count())
+print("CUDA_HOME:", CUDA_HOME)
+if torch.cuda.is_available():
+    print("device 0:", torch.cuda.get_device_name(0))
+PY
+```
+
+`nvcc` も確認します。
+
+```bash
+nvcc --version
+```
+
+## ビルド
+
+CUDA ops は通常の editable install ではビルドされません。
+ビルドする場合は `TENNIS_LAB_BUILD_CUDA_OPS=1` を付けて editable install を実行します。
+
+```bash
+TENNIS_LAB_BUILD_CUDA_OPS=1 \
+  uv pip install -e . --no-build-isolation --python .venv/bin/python
+```
+
+ビルドに成功すると、次のような共有ライブラリが生成されます。
+
+```text
+src/utils/models/components/ops/moe/_C.so
+src/utils/models/components/ops/time_local/_C.so
+```
+
+これらは生成物なので git にはコミットしません。
+
+## ロード確認
+
+```bash
+.venv/bin/python - <<'PY'
+from src.utils.models.components.ops import (
+    is_moe_cuda_available,
+    is_time_local_cuda_available,
+)
+
+print("moe cuda:", is_moe_cuda_available())
+print("time-local cuda:", is_time_local_cuda_available())
+PY
+```
+
+どちらも `True` なら extension を import できています。
+
+## time-local CUDA path の動作確認
+
+`use_cuda=True` を指定すると、extension が未ビルドの場合は fallback せずに失敗します。
+これは「本当に CUDA path を使えているか」を確認するために便利です。
+
+```bash
+.venv/bin/python - <<'PY'
+import torch
+
+from src.utils.models.components.ops.time_local import time_local_attention
+
+query = torch.randn(2, 4, 8, 16, device="cuda", requires_grad=True)
+key = torch.randn(2, 4, 8, 16, device="cuda", requires_grad=True)
+value = torch.randn(2, 4, 8, 16, device="cuda", requires_grad=True)
+valid_mask = torch.ones(2, 8, device="cuda", dtype=torch.bool)
+
+out = time_local_attention(
+    query,
+    key,
+    value,
+    valid_mask=valid_mask,
+    window_radius=2,
+    use_cuda=True,
+)
+out.square().mean().backward()
+torch.cuda.synchronize()
+
+print("out device:", out.device)
+print("grad device:", query.grad.device)
+PY
+```
+
+期待される出力例:
+
+```text
+out device: cuda:0
+grad device: cuda:0
+```
+
+## 実行時の選択
+
+低レベル API の `use_cuda` は次のように振る舞います。
+
+- `use_cuda=True`: CUDA tensor と CUDA extension が必要です。条件を満たさない場合は失敗します。
+- `use_cuda=False`: reference 実装を使います。
+- `use_cuda=None`: 既定では reference 実装を使います。
+
+環境変数でも制御できます。
+
+- `TENNIS_LAB_USE_TIME_LOCAL_CUDA=1`: `use_cuda=None` の time-local attention で CUDA path を優先します。
+- `TENNIS_LAB_FORCE_TIME_LOCAL_REFERENCE=1`: time-local attention で reference 実装を強制します。
+
+PLCS/BLCS の axial multi-view model は、local time attention を CUDA tensor 上で
+実行する場合に `use_cuda=True` 相当で呼び出します。そのため、GPU 学習や GPU 推論で
+local time attention を使う場合は、事前に `time_local` CUDA extension をビルドしてください。
+
+## トラブルシュート
+
+`Time-local CUDA extension is not available` が出る場合:
+
+- `TENNIS_LAB_BUILD_CUDA_OPS=1` 付きで editable install したか確認する
+- `src/utils/models/components/ops/time_local/_C.so` が生成されているか確認する
+- `CUDA_HOME` と `nvcc --version` を確認する
+- `.venv/bin/python` と `uv pip install --python .venv/bin/python` の対象が同じ環境か確認する
+
+`CUDA_HOME was not found` が出る場合:
+
+- CUDA toolkit が入っているか確認する
+- 必要に応じて `CUDA_HOME=/usr/local/cuda` などを設定して再ビルドする
+

--- a/src/tasks/blcs/configs/model/axial.yaml
+++ b/src/tasks/blcs/configs/model/axial.yaml
@@ -1,0 +1,25 @@
+# Axial BLCS model configuration
+# Uses one court-ball token per timestep and temporal self-attention.
+name: blcs_axial
+io:
+  input_profile: single
+
+hidden_dim: 256
+num_layers: 6
+num_heads: 8
+attention_type: mha
+num_kv_heads: null
+ffn_dim: null
+ffn_type: swiglu
+dropout: 0.1
+max_seq_len: 10240
+invisible_init_std: 0.02
+
+rope_dim: null
+rope_theta: 10000.0
+rope_theta_time: 10000.0
+
+time_window_radius: 16
+time_global_layer_mask: [false, false, false, false, false, false]
+
+predict_velocity: true

--- a/src/tasks/blcs/models/__init__.py
+++ b/src/tasks/blcs/models/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from torch import nn
 
+from src.tasks.blcs.models.blcs_axial_model import BLCSAxialModel
 from src.tasks.blcs.models.blcs_model import BLCSModel
 from src.tasks.blcs.models.blcs_multiview_axial_model import BLCSMultiViewAxialModel
 from src.tasks.blcs.models.blcs_multiview_model import BLCSMultiViewModel
@@ -21,17 +22,21 @@ def build_blcs_model(config: DictConfig) -> nn.Module:
     model_name = str(model_cfg.get("name", "blcs"))
     if model_name == "blcs":
         return BLCSModel.from_config(config)
+    if model_name == "blcs_axial":
+        return BLCSAxialModel.from_config(config)
     if model_name == "blcs_multiview":
         return BLCSMultiViewModel.from_config(config)
     if model_name == "blcs_multiview_axial":
         return BLCSMultiViewAxialModel.from_config(config)
     raise ValueError(
         "Unknown BLCS model.name="
-        f"'{model_name}'. Supported: ['blcs', 'blcs_multiview', 'blcs_multiview_axial']"
+        f"'{model_name}'. Supported: "
+        "['blcs', 'blcs_axial', 'blcs_multiview', 'blcs_multiview_axial']"
     )
 
 
 __all__ = [
+    "BLCSAxialModel",
     "BLCSModel",
     "BLCSMultiViewModel",
     "BLCSMultiViewAxialModel",

--- a/src/tasks/blcs/models/blcs_axial_model.py
+++ b/src/tasks/blcs/models/blcs_axial_model.py
@@ -1,0 +1,380 @@
+"""Axial single-view BLCS model with one court-ball token per timestep."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Literal, cast
+
+import torch
+from torch import Tensor, nn
+
+from src.tasks.blcs.models.components.heads import Trajectory3DHead, VelocityHead
+from src.utils.models import (
+    RMSNorm,
+    TransformerBlock,
+    TransformerBlockConfig,
+    precompute_freqs_cis_nd,
+)
+from src.utils.models.components.ops.time_local import build_local_attention_keep_mask
+from src.utils.models.embeddings import CourtBallGroupEmbedding, InvisibleTokenEmbedding
+from src.utils.schema.court import NUM_COURT_KP
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+class BLCSAxialModel(nn.Module):
+    """BLCS single-view model with temporal self-attention over group tokens.
+
+    Each timestep is represented by one token built from the court keypoints and
+    the observed ball UV coordinate. This keeps the standard single-view BLCS
+    input/output contract while avoiding full attention over separate court and
+    ball token sequences.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int = 256,
+        num_layers: int = 6,
+        num_heads: int = 8,
+        attention_type: Literal["mha", "gqa"] = "mha",
+        num_kv_heads: int | None = None,
+        ffn_dim: int | None = None,
+        ffn_type: Literal["swiglu", "mlp"] = "swiglu",
+        dropout: float = 0.1,
+        rope_dim: int | None = None,
+        rope_theta: float = 10000.0,
+        rope_theta_time: float | None = None,
+        predict_velocity: bool = False,
+        max_seq_len: int = 120,
+        invisible_init_std: float = 0.02,
+        num_court_tokens: int = NUM_COURT_KP,
+        time_window_radius: int = 16,
+        time_global_layer_mask: Sequence[bool] | None = None,
+    ) -> None:
+        super().__init__()
+        self.hidden_dim = int(hidden_dim)
+        self.num_layers = int(num_layers)
+        self.max_seq_len = int(max_seq_len)
+        self.predict_velocity = bool(predict_velocity)
+        self.num_court_tokens = int(num_court_tokens)
+        self.time_window_radius = int(time_window_radius)
+        self.time_global_layer_mask = self._normalize_layer_mask(
+            time_global_layer_mask,
+            num_layers=self.num_layers,
+        )
+
+        self._validate_init_args(
+            hidden_dim=self.hidden_dim,
+            num_heads=num_heads,
+            max_seq_len=self.max_seq_len,
+            num_layers=self.num_layers,
+            time_window_radius=self.time_window_radius,
+            time_global_layer_mask=self.time_global_layer_mask,
+        )
+
+        head_dim = self.hidden_dim // num_heads
+        rope_dim = head_dim if rope_dim is None else int(rope_dim)
+        self._validate_rope_dim(rope_dim=rope_dim, head_dim=head_dim)
+        self.rope_dim = int(rope_dim)
+        self.rope_theta = float(
+            rope_theta if rope_theta_time is None else rope_theta_time
+        )
+
+        if ffn_dim is None:
+            ffn_dim = int((8 * self.hidden_dim) / 3)
+            ffn_dim = (ffn_dim + 63) // 64 * 64
+
+        self.invisible_token = InvisibleTokenEmbedding(
+            dim=self.hidden_dim,
+            init_std=invisible_init_std,
+        )
+        self.group_embed = CourtBallGroupEmbedding(
+            dim=self.hidden_dim,
+            invisible_token=self.invisible_token,
+            num_court_tokens=self.num_court_tokens,
+        )
+
+        self.time_layers = nn.ModuleList(
+            [
+                TransformerBlock(
+                    TransformerBlockConfig(
+                        dim=self.hidden_dim,
+                        n_heads=num_heads,
+                        ffn_dim=ffn_dim,
+                        head_dim=head_dim,
+                        rope_dim=self.rope_dim,
+                        attn_dropout=dropout,
+                        attention_type=attention_type,
+                        n_kv_heads=num_kv_heads,
+                        rope_base=self.rope_theta,
+                        ffn_type=ffn_type,
+                    )
+                )
+                for _ in range(self.num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm(self.hidden_dim)
+
+        self.position_head = Trajectory3DHead(
+            input_dim=self.hidden_dim,
+            hidden_dim=self.hidden_dim // 2,
+            output_dim=3,
+            num_layers=2,
+            dropout=dropout,
+        )
+        self.velocity_head = None
+        if self.predict_velocity:
+            self.velocity_head = VelocityHead(
+                input_dim=self.hidden_dim,
+                hidden_dim=self.hidden_dim // 2,
+                output_dim=3,
+                num_layers=2,
+                dropout=dropout,
+            )
+
+        freqs = precompute_freqs_cis_nd(
+            dim=self.rope_dim,
+            pos=self._build_time_positions(seq_len=self.max_seq_len),
+            base=self.rope_theta,
+        )
+        self.register_buffer("freqs_cis", freqs, persistent=False)
+
+    @staticmethod
+    def _validate_init_args(
+        *,
+        hidden_dim: int,
+        num_heads: int,
+        max_seq_len: int,
+        num_layers: int,
+        time_window_radius: int,
+        time_global_layer_mask: tuple[bool, ...],
+    ) -> None:
+        if hidden_dim % num_heads != 0:
+            raise ValueError(
+                f"hidden_dim={hidden_dim} must be divisible by num_heads={num_heads}"
+            )
+        if max_seq_len <= 0:
+            raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
+        if num_layers < 0:
+            raise ValueError(f"num_layers must be non-negative, got {num_layers}")
+        if time_window_radius < 0:
+            raise ValueError(
+                f"time_window_radius must be non-negative, got {time_window_radius}"
+            )
+        if len(time_global_layer_mask) != num_layers:
+            raise ValueError(
+                "time_global_layer_mask length must equal num_layers, got "
+                f"{len(time_global_layer_mask)} and {num_layers}"
+            )
+
+    @staticmethod
+    def _validate_rope_dim(*, rope_dim: int, head_dim: int) -> None:
+        if rope_dim % 2 != 0:
+            raise ValueError(f"rope_dim must be even, got {rope_dim}")
+        if rope_dim > head_dim:
+            raise ValueError(f"rope_dim={rope_dim} cannot exceed head_dim={head_dim}")
+
+    @staticmethod
+    def _normalize_layer_mask(
+        values: Sequence[bool] | None,
+        *,
+        num_layers: int,
+    ) -> tuple[bool, ...]:
+        if values is None:
+            return tuple(False for _ in range(num_layers))
+        return tuple(bool(value) for value in values)
+
+    @classmethod
+    def from_config(cls, config: DictConfig) -> BLCSAxialModel:
+        """Create model from Hydra/OmegaConf config."""
+        model_cfg = config.get("model", {})
+        data_cfg = config.get("data", {})
+        global_mask = model_cfg.get(
+            "time_global_layer_mask",
+            model_cfg.get("time_global_stage_mask", None),
+        )
+
+        return cls(
+            hidden_dim=int(model_cfg.get("hidden_dim", 256)),
+            num_layers=int(model_cfg.get("num_layers", 6)),
+            num_heads=int(model_cfg.get("num_heads", 8)),
+            attention_type=cast(
+                Literal["mha", "gqa"], str(model_cfg.get("attention_type", "mha"))
+            ),
+            num_kv_heads=model_cfg.get("num_kv_heads", None),
+            ffn_dim=model_cfg.get("ffn_dim", None),
+            ffn_type=cast(
+                Literal["swiglu", "mlp"], str(model_cfg.get("ffn_type", "swiglu"))
+            ),
+            dropout=float(model_cfg.get("dropout", 0.1)),
+            rope_dim=model_cfg.get("rope_dim", None),
+            rope_theta=float(model_cfg.get("rope_theta", 10000.0)),
+            rope_theta_time=model_cfg.get("rope_theta_time", None),
+            predict_velocity=bool(model_cfg.get("predict_velocity", False)),
+            max_seq_len=int(
+                model_cfg.get("max_seq_len", data_cfg.get("max_seq_len", 120))
+            ),
+            invisible_init_std=float(model_cfg.get("invisible_init_std", 0.02)),
+            num_court_tokens=int(
+                model_cfg.get(
+                    "num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP)
+                )
+            ),
+            time_window_radius=int(model_cfg.get("time_window_radius", 16)),
+            time_global_layer_mask=global_mask,
+        )
+
+    @staticmethod
+    def _build_time_positions(*, seq_len: int) -> Tensor:
+        return torch.arange(seq_len, dtype=torch.long) + 1
+
+    @staticmethod
+    def _build_self_attn_mask(valid: Tensor) -> tuple[Tensor, Tensor]:
+        valid_fixed = valid.bool()
+        fully_masked = ~valid_fixed.any(dim=1)
+        if fully_masked.any():
+            valid_fixed = valid_fixed.clone()
+            valid_fixed[fully_masked, 0] = True
+        attn_mask = valid_fixed[:, None, :].expand(
+            valid_fixed.shape[0],
+            valid_fixed.shape[1],
+            valid_fixed.shape[1],
+        )
+        return attn_mask, valid_fixed
+
+    @staticmethod
+    def _build_sliding_attn_mask(valid: Tensor, radius: int) -> Tensor:
+        return build_local_attention_keep_mask(valid, radius)
+
+    def forward(
+        self,
+        ball_uv: Tensor,
+        court_kp: Tensor,
+        ball_vis: Tensor | None = None,
+        ball_mask: Tensor | None = None,
+        court_vis: Tensor | None = None,
+    ) -> dict[str, Tensor]:
+        """Forward pass for single-view BLCS inputs."""
+        court_kp, ball_vis, ball_mask, seq_len_in = (
+            self._prepare_forward_inputs(
+                ball_uv=ball_uv,
+                court_kp=court_kp,
+                ball_vis=ball_vis,
+                ball_mask=ball_mask,
+                court_vis=court_vis,
+            )
+        )
+
+        x = self.group_embed(court_kp, ball_uv, ball_vis)
+        token_valid = ball_mask > 0
+        time_full_mask, time_valid = self._build_self_attn_mask(token_valid)
+        sliding_mask = self._build_sliding_attn_mask(
+            time_valid,
+            radius=self.time_window_radius,
+        )
+        freqs_cis = self._freqs_for_sequence(x=x, seq_len=seq_len_in)
+
+        for layer_index, time_layer in enumerate(self.time_layers):
+            use_global_attention = self.time_global_layer_mask[layer_index]
+            x = time_layer(
+                x,
+                freqs_cis=freqs_cis,
+                attn_mask=time_full_mask if use_global_attention else sliding_mask,
+            )
+
+        x = self.final_norm(x)
+        out: dict[str, Tensor] = {"position": self.position_head(x)}
+        if self.predict_velocity and self.velocity_head is not None:
+            out["velocity"] = self.velocity_head(x)
+        return out
+
+    def _prepare_forward_inputs(
+        self,
+        *,
+        ball_uv: Tensor,
+        court_kp: Tensor,
+        ball_vis: Tensor | None,
+        ball_mask: Tensor | None,
+        court_vis: Tensor | None,
+    ) -> tuple[Tensor, Tensor | None, Tensor, int]:
+        if ball_uv.dim() != 3:
+            raise ValueError(
+                f"ball_uv must have shape (B, T, 2), got {tuple(ball_uv.shape)}"
+            )
+        batch_size, seq_len_in, coord_dim = ball_uv.shape
+        if coord_dim != 2:
+            raise ValueError(
+                f"ball_uv must have shape (B, T, 2), got {tuple(ball_uv.shape)}"
+            )
+        if seq_len_in > self.max_seq_len:
+            raise ValueError(
+                f"seq_len={seq_len_in} exceeds max_seq_len={self.max_seq_len}. "
+                "Increase model.max_seq_len."
+            )
+
+        if court_kp.dim() == 2 or (
+            court_kp.dim() == 3
+            and tuple(court_kp.shape[-2:]) == (self.num_court_tokens, 2)
+        ):
+            court_kp = court_kp.unsqueeze(1).expand(-1, seq_len_in, *court_kp.shape[1:])
+        if court_kp.dim() not in {3, 4}:
+            raise ValueError(
+                "court_kp must have shape "
+                f"(B, {self.num_court_tokens}, 2), "
+                f"(B, {self.num_court_tokens * 2}), "
+                f"(B, T, {self.num_court_tokens}, 2), or "
+                f"(B, T, {self.num_court_tokens * 2}), "
+                f"got {tuple(court_kp.shape)}"
+            )
+        if court_kp.shape[:2] != (batch_size, seq_len_in):
+            raise ValueError(
+                f"court_kp leading shape must be {(batch_size, seq_len_in)}, "
+                f"got {tuple(court_kp.shape[:2])}"
+            )
+
+        if court_vis is not None:
+            if court_vis.dim() == 2:
+                court_vis = court_vis.unsqueeze(1).expand(-1, seq_len_in, -1)
+            if court_vis.shape != (batch_size, seq_len_in, self.num_court_tokens):
+                raise ValueError(
+                    "court_vis must have shape "
+                    f"(B, {self.num_court_tokens}) or "
+                    f"(B, T, {self.num_court_tokens}), "
+                    f"got {tuple(court_vis.shape)}"
+                )
+
+        if ball_vis is not None and ball_vis.shape != (batch_size, seq_len_in):
+            raise ValueError(
+                f"ball_vis must have shape {(batch_size, seq_len_in)}, "
+                f"got {tuple(ball_vis.shape)}"
+            )
+        if ball_mask is None:
+            ball_mask = torch.ones(
+                batch_size,
+                seq_len_in,
+                device=ball_uv.device,
+                dtype=torch.bool,
+            )
+        if ball_mask.shape != (batch_size, seq_len_in):
+            raise ValueError(
+                f"ball_mask must have shape {(batch_size, seq_len_in)}, "
+                f"got {tuple(ball_mask.shape)}"
+            )
+        return court_kp, ball_vis, ball_mask, seq_len_in
+
+    def _freqs_for_sequence(self, *, x: Tensor, seq_len: int) -> Tensor:
+        freqs_cis = cast(Tensor, self.freqs_cis)
+        if freqs_cis.shape[0] < seq_len:
+            raise ValueError(
+                f"Sequence length T={seq_len} exceeds cached freqs_cis length {freqs_cis.shape[0]}. "
+                "Increase max_seq_len."
+            )
+        freqs_cis = freqs_cis[:seq_len]
+        if freqs_cis.device != x.device:
+            freqs_cis = freqs_cis.to(x.device)
+        return freqs_cis
+
+    def get_num_params(self) -> int:
+        """Get total number of trainable parameters."""
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)

--- a/src/tasks/blcs/models/blcs_multiview_axial_model.py
+++ b/src/tasks/blcs/models/blcs_multiview_axial_model.py
@@ -233,9 +233,13 @@ class BLCSMultiViewAxialModel(nn.Module):
                 f"{len(time_global_stage_mask)} and {num_layers}"
             )
         if any(layer_count <= 0 for layer_count in camera_layers_per_stage):
-            raise ValueError("camera_layers_per_stage must contain only positive integers")
+            raise ValueError(
+                "camera_layers_per_stage must contain only positive integers"
+            )
         if any(layer_count <= 0 for layer_count in time_layers_per_stage):
-            raise ValueError("time_layers_per_stage must contain only positive integers")
+            raise ValueError(
+                "time_layers_per_stage must contain only positive integers"
+            )
 
     @staticmethod
     def _normalize_stage_ints(
@@ -381,18 +385,23 @@ class BLCSMultiViewAxialModel(nn.Module):
         time_layer: TransformerBlock,
         use_global_attention: bool,
         time_full_mask: Tensor,
-        sliding_mask: Tensor,
+        time_valid: Tensor,
         time_freqs: Tensor,
     ) -> Tensor:
         batch_size, seq_len, n_cams, _ = x.shape
         x_time = x.permute(0, 2, 1, 3).reshape(
             batch_size * n_cams, seq_len, self.hidden_dim
         )
-        attn_mask = time_full_mask if use_global_attention else sliding_mask
+        attn_mask = time_full_mask if use_global_attention else None
+        local_valid_mask = None if use_global_attention else time_valid
+        local_window_radius = None if use_global_attention else self.time_window_radius
         x_time = time_layer(
             x_time,
             freqs_cis=time_freqs,
             attn_mask=attn_mask,
+            local_valid_mask=local_valid_mask,
+            local_window_radius=local_window_radius,
+            local_use_cuda=x_time.is_cuda if not use_global_attention else None,
         )
         return x_time.reshape(batch_size, n_cams, seq_len, self.hidden_dim).permute(
             0, 2, 1, 3
@@ -457,16 +466,13 @@ class BLCSMultiViewAxialModel(nn.Module):
             seq_len=seq_len_in,
             n_cams=n_cams,
         )
-        sliding_mask = self._build_sliding_attn_mask(
-            time_valid,
-            radius=self.time_window_radius,
-        )
-
-        for stage_index, (camera_stage_layers, time_stage_layers) in enumerate(zip(
-            self.camera_layers,
-            self.time_layers,
-            strict=True,
-        )):
+        for stage_index, (camera_stage_layers, time_stage_layers) in enumerate(
+            zip(
+                self.camera_layers,
+                self.time_layers,
+                strict=True,
+            )
+        ):
             for camera_layer in camera_stage_layers:
                 x_camera = x.reshape(batch_size * seq_len_in, n_cams, self.hidden_dim)
                 x_camera = camera_layer(
@@ -487,7 +493,7 @@ class BLCSMultiViewAxialModel(nn.Module):
                         time_layers_in_stage=time_layers_in_stage,
                     ),
                     time_full_mask=time_mask,
-                    sliding_mask=sliding_mask,
+                    time_valid=time_valid,
                     time_freqs=time_freqs,
                 )
 

--- a/src/tasks/plcs/configs/model/multiview_axial.yaml
+++ b/src/tasks/plcs/configs/model/multiview_axial.yaml
@@ -9,12 +9,20 @@ io:
   strict_input: true
 
 hidden_dim: 512
+
+# `num_layers` is the number of camera/time stages.
 num_layers: 12
+camera_layers_per_stage: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+time_layers_per_stage: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+time_global_stage_mask: [false, false, false, false, false, false, false, false, false, false, false, false]
 num_heads: 8
+attention_type: mha
+num_kv_heads: null
 ffn_dim: null
 ffn_type: swiglu
 dropout: 0.1
 invisible_init_std: 0.02
+time_window_radius: 16
 
 max_views: 6
 max_seq_len: 10240

--- a/src/tasks/plcs/models/plcs_multiview_axial_model.py
+++ b/src/tasks/plcs/models/plcs_multiview_axial_model.py
@@ -397,18 +397,23 @@ class PLCSMultiViewAxialModel(nn.Module):
         time_layer: TransformerBlock,
         use_global_attention: bool,
         time_full_mask: Tensor,
-        sliding_mask: Tensor,
+        time_valid: Tensor,
         time_freqs: Tensor,
     ) -> Tensor:
         batch_size, seq_len, n_cams, _ = x.shape
         x_time = x.permute(0, 2, 1, 3).reshape(
             batch_size * n_cams, seq_len, self.hidden_dim
         )
-        attn_mask = time_full_mask if use_global_attention else sliding_mask
+        attn_mask = time_full_mask if use_global_attention else None
+        local_valid_mask = None if use_global_attention else time_valid
+        local_window_radius = None if use_global_attention else self.time_window_radius
         x_time = time_layer(
             x_time,
             freqs_cis=time_freqs,
             attn_mask=attn_mask,
+            local_valid_mask=local_valid_mask,
+            local_window_radius=local_window_radius,
+            local_use_cuda=x_time.is_cuda if not use_global_attention else None,
         )
         return x_time.reshape(batch_size, n_cams, seq_len, self.hidden_dim).permute(
             0, 2, 1, 3
@@ -480,11 +485,6 @@ class PLCSMultiViewAxialModel(nn.Module):
             seq_len=seq_len_in,
             n_cams=n_cams,
         )
-        sliding_mask = self._build_sliding_attn_mask(
-            time_valid,
-            radius=self.time_window_radius,
-        )
-
         for stage_index, (camera_stage_layers, time_stage_layers) in enumerate(
             zip(
                 self.camera_layers,
@@ -512,7 +512,7 @@ class PLCSMultiViewAxialModel(nn.Module):
                         time_layers_in_stage=time_layers_in_stage,
                     ),
                     time_full_mask=time_mask,
-                    sliding_mask=sliding_mask,
+                    time_valid=time_valid,
                     time_freqs=time_freqs,
                 )
 

--- a/src/tasks/plcs/models/plcs_multiview_axial_model.py
+++ b/src/tasks/plcs/models/plcs_multiview_axial_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal, cast
 
 import torch
@@ -19,6 +20,7 @@ from src.utils.models import (
     TransformerBlockConfig,
     precompute_freqs_cis_nd,
 )
+from src.utils.models.components.ops.time_local import build_local_attention_keep_mask
 from src.utils.models.embeddings import (
     CourtPlayerGroupEmbedding,
     InvisibleTokenEmbedding,
@@ -38,6 +40,8 @@ class PLCSMultiViewAxialModel(nn.Module):
         hidden_dim: int = 256,
         num_layers: int = 6,
         num_heads: int = 8,
+        attention_type: Literal["mha", "gqa"] = "mha",
+        num_kv_heads: int | None = None,
         ffn_dim: int | None = None,
         dropout: float = 0.1,
         rope_dim: int | None = None,
@@ -50,22 +54,53 @@ class PLCSMultiViewAxialModel(nn.Module):
         max_seq_len: int = 120,
         invisible_init_std: float = 0.02,
         num_court_tokens: int = NUM_COURT_KP,
+        time_window_radius: int = 16,
+        camera_layers_per_stage: Sequence[int] | None = None,
+        time_layers_per_stage: Sequence[int] | None = None,
+        time_global_stage_mask: Sequence[bool] | None = None,
     ) -> None:
         super().__init__()
 
         self.hidden_dim = int(hidden_dim)
+        num_layers = int(num_layers)
+        camera_layers_per_stage = self._normalize_stage_ints(
+            camera_layers_per_stage,
+            num_layers=num_layers,
+            default_value=1,
+        )
+        time_layers_per_stage = self._normalize_stage_ints(
+            time_layers_per_stage,
+            num_layers=num_layers,
+            default_value=1,
+        )
+        time_global_stage_mask = self._normalize_stage_mask(
+            time_global_stage_mask,
+            num_layers=num_layers,
+        )
         self.predict_canonical_pose = bool(predict_canonical_pose)
         self.max_views = int(max_views)
         self.max_seq_len = int(max_seq_len)
         self.num_court_tokens = int(num_court_tokens)
+        self.num_layers = num_layers
+        self.time_window_radius = int(time_window_radius)
+        self.camera_layers_per_stage = camera_layers_per_stage
+        self.time_layers_per_stage = time_layers_per_stage
+        self.time_global_stage_mask = time_global_stage_mask
 
         self._validate_init_args(
             hidden_dim=self.hidden_dim,
             num_heads=num_heads,
-            num_layers=num_layers,
+            num_layers=self.num_layers,
             max_views=self.max_views,
             max_seq_len=self.max_seq_len,
+            camera_layers_per_stage=self.camera_layers_per_stage,
+            time_layers_per_stage=self.time_layers_per_stage,
+            time_global_stage_mask=self.time_global_stage_mask,
         )
+        if self.time_window_radius < 0:
+            raise ValueError(
+                f"time_window_radius must be non-negative, got {self.time_window_radius}"
+            )
 
         head_dim = self.hidden_dim // num_heads
         rope_dim = head_dim if rope_dim is None else int(rope_dim)
@@ -93,36 +128,50 @@ class PLCSMultiViewAxialModel(nn.Module):
 
         self.camera_layers = nn.ModuleList(
             [
-                TransformerBlock(
-                    TransformerBlockConfig(
-                        dim=self.hidden_dim,
-                        n_heads=num_heads,
-                        ffn_dim=ffn_dim,
-                        head_dim=head_dim,
-                        rope_dim=self.rope_dim,
-                        attn_dropout=dropout,
-                        rope_base=self.rope_bases[1],
-                        ffn_type=ffn_type,
-                    )
+                nn.ModuleList(
+                    [
+                        TransformerBlock(
+                            TransformerBlockConfig(
+                                dim=self.hidden_dim,
+                                n_heads=num_heads,
+                                ffn_dim=ffn_dim,
+                                head_dim=head_dim,
+                                rope_dim=self.rope_dim,
+                                attn_dropout=dropout,
+                                attention_type=attention_type,
+                                n_kv_heads=num_kv_heads,
+                                rope_base=self.rope_bases[1],
+                                ffn_type=ffn_type,
+                            )
+                        )
+                        for _ in range(camera_layer_count)
+                    ]
                 )
-                for _ in range(num_layers)
+                for camera_layer_count in self.camera_layers_per_stage
             ]
         )
         self.time_layers = nn.ModuleList(
             [
-                TransformerBlock(
-                    TransformerBlockConfig(
-                        dim=self.hidden_dim,
-                        n_heads=num_heads,
-                        ffn_dim=ffn_dim,
-                        head_dim=head_dim,
-                        rope_dim=self.rope_dim,
-                        attn_dropout=dropout,
-                        rope_base=self.rope_bases[0],
-                        ffn_type=ffn_type,
-                    )
+                nn.ModuleList(
+                    [
+                        TransformerBlock(
+                            TransformerBlockConfig(
+                                dim=self.hidden_dim,
+                                n_heads=num_heads,
+                                ffn_dim=ffn_dim,
+                                head_dim=head_dim,
+                                rope_dim=self.rope_dim,
+                                attn_dropout=dropout,
+                                attention_type=attention_type,
+                                n_kv_heads=num_kv_heads,
+                                rope_base=self.rope_bases[0],
+                                ffn_type=ffn_type,
+                            )
+                        )
+                        for _ in range(time_layer_count)
+                    ]
                 )
-                for _ in range(num_layers)
+                for time_layer_count in self.time_layers_per_stage
             ]
         )
 
@@ -168,6 +217,9 @@ class PLCSMultiViewAxialModel(nn.Module):
         num_layers: int,
         max_views: int,
         max_seq_len: int,
+        camera_layers_per_stage: tuple[int, ...],
+        time_layers_per_stage: tuple[int, ...],
+        time_global_stage_mask: tuple[bool, ...],
     ) -> None:
         if hidden_dim % num_heads != 0:
             raise ValueError(
@@ -179,6 +231,50 @@ class PLCSMultiViewAxialModel(nn.Module):
             raise ValueError(f"max_views must be positive, got {max_views}")
         if max_seq_len <= 0:
             raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
+        if len(camera_layers_per_stage) != num_layers:
+            raise ValueError(
+                "camera_layers_per_stage length must equal num_layers, got "
+                f"{len(camera_layers_per_stage)} and {num_layers}"
+            )
+        if len(time_layers_per_stage) != num_layers:
+            raise ValueError(
+                "time_layers_per_stage length must equal num_layers, got "
+                f"{len(time_layers_per_stage)} and {num_layers}"
+            )
+        if len(time_global_stage_mask) != num_layers:
+            raise ValueError(
+                "time_global_stage_mask length must equal num_layers, got "
+                f"{len(time_global_stage_mask)} and {num_layers}"
+            )
+        if any(layer_count <= 0 for layer_count in camera_layers_per_stage):
+            raise ValueError(
+                "camera_layers_per_stage must contain only positive integers"
+            )
+        if any(layer_count <= 0 for layer_count in time_layers_per_stage):
+            raise ValueError(
+                "time_layers_per_stage must contain only positive integers"
+            )
+
+    @staticmethod
+    def _normalize_stage_ints(
+        values: Sequence[int] | None,
+        *,
+        num_layers: int,
+        default_value: int,
+    ) -> tuple[int, ...]:
+        if values is None:
+            return tuple(default_value for _ in range(num_layers))
+        return tuple(int(value) for value in values)
+
+    @staticmethod
+    def _normalize_stage_mask(
+        values: Sequence[bool] | None,
+        *,
+        num_layers: int,
+    ) -> tuple[bool, ...]:
+        if values is None:
+            return tuple(False for _ in range(num_layers))
+        return tuple(bool(value) for value in values)
 
     @staticmethod
     def _validate_rope_dim(*, rope_dim: int, head_dim: int) -> None:
@@ -197,6 +293,10 @@ class PLCSMultiViewAxialModel(nn.Module):
             hidden_dim=int(model_cfg.get("hidden_dim", 256)),
             num_layers=int(model_cfg.get("num_layers", 6)),
             num_heads=int(model_cfg.get("num_heads", 8)),
+            attention_type=cast(
+                Literal["mha", "gqa"], str(model_cfg.get("attention_type", "mha"))
+            ),
+            num_kv_heads=model_cfg.get("num_kv_heads", None),
             ffn_dim=model_cfg.get("ffn_dim", None),
             dropout=float(model_cfg.get("dropout", 0.1)),
             rope_dim=model_cfg.get("rope_dim", None),
@@ -217,6 +317,10 @@ class PLCSMultiViewAxialModel(nn.Module):
                     "num_court_tokens", data_cfg.get("num_court_kp", NUM_COURT_KP)
                 )
             ),
+            time_window_radius=int(model_cfg.get("time_window_radius", 16)),
+            camera_layers_per_stage=model_cfg.get("camera_layers_per_stage", None),
+            time_layers_per_stage=model_cfg.get("time_layers_per_stage", None),
+            time_global_stage_mask=model_cfg.get("time_global_stage_mask", None),
         )
 
     @staticmethod
@@ -232,6 +336,21 @@ class PLCSMultiViewAxialModel(nn.Module):
             valid_fixed.shape[1],
         )
         return attn_mask, valid_fixed
+
+    @staticmethod
+    def _build_sliding_attn_mask(valid: Tensor, radius: int) -> Tensor:
+        return build_local_attention_keep_mask(valid, radius)
+
+    def _use_global_time_attention(
+        self,
+        *,
+        stage_index: int,
+        time_layer_index: int,
+        time_layers_in_stage: int,
+    ) -> bool:
+        return self.time_global_stage_mask[stage_index] and (
+            time_layer_index == time_layers_in_stage - 1
+        )
 
     @staticmethod
     def _build_token_positions(*, seq_len: int, n_cams: int) -> Tensor:
@@ -269,6 +388,30 @@ class PLCSMultiViewAxialModel(nn.Module):
                 self.rope_dim // 2,
             )
             .reshape(batch_size * n_cams, seq_len, self.rope_dim // 2)
+        )
+
+    def _apply_time_attention_layer(
+        self,
+        x: Tensor,
+        *,
+        time_layer: TransformerBlock,
+        use_global_attention: bool,
+        time_full_mask: Tensor,
+        sliding_mask: Tensor,
+        time_freqs: Tensor,
+    ) -> Tensor:
+        batch_size, seq_len, n_cams, _ = x.shape
+        x_time = x.permute(0, 2, 1, 3).reshape(
+            batch_size * n_cams, seq_len, self.hidden_dim
+        )
+        attn_mask = time_full_mask if use_global_attention else sliding_mask
+        x_time = time_layer(
+            x_time,
+            freqs_cis=time_freqs,
+            attn_mask=attn_mask,
+        )
+        return x_time.reshape(batch_size, n_cams, seq_len, self.hidden_dim).permute(
+            0, 2, 1, 3
         )
 
     def forward(
@@ -326,7 +469,7 @@ class PLCSMultiViewAxialModel(nn.Module):
             batch_size * n_cams, seq_len_in
         )
         camera_mask, _ = self._build_self_attn_mask(camera_valid)
-        time_mask, _ = self._build_self_attn_mask(time_valid)
+        time_mask, time_valid = self._build_self_attn_mask(time_valid)
         camera_freqs = self._camera_freqs(
             batch_size=batch_size,
             seq_len=seq_len_in,
@@ -337,31 +480,41 @@ class PLCSMultiViewAxialModel(nn.Module):
             seq_len=seq_len_in,
             n_cams=n_cams,
         )
+        sliding_mask = self._build_sliding_attn_mask(
+            time_valid,
+            radius=self.time_window_radius,
+        )
 
-        for camera_layer, time_layer in zip(
-            self.camera_layers,
-            self.time_layers,
-            strict=True,
+        for stage_index, (camera_stage_layers, time_stage_layers) in enumerate(
+            zip(
+                self.camera_layers,
+                self.time_layers,
+                strict=True,
+            )
         ):
-            x_camera = x.reshape(batch_size * seq_len_in, n_cams, self.hidden_dim)
-            x_camera = camera_layer(
-                x_camera,
-                freqs_cis=camera_freqs,
-                attn_mask=camera_mask,
-            )
-            x = x_camera.reshape(batch_size, seq_len_in, n_cams, self.hidden_dim)
+            for camera_layer in camera_stage_layers:
+                x_camera = x.reshape(batch_size * seq_len_in, n_cams, self.hidden_dim)
+                x_camera = camera_layer(
+                    x_camera,
+                    freqs_cis=camera_freqs,
+                    attn_mask=camera_mask,
+                )
+                x = x_camera.reshape(batch_size, seq_len_in, n_cams, self.hidden_dim)
 
-            x_time = x.permute(0, 2, 1, 3).reshape(
-                batch_size * n_cams, seq_len_in, self.hidden_dim
-            )
-            x_time = time_layer(
-                x_time,
-                freqs_cis=time_freqs,
-                attn_mask=time_mask,
-            )
-            x = x_time.reshape(batch_size, n_cams, seq_len_in, self.hidden_dim).permute(
-                0, 2, 1, 3
-            )
+            time_layers_in_stage = len(time_stage_layers)
+            for time_layer_index, time_layer in enumerate(time_stage_layers):
+                x = self._apply_time_attention_layer(
+                    x,
+                    time_layer=time_layer,
+                    use_global_attention=self._use_global_time_attention(
+                        stage_index=stage_index,
+                        time_layer_index=time_layer_index,
+                        time_layers_in_stage=time_layers_in_stage,
+                    ),
+                    time_full_mask=time_mask,
+                    sliding_mask=sliding_mask,
+                    time_freqs=time_freqs,
+                )
 
         x = x[:, :, 0, :]
         x = self.final_norm(x)

--- a/src/utils/models/components/attention.py
+++ b/src/utils/models/components/attention.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
+from src.utils.models.components.ops.time_local import time_local_attention
 from src.utils.models.components.rope import apply_rotary_emb
 
 
@@ -134,6 +135,9 @@ class MultiHeadSelfAttention(nn.Module):
         *,
         freqs_cis: torch.Tensor | None = None,
         attn_mask: torch.Tensor | None = None,
+        local_valid_mask: torch.Tensor | None = None,
+        local_window_radius: int | None = None,
+        local_use_cuda: bool | None = None,
     ) -> torch.Tensor:
         """
         Args:
@@ -159,8 +163,56 @@ class MultiHeadSelfAttention(nn.Module):
         k_ = k.transpose(1, 2)  # (B, H, k_len, D)
         v_ = v.transpose(1, 2)  # (B, H, k_len, D)
 
-        sdpa_mask: torch.Tensor | None = None
+        if local_valid_mask is not None:
+            if local_window_radius is None:
+                raise ValueError(
+                    "local_window_radius must be set when local_valid_mask is provided"
+                )
+            out = time_local_attention(
+                q_,
+                k_,
+                v_,
+                valid_mask=local_valid_mask,
+                window_radius=local_window_radius,
+                dropout_p=self.attn_dropout,
+                training=self.training,
+                use_cuda=local_use_cuda,
+            )
+        else:
+            sdpa_mask: torch.Tensor | None = None
+            if attn_mask is not None:
+                sdpa_mask = _normalize_attn_mask(
+                    attn_mask,
+                    q_len=q_len,
+                    k_len=k_len,
+                    device=x.device,
+                    dtype=x.dtype,
+                )
+            out = F.scaled_dot_product_attention(
+                q_,
+                k_,
+                v_,
+                attn_mask=sdpa_mask,
+                dropout_p=self.attn_dropout if self.training else 0.0,
+                is_causal=False,
+            )
 
+        out = (
+            out.transpose(1, 2)
+            .contiguous()
+            .view(bsz, q_len, self.n_heads * self.head_dim)
+        )
+        return self.wo(out)
+
+    def _sdpa_mask(
+        self,
+        attn_mask: torch.Tensor | None,
+        *,
+        q_len: int,
+        k_len: int,
+        x: torch.Tensor,
+    ) -> torch.Tensor | None:
+        sdpa_mask: torch.Tensor | None = None
         if attn_mask is not None:
             sdpa_mask = _normalize_attn_mask(
                 attn_mask,
@@ -169,21 +221,7 @@ class MultiHeadSelfAttention(nn.Module):
                 device=x.device,
                 dtype=x.dtype,
             )
-
-        out = F.scaled_dot_product_attention(
-            q_,
-            k_,
-            v_,
-            attn_mask=sdpa_mask,
-            dropout_p=self.attn_dropout if self.training else 0.0,
-            is_causal=False,
-        )
-        out = (
-            out.transpose(1, 2)
-            .contiguous()
-            .view(bsz, q_len, self.n_heads * self.head_dim)
-        )
-        return self.wo(out)
+        return sdpa_mask
 
 
 class GroupedQuerySelfAttention(nn.Module):
@@ -268,6 +306,9 @@ class GroupedQuerySelfAttention(nn.Module):
         *,
         freqs_cis: torch.Tensor | None = None,
         attn_mask: torch.Tensor | None = None,
+        local_valid_mask: torch.Tensor | None = None,
+        local_window_radius: int | None = None,
+        local_use_cuda: bool | None = None,
     ) -> torch.Tensor:
         """
         Args:
@@ -292,6 +333,62 @@ class GroupedQuerySelfAttention(nn.Module):
         key = key.transpose(1, 2)
         value = value.transpose(1, 2)
 
+        if local_valid_mask is not None:
+            if local_window_radius is None:
+                raise ValueError(
+                    "local_window_radius must be set when local_valid_mask is provided"
+                )
+            key_local = key
+            value_local = value
+            if self.n_kv_heads != self.n_heads:
+                repeats = self.n_heads // self.n_kv_heads
+                key_local = key_local.repeat_interleave(repeats, dim=1)
+                value_local = value_local.repeat_interleave(repeats, dim=1)
+            out = time_local_attention(
+                query,
+                key_local,
+                value_local,
+                valid_mask=local_valid_mask,
+                window_radius=local_window_radius,
+                dropout_p=self.attn_dropout,
+                training=self.training,
+                use_cuda=local_use_cuda,
+            )
+        else:
+            sdpa_mask: torch.Tensor | None = None
+            if attn_mask is not None:
+                sdpa_mask = _normalize_attn_mask(
+                    attn_mask,
+                    q_len=q_len,
+                    k_len=k_len,
+                    device=x.device,
+                    dtype=x.dtype,
+                )
+            out = F.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=sdpa_mask,
+                dropout_p=self.attn_dropout if self.training else 0.0,
+                is_causal=False,
+                enable_gqa=self.n_kv_heads != self.n_heads,
+            )
+
+        out = (
+            out.transpose(1, 2)
+            .contiguous()
+            .view(bsz, q_len, self.n_heads * self.head_dim)
+        )
+        return self.wo(out)
+
+    def _sdpa_mask(
+        self,
+        attn_mask: torch.Tensor | None,
+        *,
+        q_len: int,
+        k_len: int,
+        x: torch.Tensor,
+    ) -> torch.Tensor | None:
         sdpa_mask: torch.Tensor | None = None
         if attn_mask is not None:
             sdpa_mask = _normalize_attn_mask(
@@ -301,22 +398,7 @@ class GroupedQuerySelfAttention(nn.Module):
                 device=x.device,
                 dtype=x.dtype,
             )
-
-        out = F.scaled_dot_product_attention(
-            query,
-            key,
-            value,
-            attn_mask=sdpa_mask,
-            dropout_p=self.attn_dropout if self.training else 0.0,
-            is_causal=False,
-            enable_gqa=self.n_kv_heads != self.n_heads,
-        )
-        out = (
-            out.transpose(1, 2)
-            .contiguous()
-            .view(bsz, q_len, self.n_heads * self.head_dim)
-        )
-        return self.wo(out)
+        return sdpa_mask
 
 
 class MultiHeadCrossAttention(nn.Module):

--- a/src/utils/models/components/block.py
+++ b/src/utils/models/components/block.py
@@ -94,11 +94,17 @@ class TransformerBlock(nn.Module):
         *,
         freqs_cis: torch.Tensor | None = None,
         attn_mask: torch.Tensor | None = None,
+        local_valid_mask: torch.Tensor | None = None,
+        local_window_radius: int | None = None,
+        local_use_cuda: bool | None = None,
     ) -> torch.Tensor:
         x_attn = x + self.attn(
             self.attn_norm(x),
             freqs_cis=freqs_cis,
             attn_mask=attn_mask,
+            local_valid_mask=local_valid_mask,
+            local_window_radius=local_window_radius,
+            local_use_cuda=local_use_cuda,
         )
         x_fnn = x_attn + self.ffn(self.ffn_norm(x_attn))
         return x_fnn

--- a/src/utils/models/components/ops/loader.py
+++ b/src/utils/models/components/ops/loader.py
@@ -37,8 +37,9 @@ def require_moe_cuda_extension() -> ModuleType:
     if extension is None:
         raise RuntimeError(
             "MoE CUDA extension is not available. Build it with "
-            "`TENNIS_LAB_BUILD_CUDA_OPS=1 .venv/bin/python -m pip install -e . "
-            "--no-build-isolation`, or call the API with use_cuda=False."
+            "`TENNIS_LAB_BUILD_CUDA_OPS=1 uv pip install -e . "
+            "--no-build-isolation --python .venv/bin/python`, or call the API "
+            "with use_cuda=False."
         )
     return extension
 
@@ -48,7 +49,8 @@ def require_time_local_cuda_extension() -> ModuleType:
     if extension is None:
         raise RuntimeError(
             "Time-local CUDA extension is not available. Build it with "
-            "`TENNIS_LAB_BUILD_CUDA_OPS=1 .venv/bin/python -m pip install -e . "
-            "--no-build-isolation`, or call the local-attention API with use_cuda=False."
+            "`TENNIS_LAB_BUILD_CUDA_OPS=1 uv pip install -e . "
+            "--no-build-isolation --python .venv/bin/python`, or call the "
+            "local-attention API with use_cuda=False."
         )
     return extension

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -131,6 +131,7 @@ SMOKE_TASK_SPECS = (
             "model.num_heads=4",
             "model.ffn_dim=64",
             "model.max_seq_len=64",
+            *BLCS_AXIAL_STAGE_OVERRIDES,
         ),
         variants=(
             SmokeVariant(name="single"),
@@ -464,6 +465,7 @@ SMOKE_TASK_SPECS = (
             "model.num_heads=4",
             "model.ffn_dim=64",
             "model.max_seq_len=64",
+            *BLCS_AXIAL_STAGE_OVERRIDES,
         ),
         variants=(
             SmokeVariant(name="multiview"),

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -11,6 +11,7 @@ from hydra.core.global_hydra import GlobalHydra
 from lightning_fabric.utilities.exceptions import MisconfigurationException
 from omegaconf import DictConfig
 
+from src.tasks.blcs.models.blcs_axial_model import BLCSAxialModel
 from src.tasks.blcs.models.blcs_multiview_axial_model import BLCSMultiViewAxialModel
 from src.tasks.blcs.training.runner import BLCSTrainingRunner
 from src.tasks.court_detection.training.runner import CourtDetectionTrainingRunner
@@ -100,6 +101,10 @@ BLCS_AXIAL_STAGE_GLOBAL_OVERRIDES = (
     "model.time_global_stage_mask=[true,false]",
 )
 
+BLCS_SINGLE_AXIAL_LAYER_OVERRIDES = (
+    "model.time_global_layer_mask=[false,false]",
+)
+
 PLCS_AXIAL_STAGE_OVERRIDES = (
     "model.camera_layers_per_stage=[1,1]",
     "model.time_layers_per_stage=[1,1]",
@@ -129,6 +134,30 @@ SMOKE_TASK_SPECS = (
         ),
         variants=(
             SmokeVariant(name="single"),
+            SmokeVariant(
+                name="axial",
+                overrides=(
+                    "model=axial",
+                    *BLCS_SINGLE_AXIAL_LAYER_OVERRIDES,
+                ),
+            ),
+            SmokeVariant(
+                name="axial_gqa",
+                overrides=(
+                    "model=axial",
+                    *BLCS_SINGLE_AXIAL_LAYER_OVERRIDES,
+                    "model.attention_type=gqa",
+                    "model.num_kv_heads=2",
+                ),
+            ),
+            SmokeVariant(
+                name="axial_sliding_global",
+                overrides=(
+                    "model=axial",
+                    "model.time_global_layer_mask=[true,false]",
+                    "model.time_window_radius=4",
+                ),
+            ),
             SmokeVariant(
                 name="single_gan",
                 overrides=(
@@ -538,6 +567,26 @@ def test_blcs_multiview_axial_stage_schedule_validation(
 
     with pytest.raises(ValueError, match=match):
         BLCSMultiViewAxialModel.from_config(config)
+
+
+def test_blcs_axial_layer_mask_validation() -> None:
+    GlobalHydra.instance().clear()
+    config_overrides = [
+        _normalize_override("model=axial"),
+        _normalize_override("model.num_layers=2"),
+        _normalize_override("model.time_global_layer_mask=[true]"),
+    ]
+    with initialize_config_dir(
+        version_base="1.3",
+        config_dir=str(REPO_ROOT / "src/tasks/blcs/configs"),
+    ):
+        config = compose(config_name="train", overrides=config_overrides)
+
+    with pytest.raises(
+        ValueError,
+        match="time_global_layer_mask length must equal num_layers",
+    ):
+        BLCSAxialModel.from_config(config)
 
 
 @pytest.mark.parametrize(

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -14,6 +14,7 @@ from omegaconf import DictConfig
 from src.tasks.blcs.models.blcs_multiview_axial_model import BLCSMultiViewAxialModel
 from src.tasks.blcs.training.runner import BLCSTrainingRunner
 from src.tasks.court_detection.training.runner import CourtDetectionTrainingRunner
+from src.tasks.plcs.models.plcs_multiview_axial_model import PLCSMultiViewAxialModel
 from src.tasks.plcs.training.runner import PLCSTrainingRunner
 
 RunnerFactory = Any  # Callable[[DictConfig], runner_instance]
@@ -94,6 +95,18 @@ BLCS_AXIAL_STAGE_OVERRIDES = (
 )
 
 BLCS_AXIAL_STAGE_GLOBAL_OVERRIDES = (
+    "model.camera_layers_per_stage=[1,1]",
+    "model.time_layers_per_stage=[1,1]",
+    "model.time_global_stage_mask=[true,false]",
+)
+
+PLCS_AXIAL_STAGE_OVERRIDES = (
+    "model.camera_layers_per_stage=[1,1]",
+    "model.time_layers_per_stage=[1,1]",
+    "model.time_global_stage_mask=[false,false]",
+)
+
+PLCS_AXIAL_STAGE_GLOBAL_OVERRIDES = (
     "model.camera_layers_per_stage=[1,1]",
     "model.time_layers_per_stage=[1,1]",
     "model.time_global_stage_mask=[true,false]",
@@ -255,6 +268,20 @@ SMOKE_TASK_SPECS = (
                     "loss=multiview_sequence",
                     "data.seq_len_range=[16,16]",
                     "model.max_seq_len=64",
+                    *PLCS_AXIAL_STAGE_OVERRIDES,
+                ),
+            ),
+            SmokeVariant(
+                name="multiview_axial_gqa",
+                overrides=(
+                    "model=multiview_axial",
+                    "data=multiview",
+                    "loss=multiview_sequence",
+                    "data.seq_len_range=[16,16]",
+                    "model.max_seq_len=64",
+                    *PLCS_AXIAL_STAGE_OVERRIDES,
+                    "model.attention_type=gqa",
+                    "model.num_kv_heads=2",
                 ),
             ),
             SmokeVariant(
@@ -265,8 +292,8 @@ SMOKE_TASK_SPECS = (
                     "loss=multiview_sequence",
                     "data.seq_len_range=[16,16]",
                     "model.max_seq_len=64",
+                    *PLCS_AXIAL_STAGE_GLOBAL_OVERRIDES,
                     "model.time_window_radius=4",
-                    "model.time_global_every=2",
                 ),
             ),
             SmokeVariant(
@@ -277,6 +304,7 @@ SMOKE_TASK_SPECS = (
                     "loss=multiview_sequence",
                     "data.seq_len_range=[16,16]",
                     "model.max_seq_len=64",
+                    *PLCS_AXIAL_STAGE_OVERRIDES,
                     "model.predict_canonical_pose=true",
                     "loss.canonical_pose_weight=0.1",
                 ),
@@ -291,6 +319,7 @@ SMOKE_TASK_SPECS = (
                     "data.seq_len_range=[16,16]",
                     "data.num_court_kp=12",
                     "model.max_seq_len=64",
+                    *PLCS_AXIAL_STAGE_OVERRIDES,
                 ),
             ),
         ),
@@ -509,6 +538,50 @@ def test_blcs_multiview_axial_stage_schedule_validation(
 
     with pytest.raises(ValueError, match=match):
         BLCSMultiViewAxialModel.from_config(config)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    (
+        (
+            (
+                "model.num_layers=2",
+                "model.camera_layers_per_stage=[2]",
+                "model.time_layers_per_stage=[3,2]",
+                "model.time_global_stage_mask=[true,false]",
+            ),
+            "camera_layers_per_stage length must equal num_layers",
+        ),
+        (
+            (
+                "model.num_layers=2",
+                "model.camera_layers_per_stage=[2,1]",
+                "model.time_layers_per_stage=[3,2]",
+                "model.time_global_stage_mask=[true]",
+            ),
+            "time_global_stage_mask length must equal num_layers",
+        ),
+    ),
+)
+def test_plcs_multiview_axial_stage_schedule_validation(
+    overrides: tuple[str, ...],
+    match: str,
+) -> None:
+    GlobalHydra.instance().clear()
+    config_overrides = [
+        _normalize_override("model=multiview_axial"),
+        _normalize_override("data=multiview"),
+        _normalize_override("loss=multiview_sequence"),
+        *(_normalize_override(override) for override in overrides),
+    ]
+    with initialize_config_dir(
+        version_base="1.3",
+        config_dir=str(REPO_ROOT / "src/tasks/plcs/configs"),
+    ):
+        config = compose(config_name="train", overrides=config_overrides)
+
+    with pytest.raises(ValueError, match=match):
+        PLCSMultiViewAxialModel.from_config(config)
 
 
 def _normalize_override(override: str) -> str:


### PR DESCRIPTION
## 概要

PLCS/BLCS の axial multi-view model で、local time attention が CUDA tensor 上では `time_local` CUDA extension を使うようにします。
あわせて CUDA ops のビルド手順と確認方法を README/docs に追加し、未ビルド時の案内メッセージも `uv pip install` ベースに更新します。

## 変更内容

- `MultiHeadSelfAttention` / `GroupedQuerySelfAttention` / `TransformerBlock` に local time attention 用の引数を追加しました。
- PLCS/BLCS axial multi-view model の local time attention を mask-based SDPA から `time_local_attention` 呼び出しへ切り替えました。
- `docs/cuda_ops.md` を追加し、CUDA ops の前提条件、ビルド、ロード確認、time-local CUDA path の検証方法、トラブルシュートを整理しました。
- ルート `README.md` から CUDA ops ビルド手順へリンクしました。
- CUDA extension 未ビルド時のエラーメッセージを `.venv/bin/python -m pip` ではなく `uv pip install ... --python .venv/bin/python` の手順に更新しました。
- BLCS smoke の小型 axial 設定で、`num_layers=2` と stage schedule の長さが一致するようにしました。

## 検証

- `TENNIS_LAB_BUILD_CUDA_OPS=1 uv pip install -e . --no-build-isolation --python .venv/bin/python`
- `.venv/bin/python -m ruff check README.md docs/cuda_ops.md src/utils/models/components/ops/loader.py tests/tasks/test_training_smoke_contracts.py`
- `.venv/bin/python -m pytest -q tests/tasks/test_training_smoke_contracts.py -k 'plcs or blcs'`
  - `32 passed, 3 deselected`
- `time_local_attention(..., use_cuda=True)` の forward/backward が `cuda:0` で成功することを確認しました。
- PLCS/BLCS axial model の forward 経由で `cuda_time_local_attention` が呼ばれることを確認しました。

## 関連Issue

なし

## 補足

CUDA ops の `.so`、`htmlcov/`、`coverage.xml` は生成物として gitignore 済みのためコミットしていません。
