### PR TITLE
Tennis Scene wrapperの入力shape正規化

### DIFF
--- a/src/tennis_scene/pipeline/components/blcs.py
+++ b/src/tennis_scene/pipeline/components/blcs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -12,6 +12,11 @@ import numpy as np
 import torch
 
 from src.tennis_scene.pipeline.components.base import BasePipelineModule
+from src.tennis_scene.pipeline.components.input_shapes import (
+    get_model_num_court_keypoints,
+    normalize_ball_uv_sequence,
+    normalize_court_keypoint_sequence,
+)
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -60,7 +65,7 @@ class BLCSResult:
         return data
 
     @classmethod
-    def from_dict(cls, data: dict) -> "BLCSResult":
+    def from_dict(cls, data: dict) -> BLCSResult:
         """Create result from dict."""
         return cls(
             ball_3d=np.array(data["ball_3d"], dtype=np.float32),
@@ -104,7 +109,7 @@ class BLCSResult:
         return len(errors) == 0, errors
 
     @classmethod
-    def load(cls, path: str | Path) -> "BLCSResult":
+    def load(cls, path: str | Path) -> BLCSResult:
         """Load result from JSON file."""
         with Path(path).open("r", encoding="utf-8") as f:
             return cls.from_dict(json.load(f))
@@ -161,10 +166,13 @@ class BLCSModule(BasePipelineModule):
         """Run BLCS inference.
 
         Args:
-            ball_uv: Ball 2D positions (T, 2), normalized [0, 1].
-            court_kp: Court keypoints (20, 2), normalized [0, 1].
-            ball_vis: Ball visibility mask (T,).
-            court_vis: Court keypoint visibility (20,).
+            ball_uv: Ball 2D positions, shape (T, 2), (N, T, 2), or
+                (B, N, T, 2), normalized [0, 1].
+            court_kp: Court keypoints, shape (K, 2), (T, K, 2),
+                (N, K, 2), (N, T, K, 2), or (B, N, T, K, 2),
+                normalized [0, 1].
+            ball_vis: Ball visibility mask aligned with ``ball_uv``.
+            court_vis: Court keypoint visibility aligned with ``court_kp``.
 
         Returns:
             BLCSResult with 3D ball trajectory.
@@ -176,40 +184,58 @@ class BLCSModule(BasePipelineModule):
             if load_path.exists():
                 LOGGER.info(f"Loading BLCS result from {load_path} (skipping inference)")
                 return BLCSResult.load(load_path)
-            else:
-                LOGGER.warning(f"load_path specified but not found: {load_path}, running inference")
+            LOGGER.warning(
+                f"load_path specified but not found: {load_path}, running inference"
+            )
 
         if not self.is_loaded:
             self.load()
 
         LOGGER.info("Running BLCS ball localization...")
 
-        if ball_vis is not None:
-            effective_vis = ball_vis.astype(np.bool_)
-        else:
-            effective_vis = np.ones(len(ball_uv), dtype=bool)
+        ball_uv_seq, ball_vis_seq, shape = normalize_ball_uv_sequence(
+            ball_uv=ball_uv,
+            ball_vis=ball_vis,
+        )
+        batch_size, num_cameras, num_frames = shape
+        if batch_size != 1:
+            raise ValueError(
+                "BLCSModule expects one trajectory batch for pipeline output, "
+                f"got B={batch_size}"
+            )
+        target_num_keypoints = get_model_num_court_keypoints(self._predictor.model)
+        court_kp_seq, court_vis_seq = normalize_court_keypoint_sequence(
+            court_kp=court_kp,
+            court_vis=court_vis,
+            target_batch_size=batch_size,
+            target_num_cameras=num_cameras,
+            target_num_frames=num_frames,
+            target_num_keypoints=target_num_keypoints,
+        )
 
-        # BLCS models expect batched inputs: (B, T, 2), (B, 20, 2), (B, T), (B, 20).
-        ball_uv_t = torch.from_numpy(ball_uv).float().unsqueeze(0)
-        court_kp_t = torch.from_numpy(court_kp).float().unsqueeze(0)
-
-        ball_vis_t = torch.from_numpy(effective_vis.astype(np.float32)).unsqueeze(0)
-
-        court_vis_t = None
-        if court_vis is not None:
-            court_vis_t = torch.from_numpy(court_vis).float().unsqueeze(0)
+        ball_uv_t = torch.from_numpy(ball_uv_seq).float()
+        court_kp_t = torch.from_numpy(court_kp_seq).float()
+        ball_vis_t = torch.from_numpy(ball_vis_seq).float()
+        ball_mask_t = torch.ones((batch_size, num_cameras, num_frames), dtype=torch.float32)
+        court_vis_t = torch.from_numpy(court_vis_seq).float()
 
         pred = self._predictor.predict(
             ball_uv=ball_uv_t,
             court_kp=court_kp_t,
             ball_vis=ball_vis_t,
+            ball_mask=ball_mask_t,
             court_vis=court_vis_t,
             denormalize=True,
         )
 
         ball_3d = pred["position"].squeeze(0).cpu().numpy().astype(np.float32)
+        if ball_3d.shape != (num_frames, 3):
+            raise ValueError(
+                f"BLCS position output must be ({num_frames}, 3), got {ball_3d.shape}"
+            )
 
         # Mask out invalid frames with zeros to keep JSON strictly numeric
+        effective_vis = ball_vis_seq[0].any(axis=0).astype(bool)
         ball_3d[~effective_vis] = 0.0
 
         result = BLCSResult(ball_3d=ball_3d, visibility=effective_vis)

--- a/src/tennis_scene/pipeline/components/input_shapes.py
+++ b/src/tennis_scene/pipeline/components/input_shapes.py
@@ -1,0 +1,280 @@
+"""Input shape normalization helpers for tennis scene pipeline components."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+def get_model_num_court_keypoints(model: object, fallback: int = 20) -> int:
+    """Return the court keypoint count expected by a loaded model."""
+    value = getattr(model, "num_court_tokens", fallback)
+    return int(value)
+
+
+def _as_float32(name: str, array: NDArray[np.float32]) -> NDArray[np.float32]:
+    arr = np.asarray(array, dtype=np.float32)
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} contains non-finite values")
+    return arr
+
+
+def _as_visibility(
+    name: str,
+    array: NDArray[np.float32] | None,
+    shape: tuple[int, ...],
+) -> NDArray[np.float32]:
+    if array is None:
+        return np.ones(shape, dtype=np.float32)
+    arr = np.asarray(array, dtype=np.float32)
+    if arr.shape != shape:
+        raise ValueError(f"{name} shape must be {shape}, got {arr.shape}")
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} contains non-finite values")
+    return arr
+
+
+def _pad_court_keypoints(
+    court_kp: NDArray[np.float32],
+    court_vis: NDArray[np.float32],
+    *,
+    target_num_keypoints: int,
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+    num_keypoints = int(court_kp.shape[-2])
+    if num_keypoints > target_num_keypoints:
+        raise ValueError(
+            "court_kp has more keypoints than the model expects: "
+            f"K={num_keypoints}, expected K={target_num_keypoints}"
+        )
+    if num_keypoints == target_num_keypoints:
+        return court_kp.astype(np.float32), court_vis.astype(np.float32)
+
+    pad_count = target_num_keypoints - num_keypoints
+    kp_pad_shape = (*court_kp.shape[:-2], pad_count, 2)
+    vis_pad_shape = (*court_vis.shape[:-1], pad_count)
+    return (
+        np.concatenate(
+            [court_kp, np.zeros(kp_pad_shape, dtype=np.float32)],
+            axis=-2,
+        ).astype(np.float32),
+        np.concatenate(
+            [court_vis, np.zeros(vis_pad_shape, dtype=np.float32)],
+            axis=-1,
+        ).astype(np.float32),
+    )
+
+
+def normalize_ball_uv_sequence(
+    ball_uv: NDArray[np.float32],
+    ball_vis: NDArray[np.bool_] | NDArray[np.float32] | None = None,
+) -> tuple[NDArray[np.float32], NDArray[np.float32], tuple[int, int, int]]:
+    """Normalize ball inputs to (B, N, T, 2) and visibility to (B, N, T)."""
+    ball = _as_float32("ball_uv", ball_uv)
+    if ball.ndim == 2 and ball.shape[-1] == 2:
+        ball = ball[None, None, ...]
+    elif ball.ndim == 3 and ball.shape[-1] == 2:
+        ball = ball[None, ...]
+    elif ball.ndim == 4 and ball.shape[-1] == 2:
+        ball = ball
+    else:
+        raise ValueError(
+            "ball_uv shape must be (T, 2), (N, T, 2), or (B, N, T, 2), "
+            f"got {ball.shape}"
+        )
+
+    batch_size, num_cameras, num_frames = ball.shape[:3]
+    vis_shape = (batch_size, num_cameras, num_frames)
+    if ball_vis is None:
+        vis = np.ones(vis_shape, dtype=np.float32)
+    else:
+        vis = np.asarray(ball_vis, dtype=np.float32)
+        if vis.ndim == 1:
+            vis = vis[None, None, ...]
+        elif vis.ndim == 2:
+            vis = vis[None, ...]
+        elif vis.ndim != 3:
+            raise ValueError(
+                "ball_vis shape must be (T,), (N, T), or (B, N, T), "
+                f"got {vis.shape}"
+            )
+        if vis.shape != vis_shape:
+            raise ValueError(f"ball_vis shape must be {vis_shape}, got {vis.shape}")
+        if not np.isfinite(vis).all():
+            raise ValueError("ball_vis contains non-finite values")
+    return ball.astype(np.float32), vis.astype(np.float32), vis_shape
+
+
+def normalize_player_keypoint_sequence(
+    human_kp_2d: NDArray[np.float32],
+    human_kp_vis: NDArray[np.float32] | None = None,
+) -> tuple[NDArray[np.float32], NDArray[np.float32], tuple[int, int, int]]:
+    """Normalize player keypoints to (P, N, T, 17, 2)."""
+    human = _as_float32("human_kp_2d", human_kp_2d)
+    if human.ndim == 4 and human.shape[-2:] == (17, 2):
+        human = human[:, None, ...]
+    elif human.ndim == 5 and human.shape[-2:] == (17, 2):
+        human = human
+    else:
+        raise ValueError(
+            "human_kp_2d shape must be (P, T, 17, 2) or (P, N, T, 17, 2), "
+            f"got {human.shape}"
+        )
+
+    num_players, num_cameras, num_frames = human.shape[:3]
+    vis_shape = (num_players, num_cameras, num_frames, 17)
+    if human_kp_vis is None:
+        vis = np.ones(vis_shape, dtype=np.float32)
+    else:
+        vis = np.asarray(human_kp_vis, dtype=np.float32)
+        if vis.ndim == 3:
+            vis = vis[:, None, ...]
+        elif vis.ndim != 4:
+            raise ValueError(
+                "human_kp_vis shape must be (P, T, 17) or (P, N, T, 17), "
+                f"got {vis.shape}"
+            )
+        if vis.shape != vis_shape:
+            raise ValueError(f"human_kp_vis shape must be {vis_shape}, got {vis.shape}")
+        if not np.isfinite(vis).all():
+            raise ValueError("human_kp_vis contains non-finite values")
+    return human.astype(np.float32), vis.astype(np.float32), (
+        num_players,
+        num_cameras,
+        num_frames,
+    )
+
+
+def normalize_court_keypoint_sequence(
+    court_kp: NDArray[np.float32],
+    court_vis: NDArray[np.float32] | None,
+    *,
+    target_batch_size: int,
+    target_num_cameras: int,
+    target_num_frames: int,
+    target_num_keypoints: int,
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+    """Normalize court keypoints to (B, N, T, K, 2)."""
+    court = _as_float32("court_kp", court_kp)
+
+    if court.ndim == 2 and court.shape[-1] == 2:
+        court = np.broadcast_to(
+            court[None, None, None, ...],
+            (
+                target_batch_size,
+                target_num_cameras,
+                target_num_frames,
+                court.shape[-2],
+                2,
+            ),
+        )
+    elif court.ndim == 3 and court.shape[-1] == 2:
+        if court.shape[0] == target_num_frames:
+            court = np.broadcast_to(
+                court[None, None, ...],
+                (
+                    target_batch_size,
+                    target_num_cameras,
+                    target_num_frames,
+                    court.shape[-2],
+                    2,
+                ),
+            )
+        elif court.shape[0] == target_num_cameras:
+            court = np.broadcast_to(
+                court[None, :, None, ...],
+                (
+                    target_batch_size,
+                    target_num_cameras,
+                    target_num_frames,
+                    court.shape[-2],
+                    2,
+                ),
+            )
+        else:
+            raise ValueError(
+                "court_kp shape (X, K, 2) must use X equal to T or N, "
+                f"got X={court.shape[0]}, T={target_num_frames}, "
+                f"N={target_num_cameras}"
+            )
+    elif court.ndim == 4 and court.shape[-1] == 2:
+        if court.shape[:2] != (target_num_cameras, target_num_frames):
+            raise ValueError(
+                "court_kp shape (N, T, K, 2) must match target N/T, "
+                f"got {court.shape[:2]}, expected "
+                f"{(target_num_cameras, target_num_frames)}"
+            )
+        court = np.broadcast_to(
+            court[None, ...],
+            (target_batch_size, *court.shape),
+        )
+    elif court.ndim == 5 and court.shape[-1] == 2:
+        if court.shape[:3] != (
+            target_batch_size,
+            target_num_cameras,
+            target_num_frames,
+        ):
+            raise ValueError(
+                "court_kp shape (B, N, T, K, 2) must match target B/N/T, "
+                f"got {court.shape[:3]}, expected "
+                f"{(target_batch_size, target_num_cameras, target_num_frames)}"
+            )
+    else:
+        raise ValueError(
+            "court_kp shape must be (K, 2), (T, K, 2), (N, K, 2), "
+            "(N, T, K, 2), or (B, N, T, K, 2), "
+            f"got {court.shape}"
+        )
+
+    vis_input_shape = court.shape[:-1]
+    if court_vis is None:
+        vis = np.ones(vis_input_shape, dtype=np.float32)
+    else:
+        raw_vis = np.asarray(court_vis, dtype=np.float32)
+        if raw_vis.ndim == 1:
+            vis = np.broadcast_to(
+                raw_vis[None, None, None, ...],
+                vis_input_shape,
+            )
+        elif raw_vis.ndim == 2:
+            if raw_vis.shape[0] == target_num_frames:
+                vis = np.broadcast_to(raw_vis[None, None, ...], vis_input_shape)
+            elif raw_vis.shape[0] == target_num_cameras:
+                vis = np.broadcast_to(raw_vis[None, :, None, ...], vis_input_shape)
+            else:
+                raise ValueError(
+                    "court_vis shape (X, K) must use X equal to T or N, "
+                    f"got X={raw_vis.shape[0]}, T={target_num_frames}, "
+                    f"N={target_num_cameras}"
+                )
+        elif raw_vis.ndim == 3:
+            if raw_vis.shape[:2] != (target_num_cameras, target_num_frames):
+                raise ValueError(
+                    "court_vis shape (N, T, K) must match target N/T, "
+                    f"got {raw_vis.shape[:2]}, expected "
+                    f"{(target_num_cameras, target_num_frames)}"
+                )
+            vis = np.broadcast_to(raw_vis[None, ...], vis_input_shape)
+        elif raw_vis.ndim == 4:
+            if raw_vis.shape != vis_input_shape:
+                raise ValueError(
+                    f"court_vis shape must be {vis_input_shape}, got {raw_vis.shape}"
+                )
+            vis = raw_vis
+        else:
+            raise ValueError(
+                "court_vis shape must be (K,), (T, K), (N, K), "
+                "(N, T, K), or (B, N, T, K), "
+                f"got {raw_vis.shape}"
+            )
+        if not np.isfinite(vis).all():
+            raise ValueError("court_vis contains non-finite values")
+
+    return _pad_court_keypoints(
+        np.array(court, dtype=np.float32, copy=True),
+        np.array(vis, dtype=np.float32, copy=True),
+        target_num_keypoints=target_num_keypoints,
+    )

--- a/src/tennis_scene/pipeline/components/plcs.py
+++ b/src/tennis_scene/pipeline/components/plcs.py
@@ -12,6 +12,11 @@ import numpy as np
 import torch
 
 from src.tennis_scene.pipeline.components.base import BasePipelineModule
+from src.tennis_scene.pipeline.components.input_shapes import (
+    get_model_num_court_keypoints,
+    normalize_court_keypoint_sequence,
+    normalize_player_keypoint_sequence,
+)
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -54,7 +59,7 @@ class PLCSResult:
         return result
 
     @classmethod
-    def from_dict(cls, data: dict) -> "PLCSResult":
+    def from_dict(cls, data: dict) -> PLCSResult:
         position = np.array(data["position"], dtype=np.float32)
         yaw = np.array(data["yaw"], dtype=np.float32)
 
@@ -81,9 +86,12 @@ class PLCSResult:
         if self.yaw.ndim != 2:
             errors.append(f"yaw shape must be (P, T), got {self.yaw.shape}")
 
-        if self.position.ndim == 3 and self.yaw.ndim == 2:
-            if self.position.shape[:2] != self.yaw.shape:
-                errors.append("position and yaw shapes are inconsistent on (P, T)")
+        if (
+            self.position.ndim == 3
+            and self.yaw.ndim == 2
+            and self.position.shape[:2] != self.yaw.shape
+        ):
+            errors.append("position and yaw shapes are inconsistent on (P, T)")
 
         if self.track_ids is not None:
             if self.track_ids.ndim != 1:
@@ -101,7 +109,7 @@ class PLCSResult:
         return len(errors) == 0, errors
 
     @classmethod
-    def load(cls, path: str | Path) -> "PLCSResult":
+    def load(cls, path: str | Path) -> PLCSResult:
         with Path(path).open("r", encoding="utf-8") as f:
             return cls.from_dict(json.load(f))
 
@@ -159,10 +167,14 @@ class PLCSModule(BasePipelineModule):
         """Run PLCS inference.
 
         Args:
-            human_kp_2d: Human 2D keypoints, shape (P, T, 17, 2), normalized [0, 1].
-            court_kp: Court keypoints (20, 2), normalized [0, 1].
-            human_kp_vis: Human keypoint visibility, shape (P, T, 17).
-            court_vis: Court keypoint visibility (20,).
+            human_kp_2d: Human 2D keypoints, shape (P, T, 17, 2) or
+                (P, N, T, 17, 2), normalized [0, 1].
+            court_kp: Court keypoints, shape (K, 2), (T, K, 2),
+                (N, K, 2), (N, T, K, 2), or (P, N, T, K, 2),
+                normalized [0, 1].
+            human_kp_vis: Human keypoint visibility, shape (P, T, 17) or
+                (P, N, T, 17).
+            court_vis: Court keypoint visibility aligned with ``court_kp``.
             track_ids: Optional track IDs aligned with P.
 
         Returns:
@@ -180,60 +192,64 @@ class PLCSModule(BasePipelineModule):
         if not self.is_loaded:
             self.load()
 
-        if human_kp_2d.ndim != 4 or human_kp_2d.shape[2:] != (17, 2):
-            raise ValueError(
-                "human_kp_2d shape must be (P, T, 17, 2), "
-                f"got {human_kp_2d.shape}"
-            )
-
-        num_players, num_frames = human_kp_2d.shape[:2]
-        if human_kp_vis is not None:
-            if human_kp_vis.shape != (num_players, num_frames, 17):
-                raise ValueError(
-                    "human_kp_vis shape must match (P, T, 17), "
-                    f"got {human_kp_vis.shape}"
-                )
+        human_kp, human_vis, shape = normalize_player_keypoint_sequence(
+            human_kp_2d=human_kp_2d,
+            human_kp_vis=human_kp_vis,
+        )
+        num_players, num_cameras, num_frames = shape
 
         if track_ids is None:
             track_ids = np.arange(num_players, dtype=np.int32)
+        elif track_ids.shape != (num_players,):
+            raise ValueError(
+                f"track_ids shape must be ({num_players},), got {track_ids.shape}"
+            )
 
-        LOGGER.info(f"Running PLCS player localization for {num_players} players...")
+        target_num_keypoints = get_model_num_court_keypoints(self._predictor.model)
+        court_kp_seq, court_vis_seq = normalize_court_keypoint_sequence(
+            court_kp=court_kp,
+            court_vis=court_vis,
+            target_batch_size=num_players,
+            target_num_cameras=num_cameras,
+            target_num_frames=num_frames,
+            target_num_keypoints=target_num_keypoints,
+        )
 
-        batch_size = num_players * num_frames
+        LOGGER.info(
+            "Running PLCS player localization for "
+            f"{num_players} players, {num_cameras} cameras, {num_frames} frames..."
+        )
 
-        court_kp_t = torch.from_numpy(court_kp).float()
-        court_kp_batch = court_kp_t.unsqueeze(0).repeat(batch_size, 1, 1)
-
-        court_vis_batch = None
-        if court_vis is not None:
-            court_vis_t = torch.from_numpy(court_vis).float()
-            court_vis_batch = court_vis_t.unsqueeze(0).repeat(batch_size, 1)
-
-        human_kp_t = torch.from_numpy(human_kp_2d).float().reshape(
-            batch_size, 17, 2
-        )  # (P*T, 17, 2)
-        human_vis_t = None
-        if human_kp_vis is not None:
-            human_vis_t = torch.from_numpy(human_kp_vis).float().reshape(
-                batch_size, 17
-            )  # (P*T, 17)
-        human_mask_t = torch.ones((batch_size,), dtype=torch.float32)
+        human_kp_t = torch.from_numpy(human_kp).float()
+        human_vis_t = torch.from_numpy(human_vis).float()
+        human_mask_t = torch.ones(
+            (num_players, num_cameras, num_frames),
+            dtype=torch.float32,
+        )
+        court_kp_t = torch.from_numpy(court_kp_seq).float()
+        court_vis_t = torch.from_numpy(court_vis_seq).float()
 
         pred = self._predictor.predict(
             human_kp=human_kp_t,
-            court_kp=court_kp_batch,
+            court_kp=court_kp_t,
             human_vis=human_vis_t,
             human_mask=human_mask_t,
-            court_vis=court_vis_batch,
+            court_vis=court_vis_t,
             denormalize=True,
         )
 
-        positions = pred["position_meters"].numpy().astype(np.float32).reshape(
-            num_players, num_frames, 3
-        )  # (P, T, 3)
-        yaws = pred["yaw_radians"].numpy().astype(np.float32).reshape(
-            num_players, num_frames
-        )  # (P, T)
+        positions = pred["position_meters"].numpy().astype(np.float32)
+        yaws = pred["yaw_radians"].numpy().astype(np.float32)
+        if positions.shape != (num_players, num_frames, 3):
+            raise ValueError(
+                "PLCS position output must be "
+                f"({num_players}, {num_frames}, 3), got {positions.shape}"
+            )
+        if yaws.shape != (num_players, num_frames):
+            raise ValueError(
+                "PLCS yaw output must be "
+                f"({num_players}, {num_frames}), got {yaws.shape}"
+            )
 
         result = PLCSResult(
             position=positions,  # (P, T, 3)

--- a/tests/test_tennis_scene_wrapper_input_shapes.py
+++ b/tests/test_tennis_scene_wrapper_input_shapes.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from src.tennis_scene.pipeline.components.blcs import BLCSConfig, BLCSModule
+from src.tennis_scene.pipeline.components.input_shapes import (
+    normalize_court_keypoint_sequence,
+)
+from src.tennis_scene.pipeline.components.plcs import PLCSModule
+
+
+def _make_float_array(shape: tuple[int, ...]) -> np.ndarray:
+    values = np.linspace(0.05, 0.95, num=int(np.prod(shape)), dtype=np.float32)
+    return values.reshape(shape)
+
+
+def _assert_tensor_shape(value: object, shape: tuple[int, ...]) -> torch.Tensor:
+    assert isinstance(value, torch.Tensor)
+    assert tuple(value.shape) == shape
+    return value
+
+
+class _BLCSStubPredictor:
+    def __init__(self, position: torch.Tensor, *, num_court_tokens: int = 20) -> None:
+        self.model = SimpleNamespace(num_court_tokens=num_court_tokens)
+        self.position = position
+        self.last_call: dict[str, object] | None = None
+
+    def predict(self, **kwargs: object) -> dict[str, torch.Tensor]:
+        self.last_call = kwargs
+        return {"position": self.position.clone()}
+
+
+class _PLCSStubPredictor:
+    def __init__(
+        self,
+        position_meters: torch.Tensor,
+        yaw_radians: torch.Tensor,
+        *,
+        num_court_tokens: int = 20,
+    ) -> None:
+        self.model = SimpleNamespace(num_court_tokens=num_court_tokens)
+        self.position_meters = position_meters
+        self.yaw_radians = yaw_radians
+        self.last_call: dict[str, object] | None = None
+
+    def predict(self, **kwargs: object) -> dict[str, torch.Tensor]:
+        self.last_call = kwargs
+        return {
+            "position_meters": self.position_meters.clone(),
+            "yaw_radians": self.yaw_radians.clone(),
+            "canonical_pose": torch.ones(1, dtype=torch.float32),
+        }
+
+
+def test_normalize_court_keypoint_sequence_pads_k14_visibility_to_zero() -> None:
+    court_kp = _make_float_array((3, 14, 2))
+    court_vis = np.ones((3, 14), dtype=np.float32)
+
+    normalized_kp, normalized_vis = normalize_court_keypoint_sequence(
+        court_kp=court_kp,
+        court_vis=court_vis,
+        target_batch_size=1,
+        target_num_cameras=1,
+        target_num_frames=3,
+        target_num_keypoints=20,
+    )
+
+    assert normalized_kp.shape == (1, 1, 3, 20, 2)
+    assert normalized_vis.shape == (1, 1, 3, 20)
+    np.testing.assert_allclose(normalized_kp[0, 0, :, :14], court_kp)
+    np.testing.assert_allclose(normalized_vis[0, 0, :, :14], court_vis)
+    np.testing.assert_array_equal(normalized_kp[0, 0, :, 14:], 0.0)
+    np.testing.assert_array_equal(normalized_vis[0, 0, :, 14:], 0.0)
+
+
+def test_blcs_process_normalizes_single_camera_per_frame_inputs() -> None:
+    num_frames = 3
+    predictor = _BLCSStubPredictor(
+        torch.tensor(
+            [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]],
+            dtype=torch.float32,
+        )
+    )
+    module = BLCSModule(BLCSConfig(checkpoint_path="dummy.ckpt", device="cpu"))
+    module._predictor = predictor
+
+    ball_uv = _make_float_array((num_frames, 2))
+    court_kp = _make_float_array((num_frames, 14, 2))
+    ball_vis = np.array([1.0, 0.0, 1.0], dtype=np.float32)
+
+    result = module.process(ball_uv=ball_uv, court_kp=court_kp, ball_vis=ball_vis)
+
+    is_valid, errors = result.validate()
+    assert is_valid, errors
+    np.testing.assert_array_equal(result.visibility, np.array([True, False, True]))
+    np.testing.assert_array_equal(result.ball_3d[1], np.zeros(3, dtype=np.float32))
+
+    assert predictor.last_call is not None
+    ball_uv_t = _assert_tensor_shape(predictor.last_call["ball_uv"], (1, 1, 3, 2))
+    court_kp_t = _assert_tensor_shape(
+        predictor.last_call["court_kp"],
+        (1, 1, 3, 20, 2),
+    )
+    ball_vis_t = _assert_tensor_shape(predictor.last_call["ball_vis"], (1, 1, 3))
+    ball_mask_t = _assert_tensor_shape(predictor.last_call["ball_mask"], (1, 1, 3))
+    court_vis_t = _assert_tensor_shape(
+        predictor.last_call["court_vis"],
+        (1, 1, 3, 20),
+    )
+    assert predictor.last_call["denormalize"] is True
+    np.testing.assert_allclose(ball_uv_t.numpy()[0, 0], ball_uv)
+    np.testing.assert_allclose(court_kp_t.numpy()[0, 0, :, :14], court_kp)
+    np.testing.assert_allclose(ball_vis_t.numpy()[0, 0], ball_vis)
+    np.testing.assert_array_equal(ball_mask_t.numpy(), np.ones((1, 1, 3), dtype=np.float32))
+    np.testing.assert_array_equal(court_vis_t.numpy()[0, 0, :, 14:], 0.0)
+
+
+def test_blcs_process_normalizes_multicamera_fixed_court_inputs() -> None:
+    num_cameras = 2
+    num_frames = 3
+    predictor = _BLCSStubPredictor(
+        torch.ones((1, num_frames, 3), dtype=torch.float32)
+    )
+    module = BLCSModule(BLCSConfig(checkpoint_path="dummy.ckpt", device="cpu"))
+    module._predictor = predictor
+
+    ball_uv = _make_float_array((num_cameras, num_frames, 2))
+    court_kp = _make_float_array((14, 2))
+
+    result = module.process(ball_uv=ball_uv, court_kp=court_kp)
+
+    is_valid, errors = result.validate()
+    assert is_valid, errors
+    assert result.ball_3d.shape == (num_frames, 3)
+
+    assert predictor.last_call is not None
+    ball_uv_t = _assert_tensor_shape(
+        predictor.last_call["ball_uv"],
+        (1, num_cameras, num_frames, 2),
+    )
+    court_kp_t = _assert_tensor_shape(
+        predictor.last_call["court_kp"],
+        (1, num_cameras, num_frames, 20, 2),
+    )
+    court_vis_t = _assert_tensor_shape(
+        predictor.last_call["court_vis"],
+        (1, num_cameras, num_frames, 20),
+    )
+    np.testing.assert_allclose(ball_uv_t.numpy()[0], ball_uv)
+    np.testing.assert_allclose(court_kp_t.numpy()[0, 0, 0, :14], court_kp)
+    np.testing.assert_allclose(court_kp_t.numpy()[0, 1, 2, :14], court_kp)
+    np.testing.assert_array_equal(court_vis_t.numpy()[0, :, :, 14:], 0.0)
+
+
+def test_plcs_process_normalizes_single_camera_per_frame_inputs() -> None:
+    num_players = 2
+    num_frames = 3
+    predictor = _PLCSStubPredictor(
+        position_meters=torch.ones((num_players, num_frames, 3), dtype=torch.float32),
+        yaw_radians=torch.zeros((num_players, num_frames), dtype=torch.float32),
+    )
+    module = PLCSModule(checkpoint_path="dummy.ckpt", device="cpu")
+    module._predictor = predictor
+
+    human_kp = _make_float_array((num_players, num_frames, 17, 2))
+    court_kp = _make_float_array((num_frames, 14, 2))
+    track_ids = np.array([10, 11], dtype=np.int32)
+
+    result = module.process(
+        human_kp_2d=human_kp,
+        court_kp=court_kp,
+        track_ids=track_ids,
+    )
+
+    is_valid, errors = result.validate()
+    assert is_valid, errors
+    np.testing.assert_array_equal(result.track_ids, track_ids)
+
+    assert predictor.last_call is not None
+    human_kp_t = _assert_tensor_shape(
+        predictor.last_call["human_kp"],
+        (num_players, 1, num_frames, 17, 2),
+    )
+    human_vis_t = _assert_tensor_shape(
+        predictor.last_call["human_vis"],
+        (num_players, 1, num_frames, 17),
+    )
+    human_mask_t = _assert_tensor_shape(
+        predictor.last_call["human_mask"],
+        (num_players, 1, num_frames),
+    )
+    court_kp_t = _assert_tensor_shape(
+        predictor.last_call["court_kp"],
+        (num_players, 1, num_frames, 20, 2),
+    )
+    court_vis_t = _assert_tensor_shape(
+        predictor.last_call["court_vis"],
+        (num_players, 1, num_frames, 20),
+    )
+    assert predictor.last_call["denormalize"] is True
+    np.testing.assert_allclose(human_kp_t.numpy()[:, 0], human_kp)
+    np.testing.assert_array_equal(
+        human_vis_t.numpy(),
+        np.ones((num_players, 1, num_frames, 17), dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        human_mask_t.numpy(),
+        np.ones((num_players, 1, num_frames), dtype=np.float32),
+    )
+    np.testing.assert_allclose(
+        court_kp_t.numpy()[:, 0, :, :14],
+        np.broadcast_to(court_kp, (num_players, num_frames, 14, 2)),
+    )
+    np.testing.assert_array_equal(court_vis_t.numpy()[:, 0, :, 14:], 0.0)
+
+
+def test_plcs_process_normalizes_multicamera_fixed_court_inputs() -> None:
+    num_players = 2
+    num_cameras = 2
+    num_frames = 3
+    predictor = _PLCSStubPredictor(
+        position_meters=torch.full(
+            (num_players, num_frames, 3),
+            fill_value=2.0,
+            dtype=torch.float32,
+        ),
+        yaw_radians=torch.full(
+            (num_players, num_frames),
+            fill_value=0.5,
+            dtype=torch.float32,
+        ),
+    )
+    module = PLCSModule(checkpoint_path="dummy.ckpt", device="cpu")
+    module._predictor = predictor
+
+    human_kp = _make_float_array((num_players, num_cameras, num_frames, 17, 2))
+    court_kp = _make_float_array((num_cameras, 14, 2))
+    court_vis = np.array(
+        [
+            [1.0] * 14,
+            [0.0, 1.0] * 7,
+        ],
+        dtype=np.float32,
+    )
+
+    result = module.process(
+        human_kp_2d=human_kp,
+        court_kp=court_kp,
+        court_vis=court_vis,
+    )
+
+    is_valid, errors = result.validate()
+    assert is_valid, errors
+    assert result.position.shape == (num_players, num_frames, 3)
+    assert result.yaw.shape == (num_players, num_frames)
+
+    assert predictor.last_call is not None
+    human_kp_t = _assert_tensor_shape(
+        predictor.last_call["human_kp"],
+        (num_players, num_cameras, num_frames, 17, 2),
+    )
+    court_kp_t = _assert_tensor_shape(
+        predictor.last_call["court_kp"],
+        (num_players, num_cameras, num_frames, 20, 2),
+    )
+    court_vis_t = _assert_tensor_shape(
+        predictor.last_call["court_vis"],
+        (num_players, num_cameras, num_frames, 20),
+    )
+    np.testing.assert_allclose(human_kp_t.numpy(), human_kp)
+    np.testing.assert_allclose(court_kp_t.numpy()[0, :, 0, :14], court_kp)
+    np.testing.assert_allclose(court_kp_t.numpy()[1, :, 2, :14], court_kp)
+    np.testing.assert_allclose(court_vis_t.numpy()[0, :, 1, :14], court_vis)
+    np.testing.assert_array_equal(court_vis_t.numpy()[:, :, :, 14:], 0.0)


### PR DESCRIPTION
## 概要
Tennis Scene wrapperの入力shapeを正規化します。

## 変更内容
- `src/tennis_scene/pipeline/components/input_shapes.py` の追加
- `blcs.py`, `plcs.py` の修正
- テストコードの追加

## 検証
`tests/test_tennis_scene_wrapper_input_shapes.py` による動作確認済み。

## 関連Issue
関連するIssueは指定されていません。

## 補足
なし
