### PR TITLE
Tennis Scene の Court KP pipeline を修正

### DIFF
--- a/src/tasks/court_detection/inference/predictor.py
+++ b/src/tasks/court_detection/inference/predictor.py
@@ -70,6 +70,8 @@ class CourtKeypointPredictor(BasePredictor):
         lightning_module = CourtDetectionLightningModule.load_from_checkpoint(
             checkpoints[0],
             map_location=resolved_device,
+            weights_only=bool(kwargs.pop("weights_only", False)),
+            **kwargs,
         )
 
         model = lightning_module.model

--- a/src/tasks/court_detection/models/__init__.py
+++ b/src/tasks/court_detection/models/__init__.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from torch import nn
+
 from src.tasks.court_detection.models.court_fpn import CourtFPN
+from src.tasks.court_detection.models.court_unet import CourtUNet
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
-__all__ = ["CourtFPN", "build_court_detection_model"]
+__all__ = ["CourtFPN", "CourtUNet", "build_court_detection_model"]
 
 
-def build_court_detection_model(config: DictConfig) -> CourtFPN:
+def build_court_detection_model(config: DictConfig) -> nn.Module:
     """Build a court detection model from config.
 
     The number of output channels comes from ``config.model.num_classes``.
@@ -38,4 +41,10 @@ def build_court_detection_model(config: DictConfig) -> CourtFPN:
             f"but got {num_classes}.",
         )
 
+    model_name = str(model_cfg.get("name", "court_fpn"))
+    if model_name.startswith("court_unet"):
+        return CourtUNet(
+            in_channels=int(model_cfg.get("in_channels", 3)),
+            num_classes=num_classes,
+        )
     return CourtFPN.from_config(config)

--- a/src/tasks/court_detection/models/court_unet.py
+++ b/src/tasks/court_detection/models/court_unet.py
@@ -1,0 +1,114 @@
+"""Legacy 2-D U-Net for court detection checkpoints."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from src.tasks.court_detection.models.blocks import Conv2dWiseWiseBlock
+
+
+class EncoderBlock2d(nn.Module):
+    """Encoder stage producing a skip connection."""
+
+    def __init__(self, in_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.block = Conv2dWiseWiseBlock(in_channels, out_channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.block(x)
+
+
+class DecoderBlock2d(nn.Module):
+    """Decoder stage that fuses an upsampled tensor with a skip tensor."""
+
+    def __init__(self, in_channels: int, skip_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.block = Conv2dWiseWiseBlock(in_channels + skip_channels, out_channels)
+
+    def forward(self, x: torch.Tensor, skip: torch.Tensor) -> torch.Tensor:
+        if x.shape[-2:] != skip.shape[-2:]:
+            x = F.interpolate(
+                x,
+                size=skip.shape[-2:],
+                mode="bilinear",
+                align_corners=False,
+            )
+        return self.block(torch.cat([x, skip], dim=1))
+
+
+class CourtUNet(nn.Module):
+    """Legacy full-resolution U-Net used by older court detection checkpoints."""
+
+    def __init__(self, in_channels: int = 3, num_classes: int = 7) -> None:
+        super().__init__()
+        self.stem = nn.Sequential(
+            nn.Conv2d(
+                in_channels,
+                in_channels,
+                kernel_size=3,
+                stride=2,
+                padding=1,
+                bias=False,
+            ),
+            nn.BatchNorm2d(in_channels),
+            nn.ReLU(inplace=True),
+        )
+
+        self.enc1 = EncoderBlock2d(in_channels, 64)
+        self.enc2 = EncoderBlock2d(64, 128)
+        self.enc3 = EncoderBlock2d(128, 256)
+
+        self.bottleneck_1 = Conv2dWiseWiseBlock(256, 512)
+        self.bottleneck_2 = Conv2dWiseWiseBlock(512, 512)
+
+        self.dec3 = DecoderBlock2d(512, 256, 256)
+        self.dec2 = DecoderBlock2d(256, 128, 128)
+        self.dec1 = DecoderBlock2d(128, 64, 64)
+
+        self.pool = nn.MaxPool2d(kernel_size=2, stride=2)
+        self.upsample = nn.Upsample(
+            scale_factor=2,
+            mode="bilinear",
+            align_corners=False,
+        )
+        self.pre_head_upsample = nn.Upsample(
+            scale_factor=2,
+            mode="bilinear",
+            align_corners=False,
+        )
+        self.final_conv = nn.Conv2d(64, num_classes, kernel_size=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        input_hw = x.shape[-2:]
+
+        x = self.stem(x)
+        s1 = self.enc1(x)
+        x = self.pool(s1)
+        s2 = self.enc2(x)
+        x = self.pool(s2)
+        s3 = self.enc3(x)
+        x = self.pool(s3)
+
+        x = self.bottleneck_2(self.bottleneck_1(x))
+
+        x = self.upsample(x)
+        x = self.dec3(x, s3)
+        x = self.upsample(x)
+        x = self.dec2(x, s2)
+        x = self.upsample(x)
+        x = self.dec1(x, s1)
+
+        x = self.pre_head_upsample(x)
+        if x.shape[-2:] != input_hw:
+            x = F.interpolate(
+                x,
+                size=input_hw,
+                mode="bilinear",
+                align_corners=False,
+            )
+        return self.final_conv(x)
+
+
+__all__ = ["CourtUNet", "DecoderBlock2d", "EncoderBlock2d"]

--- a/src/tennis_scene/README.md
+++ b/src/tennis_scene/README.md
@@ -61,12 +61,13 @@ python -m src.tennis_scene.scripts.run_pipeline \
 ### Court KPをUIで入力
 
 手動入力UIを使う場合は `manual_ui` を指定します。結果JSONは `court_kp.output_path` に保存されます。
+手動入力された1フレーム分のCourt KPは、対象フレーム列へ展開されます。
 
 ```bash
 python -m src.tennis_scene.scripts.run_pipeline \
     video_path=inputs/demo/match.mp4 \
     court_kp.mode=manual_ui \
-    court_kp.output_path=outputs/tennis_scene/court_kp_result.json
+    court_kp.output_path=outputs/tennis_scene/court_kp_sequence_result.json
 ```
 
 ### GVHMRスキップ（デバッグ用）
@@ -98,7 +99,7 @@ python -m src.tennis_scene.scripts.run_pipeline \
 | `device` | 推論デバイス | `cuda` |
 | `max_frames` | 最大フレーム数 | `null`（全フレーム） |
 | `court_kp.checkpoint` | Court KPモデル | `outputs/court_detection/checkpoints/last.ckpt` |
-| `court_kp.frame_index` | Court KP検出フレーム | `0` |
+| `court_kp.frame_index` | Court KP推論開始フレーム | `0` |
 | `court_kp.mode` | Court KPの入力モード（`model`/`manual_ui`） | `model` |
 
 ### GVHMR設定

--- a/src/tennis_scene/configs/pipeline.yaml
+++ b/src/tennis_scene/configs/pipeline.yaml
@@ -10,11 +10,11 @@ device: cuda
 
 court_kp:
   checkpoint: outputs/court_detection/checkpoints/last.ckpt
-  frame_index: 0
+  frame_index: 0  # Start frame for per-frame court KP inference
   mode: manual_ui  # model/manual_ui
   save_result: true
-  output_path: ${output_dir}/court_kp_result.json
-  load_path: null  # Path to load pre-computed result (skips inference)
+  output_path: ${output_dir}/court_kp_sequence_result.json
+  load_path: null  # Path to load pre-computed sequence result (skips inference)
 
 gvhmr:
   checkpoint: third_party/GVHMR/inputs/checkpoints/gvhmr/gvhmr_siga24_release.ckpt

--- a/src/tennis_scene/configs/pipeline.yaml
+++ b/src/tennis_scene/configs/pipeline.yaml
@@ -10,11 +10,12 @@ device: cuda
 
 court_kp:
   checkpoint: outputs/court_detection/checkpoints/last.ckpt
-  frame_index: 0  # Start frame for per-frame court KP inference
+  annotation_frame_index: 0  # Frame shown in manual_ui mode, then repeated across T
   mode: manual_ui  # model/manual_ui
+  num_keypoints: 14
   save_result: true
-  output_path: ${output_dir}/court_kp_sequence_result.json
-  load_path: null  # Path to load pre-computed sequence result (skips inference)
+  output_path: ${output_dir}/court_kp_result.json
+  load_path: null  # Path to load pre-computed result (skips inference)
 
 gvhmr:
   checkpoint: third_party/GVHMR/inputs/checkpoints/gvhmr/gvhmr_siga24_release.ckpt

--- a/src/tennis_scene/io.py
+++ b/src/tennis_scene/io.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import json
+import warnings
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-import warnings
 
 import numpy as np
 from numpy.typing import NDArray
@@ -17,6 +17,7 @@ class SceneResult:
     """Result of tennis scene 3D reconstruction.
 
     Player-related arrays use (P, T, ...) as the canonical shape.
+    Court keypoints use (T, K, 2) when inferred per frame.
     """
 
     num_frames: int
@@ -24,8 +25,8 @@ class SceneResult:
     width: int
     height: int
 
-    court_kp: NDArray[np.float32]
-    court_vis: NDArray[np.float32]
+    court_kp: NDArray[np.float32]  # (T, K, 2) or legacy (K, 2)
+    court_vis: NDArray[np.float32]  # (T, K) or legacy (K,)
 
     player_position: NDArray[np.float32]  # (P, T, 3)
     player_yaw: NDArray[np.float32]  # (P, T)
@@ -94,7 +95,7 @@ class SceneResult:
                 json.dump(self.metadata, f, ensure_ascii=False, indent=2)
 
     @classmethod
-    def load(cls, path: str | Path) -> "SceneResult":
+    def load(cls, path: str | Path) -> SceneResult:
         path = Path(path)
         try:
             data = np.load(path, allow_pickle=False)
@@ -105,6 +106,7 @@ class SceneResult:
                     "Falling back to allow_pickle=True."
                 ),
                 RuntimeWarning,
+                stacklevel=2,
             )
             data = np.load(path, allow_pickle=True)
 
@@ -121,6 +123,7 @@ class SceneResult:
                         "Proceeding without metadata."
                     ),
                     RuntimeWarning,
+                    stacklevel=2,
                 )
         elif "metadata" in data.files:
             # Legacy npz fallback
@@ -130,6 +133,7 @@ class SceneResult:
                 warnings.warn(
                     f"Failed to load metadata from {path}: {exc}. Proceeding without metadata.",
                     RuntimeWarning,
+                    stacklevel=2,
                 )
 
         # Primary fields (new canonical names).
@@ -193,8 +197,8 @@ if __name__ == "__main__":
         fps=30.0,
         width=1920,
         height=1080,
-        court_kp=np.random.rand(20, 2).astype(np.float32),
-        court_vis=np.ones(20, dtype=np.float32),
+        court_kp=np.random.rand(T, 20, 2).astype(np.float32),
+        court_vis=np.ones((T, 20), dtype=np.float32),
         player_position=np.random.rand(P, T, 3).astype(np.float32),
         player_yaw=np.random.rand(P, T).astype(np.float32),
         smpl_body_pose=np.random.rand(P, T, 63).astype(np.float32),

--- a/src/tennis_scene/io.py
+++ b/src/tennis_scene/io.py
@@ -17,7 +17,7 @@ class SceneResult:
     """Result of tennis scene 3D reconstruction.
 
     Player-related arrays use (P, T, ...) as the canonical shape.
-    Court keypoints use (T, K, 2) when inferred per frame.
+    Court keypoints use (T, K, 2).
     """
 
     num_frames: int
@@ -25,8 +25,8 @@ class SceneResult:
     width: int
     height: int
 
-    court_kp: NDArray[np.float32]  # (T, K, 2) or legacy (K, 2)
-    court_vis: NDArray[np.float32]  # (T, K) or legacy (K,)
+    court_kp: NDArray[np.float32]  # (T, K, 2)
+    court_vis: NDArray[np.float32]  # (T, K)
 
     player_position: NDArray[np.float32]  # (P, T, 3)
     player_yaw: NDArray[np.float32]  # (P, T)

--- a/src/tennis_scene/pipeline/components/__init__.py
+++ b/src/tennis_scene/pipeline/components/__init__.py
@@ -11,6 +11,7 @@ from src.tennis_scene.pipeline.components.court_kp import (
     CourtKPConfig,
     CourtKPModule,
     CourtKPResult,
+    CourtKPSequenceResult,
 )
 from src.tennis_scene.pipeline.components.gvhmr import (
     GVHMRConfig,
@@ -28,6 +29,7 @@ __all__ = [
     "CourtKPConfig",
     "CourtKPModule",
     "CourtKPResult",
+    "CourtKPSequenceResult",
     "GVHMRConfig",
     "GVHMRModule",
     "GVHMRResult",

--- a/src/tennis_scene/pipeline/components/__init__.py
+++ b/src/tennis_scene/pipeline/components/__init__.py
@@ -11,7 +11,6 @@ from src.tennis_scene.pipeline.components.court_kp import (
     CourtKPConfig,
     CourtKPModule,
     CourtKPResult,
-    CourtKPSequenceResult,
 )
 from src.tennis_scene.pipeline.components.gvhmr import (
     GVHMRConfig,
@@ -29,7 +28,6 @@ __all__ = [
     "CourtKPConfig",
     "CourtKPModule",
     "CourtKPResult",
-    "CourtKPSequenceResult",
     "GVHMRConfig",
     "GVHMRModule",
     "GVHMRResult",

--- a/src/tennis_scene/pipeline/components/blcs.py
+++ b/src/tennis_scene/pipeline/components/blcs.py
@@ -162,9 +162,9 @@ class BLCSModule(BasePipelineModule):
 
         Args:
             ball_uv: Ball 2D positions (T, 2), normalized [0, 1].
-            court_kp: Court keypoints (20, 2), normalized [0, 1].
+            court_kp: Court keypoints, shape (T, K, 2), normalized [0, 1].
             ball_vis: Ball visibility mask (T,).
-            court_vis: Court keypoint visibility (20,).
+            court_vis: Court keypoint visibility, shape (T, K).
 
         Returns:
             BLCSResult with 3D ball trajectory.
@@ -189,7 +189,28 @@ class BLCSModule(BasePipelineModule):
         else:
             effective_vis = np.ones(len(ball_uv), dtype=bool)
 
-        # BLCS models expect batched inputs: (B, T, 2), (B, 20, 2), (B, T), (B, 20).
+        if court_kp.ndim != 3:
+            raise ValueError(
+                f"court_kp must have shape (T, K, 2), got {court_kp.shape}"
+            )
+        if court_kp.shape[0] != len(ball_uv):
+            raise ValueError(
+                "court_kp temporal length must match ball_uv T, "
+                f"got {court_kp.shape[0]} and {len(ball_uv)}"
+            )
+        if court_vis is not None:
+            if court_vis.ndim != 2:
+                raise ValueError(
+                    f"court_vis must have shape (T, K), got {court_vis.shape}"
+                )
+            if court_vis.shape[0] != len(ball_uv):
+                raise ValueError(
+                    "court_vis temporal length must match ball_uv T, "
+                    f"got {court_vis.shape[0]} and {len(ball_uv)}"
+                )
+
+        # BLCS models expect batched inputs:
+        # (B, T, 2), (B, T, K, 2), (B, T), and optional court_vis.
         ball_uv_t = torch.from_numpy(ball_uv).float().unsqueeze(0)
         court_kp_t = torch.from_numpy(court_kp).float().unsqueeze(0)
 

--- a/src/tennis_scene/pipeline/components/court_kp.py
+++ b/src/tennis_scene/pipeline/components/court_kp.py
@@ -8,9 +8,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+import cv2
 import numpy as np
 
 from src.tennis_scene.pipeline.components.base import BasePipelineModule
+from src.utils.video import OpenCVVideoFrameReader, probe_video_info, read_video_frame
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -28,6 +30,7 @@ class CourtKPConfig:
         checkpoint_path: Path to model checkpoint.
         mode: Detection mode ("model", "manual_ui").
         device: Inference device.
+        num_keypoints: Number of court keypoints expected from the predictor/UI.
         save_result: Whether to save result to file.
         output_path: Path to save result JSON file.
         load_path: Path to load pre-computed result from (skips inference).
@@ -37,6 +40,7 @@ class CourtKPConfig:
     checkpoint_path: str | Path
     mode: Literal["model", "manual_ui"] = "model"
     device: str = "cuda"
+    num_keypoints: int = NUM_COURT_KEYPOINTS
     save_result: bool = False
     output_path: str | Path | None = None
     load_path: str | Path | None = None
@@ -44,70 +48,6 @@ class CourtKPConfig:
 
 @dataclass
 class CourtKPResult:
-    """Result of court keypoint detection.
-
-    Attributes:
-        keypoints: Court keypoints (14, 2), normalized [0, 1].
-        frame_index: Frame index used for detection.
-
-    """
-
-    keypoints: NDArray[np.float32]
-    frame_index: int
-
-    def to_dict(self) -> dict:
-        """Convert result to JSON-serializable dict."""
-        return {
-            "keypoints": self.keypoints.tolist(),
-            "frame_index": self.frame_index,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> CourtKPResult:
-        """Create result from dict."""
-        return cls(
-            keypoints=np.array(data["keypoints"], dtype=np.float32),
-            frame_index=data["frame_index"],
-        )
-
-    def save(self, path: str | Path) -> None:
-        """Save result to JSON file."""
-        path = Path(path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("w", encoding="utf-8") as f:
-            json.dump(self.to_dict(), f, indent=2)
-        LOGGER.info(f"Saved CourtKP result to {path}")
-
-    def validate(self) -> tuple[bool, list[str]]:
-        """Validate result content.
-
-        Returns:
-            Tuple of (is_valid, errors).
-        """
-        errors: list[str] = []
-        if self.keypoints.shape != (NUM_COURT_KEYPOINTS, 2):
-            errors.append(
-                f"keypoints shape must be ({NUM_COURT_KEYPOINTS}, 2), "
-                f"got {self.keypoints.shape}"
-            )
-        if self.frame_index < 0:
-            errors.append(f"frame_index must be non-negative, got {self.frame_index}")
-        if not np.isfinite(self.keypoints).all():
-            errors.append("keypoints contain non-finite values")
-        tol = 1e-6
-        if np.any(self.keypoints < -tol) or np.any(self.keypoints > 1.0 + tol):
-            errors.append("keypoints must be normalized to [0, 1]")
-        return len(errors) == 0, errors
-
-    @classmethod
-    def load(cls, path: str | Path) -> CourtKPResult:
-        """Load result from JSON file."""
-        with Path(path).open("r", encoding="utf-8") as f:
-            return cls.from_dict(json.load(f))
-
-
-@dataclass
-class CourtKPSequenceResult:
     """Result of court keypoint detection over a video sequence.
 
     Attributes:
@@ -130,13 +70,17 @@ class CourtKPSequenceResult:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> CourtKPSequenceResult:
+    def from_dict(cls, data: dict) -> CourtKPResult:
         """Create result from dict."""
         keypoints = np.array(data["keypoints"], dtype=np.float32)
+        if keypoints.ndim == 2:
+            keypoints = keypoints[None, ...]
         if "visibility" in data:
             visibility = np.array(data["visibility"], dtype=np.float32)
         else:
             visibility = np.ones(keypoints.shape[:2], dtype=np.float32)
+        if visibility.ndim == 1:
+            visibility = visibility[None, ...]
         if "frame_indices" in data:
             frame_indices = np.array(data["frame_indices"], dtype=np.int32)
         elif "frame_index" in data:
@@ -149,37 +93,40 @@ class CourtKPSequenceResult:
             frame_indices=frame_indices,
         )
 
-    @classmethod
-    def from_single(cls, result: CourtKPResult) -> CourtKPSequenceResult:
-        """Create a one-frame sequence result from a single-frame result."""
-        return cls(
-            keypoints=result.keypoints[None, ...].astype(np.float32),
-            visibility=np.ones((1, result.keypoints.shape[0]), dtype=np.float32),
-            frame_indices=np.array([result.frame_index], dtype=np.int32),
-        )
-
     def save(self, path: str | Path) -> None:
         """Save result to JSON file."""
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", encoding="utf-8") as f:
             json.dump(self.to_dict(), f, indent=2)
-        LOGGER.info(f"Saved CourtKP sequence result to {path}")
+        LOGGER.info(f"Saved CourtKP result to {path}")
 
-    def validate(self) -> tuple[bool, list[str]]:
+    def validate(
+        self,
+        *,
+        num_keypoints: int | None = NUM_COURT_KEYPOINTS,
+    ) -> tuple[bool, list[str]]:
         """Validate result content.
 
         Returns:
             Tuple of (is_valid, errors).
         """
         errors: list[str] = []
-        if self.keypoints.ndim != 3 or self.keypoints.shape[1:] != (
-            NUM_COURT_KEYPOINTS,
-            2,
+        if num_keypoints is not None and num_keypoints <= 0:
+            errors.append(f"num_keypoints must be positive, got {num_keypoints}")
+        expected_shape = None
+        if num_keypoints is not None and num_keypoints > 0:
+            expected_shape = (num_keypoints, 2)
+        if self.keypoints.ndim != 3 or (
+            expected_shape is not None and self.keypoints.shape[1:] != expected_shape
         ):
+            expected_text = (
+                f"(T, {num_keypoints}, 2)"
+                if num_keypoints is not None
+                else "(T, K, 2)"
+            )
             errors.append(
-                "keypoints shape must be "
-                f"(T, {NUM_COURT_KEYPOINTS}, 2), got {self.keypoints.shape}"
+                f"keypoints shape must be {expected_text}, got {self.keypoints.shape}"
             )
         if self.visibility.shape != self.keypoints.shape[:2]:
             errors.append(
@@ -203,20 +150,16 @@ class CourtKPSequenceResult:
         return len(errors) == 0, errors
 
     @classmethod
-    def load(cls, path: str | Path) -> CourtKPSequenceResult:
+    def load(cls, path: str | Path) -> CourtKPResult:
         """Load result from JSON file."""
         with Path(path).open("r", encoding="utf-8") as f:
-            data = json.load(f)
-        keypoints = np.array(data["keypoints"], dtype=np.float32)
-        if keypoints.ndim == 2:
-            return cls.from_single(CourtKPResult.from_dict(data))
-        return cls.from_dict(data)
+            return cls.from_dict(json.load(f))
 
 
 class CourtKPModule(BasePipelineModule):
     """Court keypoint detection module.
 
-    Detects 14 court keypoints from a single frame.
+    Detects 14 court keypoints for each frame in a video.
 
     Attributes:
         config: Configuration for the module.
@@ -240,6 +183,9 @@ class CourtKPModule(BasePipelineModule):
         self.checkpoint_path = Path(self.config.checkpoint_path)
         self.mode = self.config.mode
         self.device = self.config.device
+        self.num_keypoints = int(self.config.num_keypoints)
+        if self.num_keypoints <= 0:
+            raise ValueError(f"num_keypoints must be positive, got {self.num_keypoints}")
         self._predictor = None
         self._manual_keypoints: NDArray[np.float32] | None = None
         self._manual_needs_normalization = False
@@ -277,13 +223,13 @@ class CourtKPModule(BasePipelineModule):
         except ImportError as exc:
             raise ImportError("OpenCV is required for manual_ui mode.") from exc
 
-        keypoints = np.zeros((NUM_COURT_KEYPOINTS, 2), dtype=np.float32)
-        placed = np.zeros(NUM_COURT_KEYPOINTS, dtype=bool)
+        keypoints = np.zeros((self.num_keypoints, 2), dtype=np.float32)
+        placed = np.zeros(self.num_keypoints, dtype=bool)
         current_idx = 0
 
         def draw_overlay(image: NDArray[np.uint8]) -> NDArray[np.uint8]:
             overlay = image.copy()
-            for idx in range(NUM_COURT_KEYPOINTS):
+            for idx in range(self.num_keypoints):
                 if not placed[idx]:
                     continue
                 x, y = keypoints[idx]
@@ -301,7 +247,7 @@ class CourtKPModule(BasePipelineModule):
                 )
             cv2.putText(
                 overlay,
-                f"Keypoint {current_idx}/{NUM_COURT_KEYPOINTS - 1}",
+                f"Keypoint {current_idx}/{self.num_keypoints - 1}",
                 (10, 20),
                 cv2.FONT_HERSHEY_SIMPLEX,
                 0.6,
@@ -326,7 +272,7 @@ class CourtKPModule(BasePipelineModule):
             if event == cv2.EVENT_LBUTTONDOWN:
                 keypoints[current_idx] = [mx, my]
                 placed[current_idx] = True
-                current_idx = (current_idx + 1) % NUM_COURT_KEYPOINTS
+                current_idx = (current_idx + 1) % self.num_keypoints
 
         window_name = "Court Keypoints (manual_ui)"
         cv2.namedWindow(window_name, cv2.WINDOW_NORMAL)
@@ -339,9 +285,9 @@ class CourtKPModule(BasePipelineModule):
                 key = cv2.waitKey(30) & 0xFF
 
                 if key in {ord("n"), ord(" "), 82}:
-                    current_idx = (current_idx + 1) % NUM_COURT_KEYPOINTS
+                    current_idx = (current_idx + 1) % self.num_keypoints
                 elif key in {ord("p"), 84}:
-                    current_idx = (current_idx - 1) % NUM_COURT_KEYPOINTS
+                    current_idx = (current_idx - 1) % self.num_keypoints
                 elif key == ord("c"):
                     keypoints[current_idx] = [0.0, 0.0]
                     placed[current_idx] = False
@@ -355,84 +301,162 @@ class CourtKPModule(BasePipelineModule):
 
     def process(
         self,
-        frame: NDArray[np.uint8],
-        frame_index: int = 0,
-        image_width: int | None = None,
-        image_height: int | None = None,
+        video_path: str | Path,
+        max_frames: int | None = None,
+        annotation_frame_index: int = 0,
     ) -> CourtKPResult:
-        """Detect court keypoints from a frame.
+        """Detect court keypoints over a video sequence.
 
         Args:
-            frame: RGB frame array (H, W, 3).
-            frame_index: Frame index (for metadata).
-            image_width: Image width for normalization.
-            image_height: Image height for normalization.
+            video_path: Path to input video.
+            max_frames: Maximum frames to return from the beginning of the video.
+            annotation_frame_index: Frame to annotate in manual UI mode.
 
         Returns:
-            CourtKPResult with normalized keypoints.
+            CourtKPResult with normalized keypoints shaped (T, K, 2).
 
         """
-        # Check if we should load from pre-computed result
         if self.config.load_path is not None:
             load_path = Path(self.config.load_path)
             if load_path.exists():
                 LOGGER.info(
                     f"Loading CourtKP result from {load_path} (skipping detection)"
                 )
-                return CourtKPResult.load(load_path)
+                result = CourtKPResult.load(load_path)
+                is_valid, errors = result.validate(num_keypoints=self.num_keypoints)
+                if not is_valid:
+                    raise ValueError(f"Invalid CourtKP result: {errors}")
+                return result
             LOGGER.warning(
                 f"load_path specified but not found: {load_path}, running detection"
             )
 
         if self.mode == "manual_ui":
-            if not self.is_loaded:
-                self.load()
-
-            if self._manual_keypoints is None:
-                self._collect_manual_keypoints_ui(frame)
-
-            keypoints = np.array(self._manual_keypoints, copy=True)
-
-            if self._manual_needs_normalization:
-                if image_width is None or image_height is None:
-                    raise ValueError(
-                        "image_width and image_height are required to normalize "
-                        "manual keypoints."
-                    )
-                keypoints[..., 0] /= max(image_width - 1, 1)
-                keypoints[..., 1] /= max(image_height - 1, 1)
-
-            result = CourtKPResult(
-                keypoints=keypoints.astype(np.float32),
-                frame_index=frame_index,
+            result = self._process_manual_video(
+                video_path,
+                max_frames=max_frames,
+                annotation_frame_index=annotation_frame_index,
             )
+        else:
+            result = self._process_model_video(video_path, max_frames=max_frames)
 
-            if self.config.save_result and self.config.output_path is not None:
-                result.save(self.config.output_path)
-
-            return result
-
-        if not self.is_loaded:
-            self.load()
-
-        pred = self._predictor.predict(frame)
-
-        # Convert tensors to numpy arrays
-        keypoints = pred["keypoints"].numpy().astype(np.float32)
-
-        if image_width is not None and image_height is not None:
-            keypoints[..., 0] /= max(image_width - 1, 1)
-            keypoints[..., 1] /= max(image_height - 1, 1)
-
-        result = CourtKPResult(
-            keypoints=keypoints,
-            frame_index=frame_index,
-        )
+        is_valid, errors = result.validate(num_keypoints=self.num_keypoints)
+        if not is_valid:
+            raise ValueError(f"Invalid CourtKP result: {errors}")
 
         if self.config.save_result and self.config.output_path is not None:
             result.save(self.config.output_path)
 
         return result
+
+    def _process_manual_video(
+        self,
+        video_path: str | Path,
+        *,
+        max_frames: int | None,
+        annotation_frame_index: int,
+    ) -> CourtKPResult:
+        """Annotate one frame and repeat it across the selected sequence."""
+        if annotation_frame_index < 0:
+            raise ValueError(
+                "annotation_frame_index must be non-negative, "
+                f"got {annotation_frame_index}"
+            )
+
+        video_info = probe_video_info(video_path)
+        if annotation_frame_index >= video_info.frame_count:
+            raise ValueError(
+                f"annotation_frame_index={annotation_frame_index} is outside video "
+                f"with {video_info.frame_count} frames"
+            )
+
+        num_frames = video_info.frame_count
+        if max_frames is not None:
+            num_frames = min(num_frames, int(max_frames))
+        if num_frames <= 0:
+            raise ValueError(f"No frames selected for CourtKP result: {video_path}")
+
+        packet = read_video_frame(video_path, annotation_frame_index)
+        frame_rgb = cv2.cvtColor(packet.frame, cv2.COLOR_BGR2RGB)
+
+        if not self.is_loaded:
+            self.load()
+
+        if self._manual_keypoints is None:
+            self._collect_manual_keypoints_ui(frame_rgb)
+
+        keypoints = np.array(self._manual_keypoints, copy=True)
+
+        if self._manual_needs_normalization:
+            image_width, image_height = packet.original_size
+            keypoints[..., 0] /= max(image_width - 1, 1)
+            keypoints[..., 1] /= max(image_height - 1, 1)
+
+        keypoints = np.repeat(
+            keypoints[None, ...].astype(np.float32),
+            repeats=num_frames,
+            axis=0,
+        )
+        return CourtKPResult(
+            keypoints=keypoints,
+            visibility=np.ones(keypoints.shape[:2], dtype=np.float32),
+            frame_indices=np.arange(num_frames, dtype=np.int32),
+        )
+
+    def _process_model_video(
+        self,
+        video_path: str | Path,
+        *,
+        max_frames: int | None,
+    ) -> CourtKPResult:
+        """Run model inference for every selected video frame."""
+        if not self.is_loaded:
+            self.load()
+
+        keypoints: list[NDArray[np.float32]] = []
+        frame_indices: list[int] = []
+        for packet in OpenCVVideoFrameReader(video_path, max_frames=max_frames):
+            frame_rgb = cv2.cvtColor(packet.frame, cv2.COLOR_BGR2RGB)
+            frame_keypoints = self._predict_frame(
+                frame_rgb,
+                image_width=packet.original_size[0],
+                image_height=packet.original_size[1],
+            )
+            keypoints.append(frame_keypoints)
+            frame_indices.append(packet.index)
+
+        if not keypoints:
+            raise RuntimeError(f"No frames were read from video: {video_path}")
+
+        stacked = np.stack(keypoints, axis=0).astype(np.float32)
+        return CourtKPResult(
+            keypoints=stacked,
+            visibility=np.ones(stacked.shape[:2], dtype=np.float32),
+            frame_indices=np.array(frame_indices, dtype=np.int32),
+        )
+
+    def _predict_frame(
+        self,
+        frame_rgb: NDArray[np.uint8],
+        *,
+        image_width: int,
+        image_height: int,
+    ) -> NDArray[np.float32]:
+        """Run the loaded model on one RGB frame and return normalized keypoints."""
+        if self._predictor is None:
+            raise RuntimeError("Court KP predictor is not loaded.")
+        pred = self._predictor.predict(frame_rgb)
+
+        raw_keypoints = pred["keypoints"]
+        if hasattr(raw_keypoints, "detach"):
+            raw_keypoints = raw_keypoints.detach().cpu().numpy()
+        elif hasattr(raw_keypoints, "numpy"):
+            raw_keypoints = raw_keypoints.numpy()
+        keypoints = np.asarray(raw_keypoints, dtype=np.float32)
+
+        keypoints[..., 0] /= max(image_width - 1, 1)
+        keypoints[..., 1] /= max(image_height - 1, 1)
+        return keypoints.astype(np.float32)
 
 
 if __name__ == "__main__":

--- a/src/tennis_scene/pipeline/components/court_kp.py
+++ b/src/tennis_scene/pipeline/components/court_kp.py
@@ -47,8 +47,7 @@ class CourtKPResult:
     """Result of court keypoint detection.
 
     Attributes:
-        keypoints: Court keypoints (20, 2), normalized [0, 1].
-        visibility: Keypoint visibility (20,).
+        keypoints: Court keypoints (14, 2), normalized [0, 1].
         frame_index: Frame index used for detection.
 
     """
@@ -87,11 +86,17 @@ class CourtKPResult:
         """
         errors: list[str] = []
         if self.keypoints.shape != (NUM_COURT_KEYPOINTS, 2):
-            errors.append(f"keypoints shape must be ({NUM_COURT_KEYPOINTS}, 2), got {self.keypoints.shape}")
+            errors.append(
+                f"keypoints shape must be ({NUM_COURT_KEYPOINTS}, 2), "
+                f"got {self.keypoints.shape}"
+            )
         if self.frame_index < 0:
             errors.append(f"frame_index must be non-negative, got {self.frame_index}")
         if not np.isfinite(self.keypoints).all():
             errors.append("keypoints contain non-finite values")
+        tol = 1e-6
+        if np.any(self.keypoints < -tol) or np.any(self.keypoints > 1.0 + tol):
+            errors.append("keypoints must be normalized to [0, 1]")
         return len(errors) == 0, errors
 
     @classmethod
@@ -101,10 +106,117 @@ class CourtKPResult:
             return cls.from_dict(json.load(f))
 
 
+@dataclass
+class CourtKPSequenceResult:
+    """Result of court keypoint detection over a video sequence.
+
+    Attributes:
+        keypoints: Court keypoints (T, 14, 2), normalized [0, 1].
+        visibility: Court keypoint visibility flags (T, 14).
+        frame_indices: Source frame indices aligned with T.
+
+    """
+
+    keypoints: NDArray[np.float32]
+    visibility: NDArray[np.float32]
+    frame_indices: NDArray[np.int32]
+
+    def to_dict(self) -> dict:
+        """Convert result to JSON-serializable dict."""
+        return {
+            "keypoints": self.keypoints.tolist(),
+            "visibility": self.visibility.tolist(),
+            "frame_indices": self.frame_indices.tolist(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> CourtKPSequenceResult:
+        """Create result from dict."""
+        keypoints = np.array(data["keypoints"], dtype=np.float32)
+        if "visibility" in data:
+            visibility = np.array(data["visibility"], dtype=np.float32)
+        else:
+            visibility = np.ones(keypoints.shape[:2], dtype=np.float32)
+        if "frame_indices" in data:
+            frame_indices = np.array(data["frame_indices"], dtype=np.int32)
+        elif "frame_index" in data:
+            frame_indices = np.array([data["frame_index"]], dtype=np.int32)
+        else:
+            frame_indices = np.arange(keypoints.shape[0], dtype=np.int32)
+        return cls(
+            keypoints=keypoints,
+            visibility=visibility,
+            frame_indices=frame_indices,
+        )
+
+    @classmethod
+    def from_single(cls, result: CourtKPResult) -> CourtKPSequenceResult:
+        """Create a one-frame sequence result from a single-frame result."""
+        return cls(
+            keypoints=result.keypoints[None, ...].astype(np.float32),
+            visibility=np.ones((1, result.keypoints.shape[0]), dtype=np.float32),
+            frame_indices=np.array([result.frame_index], dtype=np.int32),
+        )
+
+    def save(self, path: str | Path) -> None:
+        """Save result to JSON file."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(self.to_dict(), f, indent=2)
+        LOGGER.info(f"Saved CourtKP sequence result to {path}")
+
+    def validate(self) -> tuple[bool, list[str]]:
+        """Validate result content.
+
+        Returns:
+            Tuple of (is_valid, errors).
+        """
+        errors: list[str] = []
+        if self.keypoints.ndim != 3 or self.keypoints.shape[1:] != (
+            NUM_COURT_KEYPOINTS,
+            2,
+        ):
+            errors.append(
+                "keypoints shape must be "
+                f"(T, {NUM_COURT_KEYPOINTS}, 2), got {self.keypoints.shape}"
+            )
+        if self.visibility.shape != self.keypoints.shape[:2]:
+            errors.append(
+                "visibility shape must match keypoints[:2], "
+                f"got {self.visibility.shape} for {self.keypoints.shape}"
+            )
+        if self.frame_indices.shape != (self.keypoints.shape[0],):
+            errors.append(
+                "frame_indices shape must match (T,), "
+                f"got {self.frame_indices.shape} for T={self.keypoints.shape[0]}"
+            )
+        if not np.isfinite(self.keypoints).all():
+            errors.append("keypoints contain non-finite values")
+        if not np.isfinite(self.visibility).all():
+            errors.append("visibility contains non-finite values")
+        tol = 1e-6
+        if np.any(self.keypoints < -tol) or np.any(self.keypoints > 1.0 + tol):
+            errors.append("keypoints must be normalized to [0, 1]")
+        if np.any(self.visibility < -tol) or np.any(self.visibility > 1.0 + tol):
+            errors.append("visibility must be normalized to [0, 1]")
+        return len(errors) == 0, errors
+
+    @classmethod
+    def load(cls, path: str | Path) -> CourtKPSequenceResult:
+        """Load result from JSON file."""
+        with Path(path).open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        keypoints = np.array(data["keypoints"], dtype=np.float32)
+        if keypoints.ndim == 2:
+            return cls.from_single(CourtKPResult.from_dict(data))
+        return cls.from_dict(data)
+
+
 class CourtKPModule(BasePipelineModule):
     """Court keypoint detection module.
 
-    Detects 14 court keypoints from a single frame (fixed camera assumption).
+    Detects 14 court keypoints from a single frame.
 
     Attributes:
         config: Configuration for the module.
@@ -189,7 +301,7 @@ class CourtKPModule(BasePipelineModule):
                 )
             cv2.putText(
                 overlay,
-                f"Keypoint {current_idx}/19",
+                f"Keypoint {current_idx}/{NUM_COURT_KEYPOINTS - 1}",
                 (10, 20),
                 cv2.FONT_HERSHEY_SIMPLEX,
                 0.6,
@@ -241,7 +353,6 @@ class CourtKPModule(BasePipelineModule):
         self._manual_keypoints = keypoints.astype(np.float32)
         self._manual_needs_normalization = True
 
-
     def process(
         self,
         frame: NDArray[np.uint8],
@@ -265,10 +376,13 @@ class CourtKPModule(BasePipelineModule):
         if self.config.load_path is not None:
             load_path = Path(self.config.load_path)
             if load_path.exists():
-                LOGGER.info(f"Loading CourtKP result from {load_path} (skipping detection)")
+                LOGGER.info(
+                    f"Loading CourtKP result from {load_path} (skipping detection)"
+                )
                 return CourtKPResult.load(load_path)
-            else:
-                LOGGER.warning(f"load_path specified but not found: {load_path}, running detection")
+            LOGGER.warning(
+                f"load_path specified but not found: {load_path}, running detection"
+            )
 
         if self.mode == "manual_ui":
             if not self.is_loaded:
@@ -285,8 +399,8 @@ class CourtKPModule(BasePipelineModule):
                         "image_width and image_height are required to normalize "
                         "manual keypoints."
                     )
-                keypoints[..., 0] /= image_width
-                keypoints[..., 1] /= image_height
+                keypoints[..., 0] /= max(image_width - 1, 1)
+                keypoints[..., 1] /= max(image_height - 1, 1)
 
             result = CourtKPResult(
                 keypoints=keypoints.astype(np.float32),
@@ -307,8 +421,8 @@ class CourtKPModule(BasePipelineModule):
         keypoints = pred["keypoints"].numpy().astype(np.float32)
 
         if image_width is not None and image_height is not None:
-            keypoints[..., 0] /= image_width
-            keypoints[..., 1] /= image_height
+            keypoints[..., 0] /= max(image_width - 1, 1)
+            keypoints[..., 1] /= max(image_height - 1, 1)
 
         result = CourtKPResult(
             keypoints=keypoints,

--- a/src/tennis_scene/pipeline/components/plcs.py
+++ b/src/tennis_scene/pipeline/components/plcs.py
@@ -160,9 +160,9 @@ class PLCSModule(BasePipelineModule):
 
         Args:
             human_kp_2d: Human 2D keypoints, shape (P, T, 17, 2), normalized [0, 1].
-            court_kp: Court keypoints (20, 2), normalized [0, 1].
+            court_kp: Court keypoints, shape (T, K, 2), normalized [0, 1].
             human_kp_vis: Human keypoint visibility, shape (P, T, 17).
-            court_vis: Court keypoint visibility (20,).
+            court_vis: Court keypoint visibility, shape (T, K).
             track_ids: Optional track IDs aligned with P.
 
         Returns:
@@ -202,12 +202,38 @@ class PLCSModule(BasePipelineModule):
         batch_size = num_players * num_frames
 
         court_kp_t = torch.from_numpy(court_kp).float()
-        court_kp_batch = court_kp_t.unsqueeze(0).repeat(batch_size, 1, 1)
+        if court_kp_t.dim() != 3:
+            raise ValueError(
+                f"court_kp must have shape (T, K, 2), got {tuple(court_kp_t.shape)}"
+            )
+        if court_kp_t.shape[0] != num_frames:
+            raise ValueError(
+                "court_kp temporal length must match human_kp_2d T, "
+                f"got {court_kp_t.shape[0]} and {num_frames}"
+            )
+        court_kp_batch = (
+            court_kp_t.unsqueeze(0)
+            .expand(num_players, num_frames, *court_kp_t.shape[1:])
+            .reshape(batch_size, *court_kp_t.shape[1:])
+        )
 
         court_vis_batch = None
         if court_vis is not None:
             court_vis_t = torch.from_numpy(court_vis).float()
-            court_vis_batch = court_vis_t.unsqueeze(0).repeat(batch_size, 1)
+            if court_vis_t.dim() != 2:
+                raise ValueError(
+                    f"court_vis must have shape (T, K), got {tuple(court_vis_t.shape)}"
+                )
+            if court_vis_t.shape[0] != num_frames:
+                raise ValueError(
+                    "court_vis temporal length must match human_kp_2d T, "
+                    f"got {court_vis_t.shape[0]} and {num_frames}"
+                )
+            court_vis_batch = (
+                court_vis_t.unsqueeze(0)
+                .expand(num_players, num_frames, court_vis_t.shape[1])
+                .reshape(batch_size, court_vis_t.shape[1])
+            )
 
         human_kp_t = torch.from_numpy(human_kp_2d).float().reshape(
             batch_size, 17, 2

--- a/src/tennis_scene/pipeline/orchestrator.py
+++ b/src/tennis_scene/pipeline/orchestrator.py
@@ -8,29 +8,22 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import cv2
-import numpy as np
-
 from src.tennis_scene.io import SceneResult
 from src.tennis_scene.pipeline.components.ball_detection import (
     BallDetectionConfig,
     BallDetectionModule,
 )
 from src.tennis_scene.pipeline.components.blcs import BLCSConfig, BLCSModule
-from src.tennis_scene.pipeline.components.court_kp import (
-    CourtKPConfig,
-    CourtKPModule,
-    CourtKPSequenceResult,
-)
+from src.tennis_scene.pipeline.components.court_kp import CourtKPConfig, CourtKPModule
 from src.tennis_scene.pipeline.components.plcs import PLCSConfig, PLCSModule
 from src.tennis_scene.pipeline.dependency_graph import (
     ResolutionResult,
     Stage,
     build_default_dependency_graph,
 )
+from src.utils.video import probe_video_info
 
 if TYPE_CHECKING:
-    from numpy.typing import NDArray
     from omegaconf import DictConfig
 
 LOGGER = logging.getLogger(__name__)
@@ -89,8 +82,9 @@ class TennisSceneOrchestrator:
                 checkpoint_path=to_absolute_path(cfg.court_kp.checkpoint),
                 mode=str(cfg.court_kp.get("mode", "model")),
                 device=device,
+                num_keypoints=int(cfg.court_kp.get("num_keypoints", 14)),
                 save_result=cfg.court_kp.get("save_result", True),
-                output_path=get_output_path("court_kp", "court_kp_sequence_result.json"),
+                output_path=get_output_path("court_kp", "court_kp_result.json"),
                 load_path=get_load_path("court_kp"),
             )
         )
@@ -260,134 +254,20 @@ class TennisSceneOrchestrator:
         if Stage.BLCS in self.enabled_stages and self.blcs_module is not None:
             self.blcs_module.load()
 
-    def _read_video_info(self, video_path: Path) -> dict[str, Any]:
-        cap = cv2.VideoCapture(str(video_path))
-        if not cap.isOpened():
-            raise RuntimeError(f"Failed to open video: {video_path}")
-        try:
-            fps = cap.get(cv2.CAP_PROP_FPS)
-            width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-            height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-            num_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        finally:
-            cap.release()
-        return {"fps": fps, "width": width, "height": height, "num_frames": num_frames}
-
-    def _read_frame(self, video_path: Path, frame_idx: int) -> NDArray[np.uint8]:
-        cap = cv2.VideoCapture(str(video_path))
-        if not cap.isOpened():
-            raise RuntimeError(f"Failed to open video: {video_path}")
-        try:
-            cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
-            ret, frame = cap.read()
-            if not ret:
-                raise RuntimeError(f"Failed to read frame {frame_idx}")
-            return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-        finally:
-            cap.release()
-
-    def _run_court_kp_sequence(
-        self,
-        video_path: Path,
-        *,
-        start_frame: int,
-        max_frames: int | None,
-        image_width: int,
-        image_height: int,
-        total_frames: int,
-    ) -> CourtKPSequenceResult:
-        load_path = self.court_kp_module.config.load_path
-        if load_path is not None and Path(load_path).exists():
-            LOGGER.info(f"Loading CourtKP sequence result from: {load_path}")
-            return CourtKPSequenceResult.load(load_path)
-
-        if start_frame < 0:
-            raise ValueError(f"court_kp start_frame must be non-negative, got {start_frame}")
-        if start_frame >= total_frames:
-            raise ValueError(
-                f"court_kp start_frame={start_frame} is outside video with "
-                f"{total_frames} frames"
-            )
-
-        end_frame = total_frames
-        if max_frames is not None:
-            end_frame = min(end_frame, start_frame + max_frames)
-        if end_frame <= start_frame:
-            raise ValueError(
-                f"No frames selected for court KP inference: start={start_frame}, "
-                f"end={end_frame}"
-            )
-
-        LOGGER.info(
-            "Running Court KP detection for frames "
-            f"[{start_frame}, {end_frame}) ({end_frame - start_frame} frames)..."
-        )
-        previous_save_result = self.court_kp_module.config.save_result
-        previous_load_path = self.court_kp_module.config.load_path
-        self.court_kp_module.config.save_result = False
-        self.court_kp_module.config.load_path = None
-        try:
-            keypoints: list[NDArray[np.float32]] = []
-            frame_indices: list[int] = []
-
-            cap = cv2.VideoCapture(str(video_path))
-            if not cap.isOpened():
-                raise RuntimeError(f"Failed to open video: {video_path}")
-            try:
-                cap.set(cv2.CAP_PROP_POS_FRAMES, start_frame)
-                for frame_idx in range(start_frame, end_frame):
-                    ret, frame = cap.read()
-                    if not ret:
-                        raise RuntimeError(f"Failed to read frame {frame_idx}")
-                    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                    result = self.court_kp_module.process(
-                        frame_rgb,
-                        frame_index=frame_idx,
-                        image_width=image_width,
-                        image_height=image_height,
-                    )
-                    keypoints.append(result.keypoints)
-                    frame_indices.append(frame_idx)
-            finally:
-                cap.release()
-        finally:
-            self.court_kp_module.config.save_result = previous_save_result
-            self.court_kp_module.config.load_path = previous_load_path
-
-        sequence_result = CourtKPSequenceResult(
-            keypoints=np.stack(keypoints, axis=0).astype(np.float32),
-            visibility=np.ones(
-                (len(keypoints), keypoints[0].shape[0]),
-                dtype=np.float32,
-            ),
-            frame_indices=np.array(frame_indices, dtype=np.int32),
-        )
-        is_valid, errors = sequence_result.validate()
-        if not is_valid:
-            raise ValueError(f"Invalid CourtKP sequence result: {errors}")
-
-        output_path = self.court_kp_module.config.output_path
-        if previous_save_result and output_path is not None:
-            sequence_result.save(output_path)
-        return sequence_result
-
     def run(
         self,
         video_path: str | Path,
         max_frames: int | None = None,
-        court_kp_frame: int = 0,
+        court_kp_annotation_frame: int = 0,
     ) -> SceneResult:
         video_path = Path(video_path)
-        video_info = self._read_video_info(video_path)
-        width, height = video_info["width"], video_info["height"]
+        video_info = probe_video_info(video_path)
+        width, height = video_info.width, video_info.height
 
-        court_result = self._run_court_kp_sequence(
+        court_result = self.court_kp_module.process(
             video_path,
-            start_frame=court_kp_frame,
             max_frames=max_frames,
-            image_width=width,
-            image_height=height,
-            total_frames=video_info["num_frames"],
+            annotation_frame_index=court_kp_annotation_frame,
         )
         court_kp = court_result.keypoints
         court_vis = court_result.visibility
@@ -446,7 +326,7 @@ class TennisSceneOrchestrator:
 
         return SceneResult(
             num_frames=T,
-            fps=video_info["fps"],
+            fps=video_info.fps,
             width=width,
             height=height,
             court_kp=court_kp,
@@ -465,7 +345,7 @@ class TennisSceneOrchestrator:
             player_track_ids=track_ids,
             metadata={
                 "video_path": str(video_path),
-                "court_kp_start_frame": court_kp_frame,
+                "court_kp_annotation_frame": court_kp_annotation_frame,
                 "court_kp_frame_indices": court_result.frame_indices.tolist(),
                 "track_ids": track_ids.tolist(),
                 "enabled_stages": [stage.value for stage in self.execution_order],

--- a/src/tennis_scene/pipeline/orchestrator.py
+++ b/src/tennis_scene/pipeline/orchestrator.py
@@ -17,7 +17,11 @@ from src.tennis_scene.pipeline.components.ball_detection import (
     BallDetectionModule,
 )
 from src.tennis_scene.pipeline.components.blcs import BLCSConfig, BLCSModule
-from src.tennis_scene.pipeline.components.court_kp import CourtKPConfig, CourtKPModule
+from src.tennis_scene.pipeline.components.court_kp import (
+    CourtKPConfig,
+    CourtKPModule,
+    CourtKPSequenceResult,
+)
 from src.tennis_scene.pipeline.components.plcs import PLCSConfig, PLCSModule
 from src.tennis_scene.pipeline.dependency_graph import (
     ResolutionResult,
@@ -86,7 +90,7 @@ class TennisSceneOrchestrator:
                 mode=str(cfg.court_kp.get("mode", "model")),
                 device=device,
                 save_result=cfg.court_kp.get("save_result", True),
-                output_path=get_output_path("court_kp", "court_kp_result.json"),
+                output_path=get_output_path("court_kp", "court_kp_sequence_result.json"),
                 load_path=get_load_path("court_kp"),
             )
         )
@@ -282,6 +286,91 @@ class TennisSceneOrchestrator:
         finally:
             cap.release()
 
+    def _run_court_kp_sequence(
+        self,
+        video_path: Path,
+        *,
+        start_frame: int,
+        max_frames: int | None,
+        image_width: int,
+        image_height: int,
+        total_frames: int,
+    ) -> CourtKPSequenceResult:
+        load_path = self.court_kp_module.config.load_path
+        if load_path is not None and Path(load_path).exists():
+            LOGGER.info(f"Loading CourtKP sequence result from: {load_path}")
+            return CourtKPSequenceResult.load(load_path)
+
+        if start_frame < 0:
+            raise ValueError(f"court_kp start_frame must be non-negative, got {start_frame}")
+        if start_frame >= total_frames:
+            raise ValueError(
+                f"court_kp start_frame={start_frame} is outside video with "
+                f"{total_frames} frames"
+            )
+
+        end_frame = total_frames
+        if max_frames is not None:
+            end_frame = min(end_frame, start_frame + max_frames)
+        if end_frame <= start_frame:
+            raise ValueError(
+                f"No frames selected for court KP inference: start={start_frame}, "
+                f"end={end_frame}"
+            )
+
+        LOGGER.info(
+            "Running Court KP detection for frames "
+            f"[{start_frame}, {end_frame}) ({end_frame - start_frame} frames)..."
+        )
+        previous_save_result = self.court_kp_module.config.save_result
+        previous_load_path = self.court_kp_module.config.load_path
+        self.court_kp_module.config.save_result = False
+        self.court_kp_module.config.load_path = None
+        try:
+            keypoints: list[NDArray[np.float32]] = []
+            frame_indices: list[int] = []
+
+            cap = cv2.VideoCapture(str(video_path))
+            if not cap.isOpened():
+                raise RuntimeError(f"Failed to open video: {video_path}")
+            try:
+                cap.set(cv2.CAP_PROP_POS_FRAMES, start_frame)
+                for frame_idx in range(start_frame, end_frame):
+                    ret, frame = cap.read()
+                    if not ret:
+                        raise RuntimeError(f"Failed to read frame {frame_idx}")
+                    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                    result = self.court_kp_module.process(
+                        frame_rgb,
+                        frame_index=frame_idx,
+                        image_width=image_width,
+                        image_height=image_height,
+                    )
+                    keypoints.append(result.keypoints)
+                    frame_indices.append(frame_idx)
+            finally:
+                cap.release()
+        finally:
+            self.court_kp_module.config.save_result = previous_save_result
+            self.court_kp_module.config.load_path = previous_load_path
+
+        sequence_result = CourtKPSequenceResult(
+            keypoints=np.stack(keypoints, axis=0).astype(np.float32),
+            visibility=np.ones(
+                (len(keypoints), keypoints[0].shape[0]),
+                dtype=np.float32,
+            ),
+            frame_indices=np.array(frame_indices, dtype=np.int32),
+        )
+        is_valid, errors = sequence_result.validate()
+        if not is_valid:
+            raise ValueError(f"Invalid CourtKP sequence result: {errors}")
+
+        output_path = self.court_kp_module.config.output_path
+        if previous_save_result and output_path is not None:
+            sequence_result.save(output_path)
+        return sequence_result
+
     def run(
         self,
         video_path: str | Path,
@@ -292,15 +381,16 @@ class TennisSceneOrchestrator:
         video_info = self._read_video_info(video_path)
         width, height = video_info["width"], video_info["height"]
 
-        frame = self._read_frame(video_path, court_kp_frame)
-        court_result = self.court_kp_module.process(
-            frame,
-            frame_index=court_kp_frame,
+        court_result = self._run_court_kp_sequence(
+            video_path,
+            start_frame=court_kp_frame,
+            max_frames=max_frames,
             image_width=width,
             image_height=height,
+            total_frames=video_info["num_frames"],
         )
         court_kp = court_result.keypoints
-        court_vis = None
+        court_vis = court_result.visibility
 
         if Stage.GVHMR in self.enabled_stages and self.gvhmr_config is not None:
             gvhmr_result = self._run_gvhmr(video_path, max_frames)
@@ -375,7 +465,8 @@ class TennisSceneOrchestrator:
             player_track_ids=track_ids,
             metadata={
                 "video_path": str(video_path),
-                "court_kp_frame": court_kp_frame,
+                "court_kp_start_frame": court_kp_frame,
+                "court_kp_frame_indices": court_result.frame_indices.tolist(),
                 "track_ids": track_ids.tolist(),
                 "enabled_stages": [stage.value for stage in self.execution_order],
             },

--- a/src/tennis_scene/scripts/run_pipeline.py
+++ b/src/tennis_scene/scripts/run_pipeline.py
@@ -50,7 +50,7 @@ def main(cfg: DictConfig) -> int:
     LOGGER.info("Configuration:")
     LOGGER.info(f"  Device: {cfg.device}")
     LOGGER.info(f"  Max frames: {max_frames}")
-    LOGGER.info(f"  Court KP frame: {court_kp_frame}")
+    LOGGER.info(f"  Court KP start frame: {court_kp_frame}")
     LOGGER.info(f"  Skip GVHMR: {cfg.gvhmr.get('skip', False)}")
     LOGGER.info(f"  Skip ball: {cfg.ball_detection.get('skip', False)}")
     LOGGER.info(f"  Skip BLCS: {cfg.blcs.get('skip', False)}")

--- a/src/tennis_scene/scripts/run_pipeline.py
+++ b/src/tennis_scene/scripts/run_pipeline.py
@@ -45,12 +45,14 @@ def main(cfg: DictConfig) -> int:
     output_path = output_dir / f"{output_name}.npz"
 
     max_frames = cfg.get("max_frames")
-    court_kp_frame = int(cfg.court_kp.frame_index)
+    court_kp_annotation_frame = int(
+        cfg.court_kp.get("annotation_frame_index", cfg.court_kp.get("frame_index", 0))
+    )
 
     LOGGER.info("Configuration:")
     LOGGER.info(f"  Device: {cfg.device}")
     LOGGER.info(f"  Max frames: {max_frames}")
-    LOGGER.info(f"  Court KP start frame: {court_kp_frame}")
+    LOGGER.info(f"  Court KP annotation frame: {court_kp_annotation_frame}")
     LOGGER.info(f"  Skip GVHMR: {cfg.gvhmr.get('skip', False)}")
     LOGGER.info(f"  Skip ball: {cfg.ball_detection.get('skip', False)}")
     LOGGER.info(f"  Skip BLCS: {cfg.blcs.get('skip', False)}")
@@ -61,7 +63,7 @@ def main(cfg: DictConfig) -> int:
     result = orchestrator.run(
         video_path=video_path,
         max_frames=max_frames,
-        court_kp_frame=court_kp_frame,
+        court_kp_annotation_frame=court_kp_annotation_frame,
     )
 
     LOGGER.info("Saving results...")
@@ -75,7 +77,9 @@ def main(cfg: DictConfig) -> int:
     LOGGER.info(f"  FPS: {result.fps:.2f}")
     LOGGER.info(f"  Resolution: {result.width}x{result.height}")
     if result.ball_3d is not None:
-        visible_ball = result.ball_visibility.sum() if result.ball_visibility is not None else 0
+        visible_ball = (
+            result.ball_visibility.sum() if result.ball_visibility is not None else 0
+        )
         LOGGER.info(f"  Ball visible frames: {visible_ball}/{result.num_frames}")
     LOGGER.info("=" * 60)
 

--- a/src/utils/video/__init__.py
+++ b/src/utils/video/__init__.py
@@ -2,7 +2,11 @@
 
 from src.utils.video.batching import iter_temporal_batches
 from src.utils.video.prefetch import PrefetchIterator
-from src.utils.video.reader import OpenCVVideoFrameReader, probe_video_info
+from src.utils.video.reader import (
+    OpenCVVideoFrameReader,
+    probe_video_info,
+    read_video_frame,
+)
 from src.utils.video.transforms import BgrToTensorTransform, normalize_tensor_imagenet
 from src.utils.video.types import FramePacket, TemporalBatch, TemporalWindow, VideoInfo
 from src.utils.video.windows import iter_temporal_windows
@@ -19,4 +23,5 @@ __all__ = [
     "iter_temporal_windows",
     "normalize_tensor_imagenet",
     "probe_video_info",
+    "read_video_frame",
 ]

--- a/src/utils/video/reader.py
+++ b/src/utils/video/reader.py
@@ -28,6 +28,32 @@ def probe_video_info(video_path: str | Path) -> VideoInfo:
         cap.release()
 
 
+def read_video_frame(
+    video_path: str | Path, frame_index: int
+) -> FramePacket[NDArray[np.uint8]]:
+    """Read one decoded BGR frame by source frame index."""
+    if frame_index < 0:
+        raise ValueError(f"frame_index must be non-negative, got {frame_index}")
+
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        raise RuntimeError(f"Failed to open video: {video_path}")
+
+    try:
+        cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
+        ok, frame_bgr = cap.read()
+        if not ok:
+            raise RuntimeError(f"Failed to read frame {frame_index} from {video_path}")
+        original_size = (int(frame_bgr.shape[1]), int(frame_bgr.shape[0]))
+        return FramePacket(
+            index=frame_index,
+            frame=frame_bgr,
+            original_size=original_size,
+        )
+    finally:
+        cap.release()
+
+
 class OpenCVVideoFrameReader:
     """Stream decoded BGR frames from a video file."""
 


### PR DESCRIPTION
## 概要

`tennis_scene` の Court KP pipeline を、単一フレーム処理ではなく動画入力に対する時系列処理へ整理しました。
Court KP の動画読み出し・model/manual_ui 分岐・保存/読み込み・shape 検証を `CourtKPModule` に閉じ込め、orchestrator は各 stage の接続だけを担う形に薄くしています。

## 変更内容

- `CourtKPSequenceResult` を廃止し、`CourtKPResult` を canonical な時系列結果に統一
  - `keypoints`: `(T, K, 2)`
  - `visibility`: `(T, K)`
  - `frame_indices`: `(T,)`
- `CourtKPModule.process(...)` が `video_path` を受け取り、model mode では対象フレーム列すべてに推論を実行
- manual_ui mode では `annotation_frame_index` の1フレームをアノテーションし、その keypoints を `T` に拡張
- `court_kp.num_keypoints` を config 化し、Court KP 出力 shape を config と照合
- `src.utils.video.read_video_frame(...)` を追加し、manual_ui の代表フレーム取得に利用
- orchestrator から Court KP の per-frame 実装と OpenCV 直書きを削除
- PLCS/BLCS wrapper は Court KP を `(T, K, 2)` / `(T, K)` 前提に変更
- `SceneResult` と各 module docstring の Court KP shape を `(T, K, 2)` / `(T, K)` に更新

## 検証

- `.venv/bin/python -m py_compile src/utils/video/reader.py src/utils/video/__init__.py src/tennis_scene/pipeline/components/court_kp.py src/tennis_scene/pipeline/components/plcs.py src/tennis_scene/pipeline/components/blcs.py src/tennis_scene/pipeline/orchestrator.py src/tennis_scene/scripts/run_pipeline.py src/tennis_scene/io.py`
- `git diff --check`
- `outputs/court_detection/kp/logs/version_2/checkpoints/court-detection-epoch=50.ckpt` と `data/samples/tennis_clip.mp4` で Court KP 実モデル推論を確認
  - `keypoints`: `(2, 14, 2)`
  - `visibility`: `(2, 14)`
  - `frame_indices`: `[0, 1]`
- `court_kp.num_keypoints=20` に対して 14-keypoint checkpoint を使うと validation error になることを確認
- PLCS/BLCS wrapper の T-only shape smoke を確認

## 補足

`run_pipeline` でも CourtKP stage は指定 checkpoint で JSON 保存まで完了しました。以降の GVHMR stage は、この環境に `third_party/GVHMR/.venv/bin/python` がないため停止しています。

## 関連Issue

なし