### PR TITLE
feat(ball_detection): GAN 拡張によるヒートマップ品質向上

### DIFF
--- a/src/tasks/ball_detection/configs/training/_gan.yaml
+++ b/src/tasks/ball_detection/configs/training/_gan.yaml
@@ -1,5 +1,5 @@
 gan:
-  enabled: false
+  enabled: true
   # Heatmap focal-BCE loss is orders of magnitude smaller than the LSGAN
   # generator loss, so keep the adversarial weight small.
   target_weight: 0.02

--- a/src/tasks/ball_detection/configs/training/_gan.yaml
+++ b/src/tasks/ball_detection/configs/training/_gan.yaml
@@ -1,0 +1,32 @@
+gan:
+  enabled: false
+  # Heatmap focal-BCE loss is orders of magnitude smaller than the LSGAN
+  # generator loss, so keep the adversarial weight small.
+  target_weight: 0.02
+  warmup_epochs: 5
+  generator_gradient_clip_val: 1.0
+  discriminator_gradient_clip_val: 1.0
+  # Spatial softmax temperature for differentiable coordinate extraction
+  # from predicted heatmap logits.
+  soft_argmax_temperature: 1.0
+
+  transition:
+    monitor: val/loss
+    mode: min
+    patience: 3
+    min_delta: 2.0e-6
+    min_supervised_epochs: 1
+
+  discriminator:
+    name: trajectory_transformer
+    hidden_dim: 128
+    num_layers: 4
+    num_heads: 4
+    ffn_dim: 256
+    ffn_type: swiglu
+    dropout: 0.1
+    rope_dim: null
+    rope_theta: 10000.0
+    max_seq_len: ${model.num_frames}
+    invisible_init_std: 0.02
+    cls_init_std: 0.02

--- a/src/tasks/ball_detection/configs/training/gan.yaml
+++ b/src/tasks/ball_detection/configs/training/gan.yaml
@@ -1,0 +1,7 @@
+defaults:
+  - default
+  - _gan
+  - _self_
+
+gan:
+  enabled: true

--- a/src/tasks/ball_detection/models/__init__.py
+++ b/src/tasks/ball_detection/models/__init__.py
@@ -8,6 +8,9 @@ from torch import nn
 
 from src.tasks.ball_detection.models.conv_next_unet import ConvNeXtUNet
 from src.tasks.ball_detection.models.dino_pseudo3d import DINOPseudo3DBallDetector
+from src.tasks.ball_detection.models.discriminators import (
+    build_ball_detection_discriminator,
+)
 from src.tasks.ball_detection.models.spatiotemporal_unet import SpatioTemporalUNet
 
 if TYPE_CHECKING:
@@ -35,5 +38,6 @@ __all__ = [
     "ConvNeXtUNet",
     "DINOPseudo3DBallDetector",
     "SpatioTemporalUNet",
+    "build_ball_detection_discriminator",
     "build_ball_detection_model",
 ]

--- a/src/tasks/ball_detection/models/discriminators/__init__.py
+++ b/src/tasks/ball_detection/models/discriminators/__init__.py
@@ -1,0 +1,28 @@
+"""Ball detection discriminator modules."""
+
+from __future__ import annotations
+
+from omegaconf import DictConfig
+
+from src.tasks.ball_detection.models.discriminators.trajectory_discriminator import (
+    BallTrajectoryDiscriminator,
+)
+
+
+def build_ball_detection_discriminator(config: DictConfig) -> BallTrajectoryDiscriminator:
+    """Build the configured ball detection discriminator."""
+    train_cfg = config.get("training", {}) or {}
+    gan_cfg = train_cfg.get("gan", {}) or {}
+    disc_name = str(gan_cfg.get("discriminator", {}).get("name", "trajectory_transformer"))
+    if disc_name != "trajectory_transformer":
+        raise ValueError(
+            "Unknown ball_detection discriminator name="
+            f"'{disc_name}'. Supported: ['trajectory_transformer']"
+        )
+    return BallTrajectoryDiscriminator.from_config(config)
+
+
+__all__ = [
+    "BallTrajectoryDiscriminator",
+    "build_ball_detection_discriminator",
+]

--- a/src/tasks/ball_detection/models/discriminators/trajectory_discriminator.py
+++ b/src/tasks/ball_detection/models/discriminators/trajectory_discriminator.py
@@ -1,0 +1,72 @@
+"""Transformer discriminator wrapper for ball 2D trajectories."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from torch import Tensor
+
+from src.utils.models.architectures import TransformerSequenceDiscriminator
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+class BallTrajectoryDiscriminator(TransformerSequenceDiscriminator):
+    """Score normalized image-space ball trajectories as real or fake."""
+
+    def __init__(
+        self,
+        *,
+        hidden_dim: int = 128,
+        num_layers: int = 4,
+        num_heads: int = 4,
+        ffn_dim: int | None = None,
+        dropout: float = 0.1,
+        rope_dim: int | None = None,
+        rope_theta: float = 10000.0,
+        ffn_type: str = "swiglu",
+        max_seq_len: int = 64,
+        invisible_init_std: float = 0.02,
+        cls_init_std: float = 0.02,
+    ) -> None:
+        super().__init__(
+            input_dim=2,
+            hidden_dim=hidden_dim,
+            num_layers=num_layers,
+            num_heads=num_heads,
+            ffn_dim=ffn_dim,
+            dropout=dropout,
+            rope_dim=rope_dim,
+            rope_theta=rope_theta,
+            ffn_type=ffn_type,
+            max_seq_len=max_seq_len,
+            invalid_init_std=invisible_init_std,
+            cls_init_std=cls_init_std,
+        )
+
+    @classmethod
+    def from_config(cls, config: DictConfig) -> BallTrajectoryDiscriminator:
+        """Build discriminator from training.gan.discriminator config."""
+        train_cfg = config.get("training", {}) or {}
+        gan_cfg = train_cfg.get("gan", {}) or {}
+        disc_cfg = gan_cfg.get("discriminator", {}) or {}
+        model_cfg = config.get("model", {}) or {}
+
+        return cls(
+            hidden_dim=int(disc_cfg.get("hidden_dim", 128)),
+            num_layers=int(disc_cfg.get("num_layers", 4)),
+            num_heads=int(disc_cfg.get("num_heads", 4)),
+            ffn_dim=disc_cfg.get("ffn_dim", None),
+            dropout=float(disc_cfg.get("dropout", 0.1)),
+            rope_dim=disc_cfg.get("rope_dim", None),
+            rope_theta=float(disc_cfg.get("rope_theta", 10000.0)),
+            ffn_type=str(disc_cfg.get("ffn_type", "swiglu")),
+            max_seq_len=int(disc_cfg.get("max_seq_len", model_cfg.get("num_frames", 8))),
+            invisible_init_std=float(disc_cfg.get("invisible_init_std", 0.02)),
+            cls_init_std=float(disc_cfg.get("cls_init_std", 0.02)),
+        )
+
+    def forward(self, ball_xy: Tensor, *, mask: Tensor | None = None) -> Tensor:
+        """Score normalized ball coordinate sequences as real or fake."""
+        return super().forward(ball_xy, mask=mask)

--- a/src/tasks/ball_detection/training/lightning_module.py
+++ b/src/tasks/ball_detection/training/lightning_module.py
@@ -15,26 +15,33 @@ from src.tasks.ball_detection.data.argumentation import (
     denormalize_tensor_images_imagenet,
 )
 from src.tasks.ball_detection.data.utils.input_adapter import to_model_input
-from src.tasks.ball_detection.models import build_ball_detection_model
+from src.tasks.ball_detection.models import (
+    build_ball_detection_discriminator,
+    build_ball_detection_model,
+)
 from src.tasks.ball_detection.training.losses import BallDetectionFocalLoss
 from src.tasks.ball_detection.training.metrics import BallDetectionMetrics
+from src.tasks.base.training.gan_training import ManualGANSupportMixin
 from src.tasks.base.training.lightning_module import BaseLightningModule
 from src.tasks.base.training.qualitative_callback import save_image_to_tensorboard
+from src.utils.data.heatmaps import heatmaps_to_soft_argmax
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
 
-class BallDetectionLightningModule(BaseLightningModule):
+class BallDetectionLightningModule(ManualGANSupportMixin, BaseLightningModule):
     """Lightning module for training ball detection.
 
-    Inherits optimizer/scheduler logic from
-    :class:`~src.tasks.base.training.lightning_module.BaseLightningModule`.
+    Supervised training optimizes heatmap losses. When ``training.gan.enabled``
+    is set, ball coordinate sequences extracted from predicted heatmaps via
+    differentiable soft-argmax are scored by a trajectory discriminator against
+    ground-truth coordinate sequences, and the binary real/fake signal is fed
+    back to the heatmap model as an adversarial loss.
     """
 
     def __init__(self, config: DictConfig | None = None) -> None:
         super().__init__(config)
-        self.save_hyperparameters()
 
         loss_cfg = self.config.get("loss", {})
         metrics_cfg = self.config.get("metrics", {})
@@ -42,6 +49,18 @@ class BallDetectionLightningModule(BaseLightningModule):
         self.model = build_ball_detection_model(self.config)
 
         self.loss_fn = BallDetectionFocalLoss(loss_cfg)
+
+        train_cfg = self.config.get("training", {})
+        gan_cfg = train_cfg.get("gan", {}) or {}
+        gan_enabled = bool(gan_cfg.get("enabled", False))
+        self.gan_soft_argmax_temperature = float(
+            gan_cfg.get("soft_argmax_temperature", 1.0)
+        )
+        self._initialize_manual_gan(
+            discriminator=(
+                build_ball_detection_discriminator(self.config) if gan_enabled else None
+            ),
+        )
 
         self.train_metrics = BallDetectionMetrics(
             peak_threshold=float(metrics_cfg.get("peak_threshold", 0.5)),
@@ -79,15 +98,8 @@ class BallDetectionLightningModule(BaseLightningModule):
         """
         return self.model(images)
 
-    def _shared_step(
-        self,
-        batch: dict[str, Tensor],
-        stage: str,
-    ) -> dict[str, Tensor]:
-        """Shared computation for train/val/test steps."""
-        images = batch["images"]
-        target_heatmaps = batch["heatmaps"]
-
+    def _predict_heatmap_logits(self, images: Tensor, target_size_hw: tuple[int, int]) -> Tensor:
+        """Predict per-frame heatmap logits resized to the target heatmap size."""
         model_cfg = self.config.get("model", {})
         model_input = to_model_input(images, model_cfg)
 
@@ -97,81 +109,113 @@ class BallDetectionLightningModule(BaseLightningModule):
         logits = logits.squeeze(1)
 
         # Interpolate if model output size != target heatmap size
-        if logits.shape[-2:] != target_heatmaps.shape[-2:]:
+        if logits.shape[-2:] != target_size_hw:
             b, t = logits.shape[:2]
             logits_flat = logits.reshape(b * t, 1, *logits.shape[-2:])
             logits_flat = F.interpolate(
                 logits_flat,
-                size=target_heatmaps.shape[-2:],
+                size=target_size_hw,
                 mode="bilinear",
                 align_corners=False,
             )
-            logits = logits_flat.reshape(b, t, *target_heatmaps.shape[-2:])
+            logits = logits_flat.reshape(b, t, *target_size_hw)
+        return logits
+
+    def _extract_gt_trajectory(self, batch: dict[str, Tensor]) -> tuple[Tensor, Tensor]:
+        """Extract the primary ball trajectory and its visibility mask.
+
+        Returns:
+            Tuple of:
+                - ball_xy: Normalized ``(B, T, 2)`` coordinates in ``(x, y)``.
+                - mask: Boolean ``(B, T)`` mask of frames with a visible ball.
+        """
+        coords = batch["coords"]  # (B, T, K, 2) in original image pixels
+        visibility = batch["visibility"]  # (B, T, K)
+        original_size = batch["original_size"]  # (B, 2) as (width, height)
+
+        # Pick the first visible instance per frame (argmax of a 0/1 mask
+        # returns the first maximal entry).
+        first_visible = visibility.argmax(dim=-1)  # (B, T)
+        gather_index = first_visible[..., None, None].expand(-1, -1, 1, 2)
+        ball_xy = coords.gather(2, gather_index).squeeze(2)  # (B, T, 2)
+
+        scale = (original_size - 1.0).clamp(min=1.0)  # (B, 2)
+        ball_xy = ball_xy / scale[:, None, :]
+        mask = visibility.amax(dim=-1) > 0.5
+        return ball_xy, mask
+
+    def _compute_supervised_result(
+        self,
+        batch: dict[str, Tensor],
+        stage: str,
+    ) -> dict[str, Any]:
+        """Compute forward pass, supervised loss, metrics, and GAN sequences."""
+        target_heatmaps = batch["heatmaps"]
+        logits = self._predict_heatmap_logits(
+            batch["images"],
+            target_heatmaps.shape[-2:],
+        )
 
         loss = self.loss_fn(logits, target_heatmaps)
-        self.log(f"{stage}/loss", loss, prog_bar=True, sync_dist=True)
-
         pred_heatmaps = torch.sigmoid(logits)
+
+        self._select_metrics(stage).update(
+            pred_heatmaps,
+            batch["coords"],
+            batch["visibility"],
+            batch["original_size"],
+        )
+
+        gan_real, gan_mask = self._extract_gt_trajectory(batch)
+        gan_fake = heatmaps_to_soft_argmax(
+            logits,
+            temperature=self.gan_soft_argmax_temperature,
+        )
 
         return {
             "loss": loss,
+            "metrics": {},
             "pred_heatmaps": pred_heatmaps,
-            "target_coords": batch["coords"],
-            "target_visibility": batch["visibility"],
-            "original_size": batch["original_size"],
+            "gan_fake": gan_fake,
+            "gan_real": gan_real,
+            "gan_mask": gan_mask,
         }
 
-    def training_step(self, batch: dict[str, Tensor], batch_idx: int) -> Tensor:
-        """Training step."""
-        outputs = self._shared_step(batch, "train")
-        self.train_metrics.update(
-            outputs["pred_heatmaps"],
-            outputs["target_coords"],
-            outputs["target_visibility"],
-            outputs["original_size"],
-        )
-        return outputs["loss"]
+    def _select_metrics(self, stage: str) -> BallDetectionMetrics:
+        """Return the metrics object for the current stage."""
+        if stage == "train":
+            return self.train_metrics
+        if stage == "val":
+            return self.val_metrics
+        return self.test_metrics
 
-    def on_train_epoch_end(self) -> None:
-        """Log training metrics at epoch end."""
-        metrics = self.train_metrics.compute()
+    def _metric_tracker_for_stage(self, stage: str) -> BallDetectionMetrics:
+        return self._select_metrics(stage)
+
+    def _flush_stage_metrics(self, stage: str) -> None:
+        tracker = self._metric_tracker_for_stage(stage)
+        metrics = tracker.compute()
         for name, value in metrics.items():
-            self.log(f"train/{name}", value)
-        self.train_metrics.reset()
+            self.log(
+                f"{stage}/{name}",
+                value,
+                prog_bar=(stage == "val" and name == "f1"),
+            )
+        tracker.reset()
 
-    def validation_step(self, batch: dict[str, Tensor], batch_idx: int) -> None:
-        """Validation step."""
-        outputs = self._shared_step(batch, "val")
-        self.val_metrics.update(
-            outputs["pred_heatmaps"],
-            outputs["target_coords"],
-            outputs["target_visibility"],
-            outputs["original_size"],
-        )
+    def _log_stage_metrics(self, stage: str, loss: Tensor, metrics: dict[str, Any]) -> None:
+        self.log(f"{stage}/loss", loss, prog_bar=True, sync_dist=True)
+        if stage == "train" and self.gan_enabled:
+            self.log("train/gan_weight", float(self.current_gan_weight))
+            self.log("train/gan_phase_active", float(self.gan_phase_active))
+            if "loss_gan_generator" in metrics:
+                self.log("train/loss_gan_generator", metrics["loss_gan_generator"])
+            if "loss_gan_discriminator" in metrics:
+                self.log("train/loss_gan_discriminator", metrics["loss_gan_discriminator"])
 
-    def on_validation_epoch_end(self) -> None:
-        """Log validation metrics at epoch end."""
-        metrics = self.val_metrics.compute()
-        for name, value in metrics.items():
-            self.log(f"val/{name}", value, prog_bar=(name == "f1"))
-        self.val_metrics.reset()
-
-    def test_step(self, batch: dict[str, Tensor], batch_idx: int) -> None:
-        """Test step."""
-        outputs = self._shared_step(batch, "test")
-        self.test_metrics.update(
-            outputs["pred_heatmaps"],
-            outputs["target_coords"],
-            outputs["target_visibility"],
-            outputs["original_size"],
-        )
-
-    def on_test_epoch_end(self) -> None:
-        """Log test metrics at epoch end."""
-        metrics = self.test_metrics.compute()
-        for name, value in metrics.items():
-            self.log(f"test/{name}", value)
-        self.test_metrics.reset()
+    def configure_optimizers(self) -> Any:
+        """Configure generator/discriminator optimizers through the shared GAN helper."""
+        return self.configure_gan_optimizers(self.model.parameters())
 
     # ------------------------------------------------------------------
     # Qualitative validation logging
@@ -195,21 +239,8 @@ class BallDetectionLightningModule(BaseLightningModule):
             coords_gt = batch["coords"]  # (B, T, K, 2)
             visibility = batch["visibility"]  # (B, T, K)
 
-            model_cfg = self.config.get("model", {})
-            model_input = to_model_input(images, model_cfg)
-
             with torch.no_grad():
-                logits = self.model(model_input).squeeze(1)  # (B, T, Hh, Wh)
-                if logits.shape[-2:] != heatmaps_gt.shape[-2:]:
-                    b, t = logits.shape[:2]
-                    logits_flat = logits.reshape(b * t, 1, *logits.shape[-2:])
-                    logits_flat = F.interpolate(
-                        logits_flat,
-                        size=heatmaps_gt.shape[-2:],
-                        mode="bilinear",
-                        align_corners=False,
-                    )
-                    logits = logits_flat.reshape(b, t, *heatmaps_gt.shape[-2:])
+                logits = self._predict_heatmap_logits(images, heatmaps_gt.shape[-2:])
                 pred_heatmaps = torch.sigmoid(logits).cpu()
 
             # Render the first sample as a 3-row temporal contact sheet.

--- a/src/utils/data/heatmaps.py
+++ b/src/utils/data/heatmaps.py
@@ -135,6 +135,50 @@ def heatmaps_to_argmax(heatmaps: Tensor) -> tuple[Tensor, Tensor]:
     return coords, values
 
 
+def heatmaps_to_soft_argmax(
+    heatmaps: Tensor,
+    *,
+    temperature: float = 1.0,
+) -> Tensor:
+    """Convert heatmaps to dense normalized coordinates via soft-argmax.
+
+    Unlike :func:`heatmaps_to_argmax`, this conversion is differentiable and
+    can propagate gradients from coordinate-space losses back to the heatmaps.
+
+    Args:
+        heatmaps: Tensor with shape ``(..., H, W)``. Values are treated as
+            unnormalized scores (e.g. logits) for the spatial softmax.
+        temperature: Softmax temperature. Lower values sharpen the spatial
+            distribution towards the hard argmax.
+
+    Returns:
+        Normalized ``(..., 2)`` coordinates in ``(x, y)`` ordering.
+    """
+    if heatmaps.ndim < 2:
+        raise ValueError(f"heatmaps must have shape (..., H, W), got {tuple(heatmaps.shape)}.")
+    if temperature <= 0:
+        raise ValueError("temperature must be positive.")
+
+    *leading_shape, height, width = heatmaps.shape
+    flat = heatmaps.reshape(*leading_shape, height * width)
+    probs = torch.softmax(flat / float(temperature), dim=-1)
+    probs = probs.reshape(*leading_shape, height, width)
+
+    xs = (
+        torch.linspace(0.0, 1.0, width, dtype=heatmaps.dtype, device=heatmaps.device)
+        if width > 1
+        else torch.zeros(1, dtype=heatmaps.dtype, device=heatmaps.device)
+    )
+    ys = (
+        torch.linspace(0.0, 1.0, height, dtype=heatmaps.dtype, device=heatmaps.device)
+        if height > 1
+        else torch.zeros(1, dtype=heatmaps.dtype, device=heatmaps.device)
+    )
+    x = (probs.sum(dim=-2) * xs).sum(dim=-1)
+    y = (probs.sum(dim=-1) * ys).sum(dim=-1)
+    return torch.stack([x, y], dim=-1)
+
+
 def heatmaps_to_peaks(
     heatmaps: Tensor,
     *,


### PR DESCRIPTION
## 概要

ボール検出モデルのヒートマップ出力に対して、軌道 Transformer 識別器を用いた LSGAN による敵対的学習を追加する。
推論時に予測ヒートマップから微分可能な soft-argmax でボール座標列を抽出し、真の軌道と偽の軌道を識別器が判定、その敵対的損失をヒートマップモデルに逆伝播させる。
`training=gan` でオプトイン、無指定時は従来の教師あり学習と完全互換。

### Before → After

| 指標 | 旧 | 新 |
|------|-----|-----|
| 学習方式 | 教師あり heatmap loss のみ | GAN adversarial loss 併用（オプトイン） |
| 学習パイプライン | 単一 optimizer | Generator/Discriminator 独立 optimizer |
| ボール座標抽出 | hard argmax（非微分） | 微分可能 soft-argmax 追加 |

---

## 変更内容

### Commit 1：feat(ball_detection): add GAN extension with trajectory discriminator（6 files, +301/-83）

#### `src/tasks/ball_detection/training/lightning_module.py`（+145/-103）
- `BaseLightningModule` 単独継承 → `ManualGANSupportMixin` を追加継承
- `_shared_step` を分解：`_predict_heatmap_logits` / `_compute_supervised_result` / `_extract_gt_trajectory` に分割
- step/epoch-end メソッドを Mixin 互換の `_flush_stage_metrics` / `_log_stage_metrics` に統一
- `configure_optimizers` を `configure_gan_optimizers` に委譲
- GAN 有効時に `train/gan_weight`, `train/gan_phase_active`, `train/loss_gan_generator`, `train/loss_gan_discriminator` をログ出力

#### `src/tasks/ball_detection/models/discriminators/`（新規, +100 行）
- `trajectory_discriminator.py`: `TransformerSequenceDiscriminator` をラップした `BallTrajectoryDiscriminator`
- `__init__.py`: `build_ball_detection_discriminator` ファクトリ関数
- 入力：正規化 `(B, T, 2)` 座標 + visibility mask
- 出力：real/fake スコア

#### `src/tasks/ball_detection/models/__init__.py`（+4 行）
- `build_ball_detection_discriminator` をエクスポート

#### `src/utils/data/heatmaps.py`（+44 行）
- `heatmaps_to_soft_argmax` 関数を追加
- spatial softmax による微分可能な座標抽出（temperature 制御可）

### Commit 2：feat(gan): enable GAN training in configuration（2 files, +39 行）

#### `src/tasks/ball_detection/configs/training/gan.yaml`（新規, +7 行）
- `default → _gan → _self_` の Hydra 構成チェーン

#### `src/tasks/ball_detection/configs/training/_gan.yaml`（新規, +32 行）
- `gan.enabled: true`
- LSGAN generator loss weight: `target_weight: 0.02`
- Warmup: 5 epochs（教師あり学習で安定化）
- Gradient clipping: generator 1.0 / discriminator 1.0
- Transition: `val/loss` monitor, patience 3, min_delta 2e-6
- Discriminator: `trajectory_transformer`, hidden_dim=128, 4 layers, 4 heads, SwiGLU FFN

---

## 設計上のポイント

- **ManualGANSupportMixin**：BLCS で確立された GAN パターンを再利用。optimizer 管理、GAN phase 切り替え、weight warmup を共通化
- **TransformerSequenceDiscriminator**：時系列識別の汎用基盤（`src/utils/models/architectures` に実装済み）を継承
- **微分可能 soft-argmax**：hard argmax と異なり勾配が流れるため、end-to-end で敵対的損失を逆伝播可能
- **後方互換**：`training=default` を指定する限り、GAN は一切関与しない

---

## 残課題

- GAN loss の `target_weight: 0.02` は球検出ヒートマップに対する適正値の実験的検証が必要
- `warmup_epochs: 5` の適正値もハイパラ探索未実施
- trajectory discriminator のアーキテクチャ（層数・次元数）の ablation study