### PR TITLE
court detection の kp/line に DINO Swin config を追加

### DIFF
--- a/src/tasks/court_detection/configs/model/court_kp_dino_swin_fpn.yaml
+++ b/src/tasks/court_detection/configs/model/court_kp_dino_swin_fpn.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - _hierarchical
+  - _dino_swin
+  - _self_
+
+name: court_hierarchical_dino_swin_fpn_kp
+in_channels: 3
+num_classes: 14
+
+decoder:
+  name: fpn

--- a/src/tasks/court_detection/configs/model/court_kp_dino_swin_unet.yaml
+++ b/src/tasks/court_detection/configs/model/court_kp_dino_swin_unet.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - _hierarchical
+  - _dino_swin
+  - _self_
+
+name: court_hierarchical_dino_swin_unet_kp
+in_channels: 3
+num_classes: 14
+
+decoder:
+  name: unet

--- a/src/tasks/court_detection/configs/model/court_line_dino_swin_fpn.yaml
+++ b/src/tasks/court_detection/configs/model/court_line_dino_swin_fpn.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - _hierarchical
+  - _dino_swin
+  - _self_
+
+name: court_hierarchical_dino_swin_fpn_line
+in_channels: 3
+num_classes: 1
+
+decoder:
+  name: fpn

--- a/src/tasks/court_detection/configs/model/court_line_dino_swin_unet.yaml
+++ b/src/tasks/court_detection/configs/model/court_line_dino_swin_unet.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - _hierarchical
+  - _dino_swin
+  - _self_
+
+name: court_hierarchical_dino_swin_unet_line
+in_channels: 3
+num_classes: 1
+
+decoder:
+  name: unet

--- a/tests/tasks/test_training_smoke_contracts.py
+++ b/tests/tasks/test_training_smoke_contracts.py
@@ -407,11 +407,47 @@ SMOKE_TASK_SPECS = (
                 ),
             ),
             SmokeVariant(
+                name="kp_dino_swin_fpn_config",
+                overrides=(
+                    "data=court_kp",
+                    "model=court_kp_dino_swin_fpn",
+                    "loss=kp",
+                    "model.encoder.name=default",
+                ),
+            ),
+            SmokeVariant(
+                name="kp_dino_swin_unet_config",
+                overrides=(
+                    "data=court_kp",
+                    "model=court_kp_dino_swin_unet",
+                    "loss=kp",
+                    "model.encoder.name=default",
+                ),
+            ),
+            SmokeVariant(
                 name="line",
                 overrides=(
                     "data=court_line",
                     "model=court_line",
                     "loss=line",
+                ),
+            ),
+            SmokeVariant(
+                name="line_dino_swin_fpn_config",
+                overrides=(
+                    "data=court_line",
+                    "model=court_line_dino_swin_fpn",
+                    "loss=line",
+                    "model.encoder.name=default",
+                ),
+            ),
+            SmokeVariant(
+                name="line_dino_swin_unet_config",
+                overrides=(
+                    "data=court_line",
+                    "model=court_line_dino_swin_unet",
+                    "loss=line",
+                    "model.encoder.name=default",
                 ),
             ),
         ),


### PR DESCRIPTION
## 概要

`src/tasks/court_detection/configs/model` に、seg と同様の DINO Swin 構成を kp / line タスク向けにも追加しました。
各タスクで FPN decoder と U-Net decoder の両方を Hydra の model group から選べるようにしています。

## 変更内容

- `court_kp_dino_swin_fpn.yaml` を追加
- `court_kp_dino_swin_unet.yaml` を追加
- `court_line_dino_swin_fpn.yaml` を追加
- `court_line_dino_swin_unet.yaml` を追加
- court detection smoke test に kp/line の DINO Swin config variants を追加

## 検証

- `.venv/bin/python -m pytest tests/tasks/test_training_smoke_contracts.py -k 'court_detection' -q`
  - 10 passed
- `.venv/bin/ruff check tests/tasks/test_training_smoke_contracts.py src/tasks/court_detection/configs/model`
- Hydra config compose/model build で以下を確認
  - `model=court_kp_dino_swin_fpn`
  - `model=court_kp_dino_swin_unet`
  - `model=court_line_dino_swin_fpn`
  - `model=court_line_dino_swin_unet`

## 関連Issue

なし

## 補足

smoke test では重い DINO checkpoint 依存を避けるため、DINO Swin config variants の encoder を `default` に上書きしています。
