### PR TITLE
TQDMプログレスバーへの移行

### DIFF
--- a/src/tasks/base/training/runner.py
+++ b/src/tasks/base/training/runner.py
@@ -21,6 +21,8 @@ from pytorch_lightning.callbacks import (
     EarlyStopping,
     LearningRateMonitor,
     ModelCheckpoint,
+    ProgressBar,
+    TQDMProgressBar,
 )
 from pytorch_lightning.loggers import TensorBoardLogger
 
@@ -252,6 +254,14 @@ class BaseTrainingRunner:
 
         # Add task-specific callbacks
         callbacks.extend(self.callbacks_extra(config, datamodule, logger))
+
+        # Lightning 2.6 defaults to RichProgressBar when no explicit progress
+        # callback is provided, which is noisy in notebook environments.
+        if config.training.trainer.get("enable_progress_bar", True) and not any(
+            isinstance(callback, ProgressBar) for callback in callbacks
+        ):
+            callbacks.append(TQDMProgressBar())
+
         return callbacks
 
     def build_trainer(


### PR DESCRIPTION
## 概要
RichのProgressからTQDMProgressBarに移行しました。
カスタムプログレスバーの重複排除や、無効化フラグの動作確認を含みます。

## 検証用コマンド
.venv/bin/python -m pytest tests/tasks/test_base_training_runner_progress_bar.py -q

Closes #476