### PR TITLE
refactor(losses): blcs/plcsの時系列損失を削除 (#503)

### DIFF
--- a/src/tasks/blcs/training/lightning_module.py
+++ b/src/tasks/blcs/training/lightning_module.py
@@ -42,13 +42,10 @@ class BLCSLightningModule(ManualGANSupportMixin, BaseLightningModule):
 
         train_cfg = self.config.get("training", {})
         trainer_cfg = train_cfg.get("trainer", {}) or {}
-        self.max_epochs = int(trainer_cfg.get("max_epochs", self.max_epochs))
+        self.max_epochs = int(trainer_cfg.get("max_epochs") or self.max_epochs)  # type: ignore[has-type]
         self.loss_fn = BLCSLoss(
             position_weight=train_cfg.get("position_loss_weight", 1.0),
-            velocity_weight=train_cfg.get("velocity_loss_weight", 0.1),
-            smoothness_weight=train_cfg.get("smoothness_loss_weight", 0.05),
             reprojection_weight=train_cfg.get("reprojection_loss_weight", 0.0),
-            uv_velocity_weight=train_cfg.get("uv_velocity_loss_weight", 0.0),
         )
         gan_enabled = bool((train_cfg.get("gan", {}) or {}).get("enabled", False))
         self._initialize_manual_gan(
@@ -71,13 +68,14 @@ class BLCSLightningModule(ManualGANSupportMixin, BaseLightningModule):
 
     def _forward_from_batch(self, batch: BLCSBatch | BLCSMultiViewBatch) -> dict[str, Tensor]:
         """Forward model from a batch."""
-        return self.model(
+        result: dict[str, Tensor] = self.model(
             ball_uv=batch["ball_uv"],
             court_kp=batch["court_kp"],
             ball_vis=batch.get("ball_vis"),
             ball_mask=batch.get("ball_mask"),
             court_vis=batch.get("court_vis"),
         )
+        return result
 
     def _normalize_loss_mask(self, batch: BLCSBatch | BLCSMultiViewBatch) -> Tensor | None:
         """Normalize loss/metric mask to shape (B, T)."""
@@ -185,9 +183,9 @@ class BLCSLightningModule(ManualGANSupportMixin, BaseLightningModule):
 
             fig_w, fig_h = 400, 400
             # Top-down: X vs Y
-            canvas_top = np.ones((fig_h, fig_w, 3), dtype=np.uint8) * 255
+            canvas_top: np.ndarray = np.ones((fig_h, fig_w, 3), dtype=np.uint8) * 255
             # Side: X vs Z
-            canvas_side = np.ones((fig_h, fig_w, 3), dtype=np.uint8) * 255
+            canvas_side: np.ndarray = np.ones((fig_h, fig_w, 3), dtype=np.uint8) * 255
 
             def _normalize_and_draw(
                 canvas: np.ndarray, gt_2d: np.ndarray, pred_2d: np.ndarray, valid: np.ndarray

--- a/src/tasks/blcs/training/losses.py
+++ b/src/tasks/blcs/training/losses.py
@@ -34,62 +34,6 @@ def trajectory_position_loss(
     return masked_mean(loss, mask, eps=1e-8)
 
 
-def velocity_loss(
-    pred_pos: Tensor,
-    target_pos: Tensor,
-    mask: Tensor | None = None,
-) -> Tensor:
-    """Compute velocity consistency loss.
-
-    Encourages predicted trajectory to have consistent velocities
-    with the ground truth.
-
-    Args:
-        pred_pos: Predicted positions, shape (B, T, 3).
-        target_pos: Target positions, shape (B, T, 3).
-        mask: Visibility mask, shape (B, T).
-
-    Returns:
-        Tensor: Velocity loss.
-
-    """
-    # Compute finite differences (velocities)
-    pred_vel = pred_pos[:, 1:] - pred_pos[:, :-1]
-    target_vel = target_pos[:, 1:] - target_pos[:, :-1]
-
-    loss = nn.functional.smooth_l1_loss(pred_vel, target_vel, reduction="none")
-    # Velocity is valid only when both adjacent frames are valid.
-    vel_mask = mask[:, 1:] * mask[:, :-1] if mask is not None else None
-    return masked_mean(loss, vel_mask, eps=1e-8)
-
-
-def smoothness_loss(
-    pred_pos: Tensor,
-    mask: Tensor | None = None,
-) -> Tensor:
-    """Compute trajectory smoothness loss.
-
-    Penalizes high acceleration (second derivative) to encourage
-    smooth trajectories.
-
-    Args:
-        pred_pos: Predicted positions, shape (B, T, 3).
-        mask: Visibility mask, shape (B, T).
-
-    Returns:
-        Tensor: Smoothness loss.
-
-    """
-    # Compute second derivative (acceleration)
-    vel = pred_pos[:, 1:] - pred_pos[:, :-1]
-    accel = vel[:, 1:] - vel[:, :-1]
-
-    loss = (accel**2).sum(dim=-1)  # (B, T-2)
-    # Acceleration is valid only when three consecutive frames are valid.
-    accel_mask = mask[:, 2:] * mask[:, 1:-1] * mask[:, :-2] if mask is not None else None
-    return masked_mean(loss, accel_mask, eps=1e-8)
-
-
 # ---------------------------------------------------------------------------
 # Reprojection losses (2D supervision)
 # ---------------------------------------------------------------------------
@@ -145,97 +89,33 @@ def reprojection_loss(
     return masked_mean(loss, effective_mask.unsqueeze(-1).expand_as(loss), eps=1e-8)
 
 
-def uv_velocity_loss(
-    pred_position: Tensor,
-    target_uv: Tensor,
-    target_vis: Tensor,
-    camera_R: Tensor,
-    camera_C: Tensor,
-    camera_f: Tensor,
-    camera_cx: Tensor,
-    camera_cy: Tensor,
-    camera_w: Tensor,
-    camera_h: Tensor,
-    projector: DifferentiableProjection,
-    mask: Tensor | None = None,
-) -> Tensor:
-    """Compute 2D velocity consistency loss in UV space.
-
-    Encourages predicted UV frame-to-frame velocity to match the GT UV
-    velocity for each camera view.
-
-    Args:
-        pred_position: Predicted 3D in normalised court coords, ``(B, T, 3)``.
-        target_uv: Ground truth ball UV per camera, ``(B, N, T, 2)``.
-        target_vis: Ball visibility per camera, ``(B, N, T)``.
-        camera_R .. camera_h: Camera parameters.
-        projector: Differentiable projection module.
-        mask: Sequence-level padding mask, ``(B, T)``.
-
-    Returns:
-        Scalar UV velocity loss.
-    """
-    pred_uv, in_front = projector(
-        position_norm=pred_position,
-        camera_R=camera_R,
-        camera_C=camera_C,
-        camera_f=camera_f,
-        camera_cx=camera_cx,
-        camera_cy=camera_cy,
-        camera_w=camera_w,
-        camera_h=camera_h,
-    )  # (B, N, T, 2)
-
-    pred_vel = pred_uv[:, :, 1:] - pred_uv[:, :, :-1]  # (B, N, T-1, 2)
-    target_vel = target_uv[:, :, 1:] - target_uv[:, :, :-1]
-
-    # Both adjacent frames must be visible and in front
-    vis = (target_vis > 0).float() * in_front.float()
-    vel_vis = vis[:, :, 1:] * vis[:, :, :-1]  # (B, N, T-1)
-    if mask is not None:
-        vel_mask = (mask[:, 1:] * mask[:, :-1]).unsqueeze(1)  # (B, 1, T-1)
-        vel_vis = vel_vis * vel_mask
-
-    loss = nn.functional.smooth_l1_loss(pred_vel, target_vel, reduction="none")
-    return masked_mean(loss, vel_vis.unsqueeze(-1).expand_as(loss), eps=1e-8)
-
-
 class BLCSLoss(nn.Module):
     """Combined loss for BLCS training.
 
-    Combines position, velocity, smoothness, reprojection and UV velocity
-    losses with configurable weights.  Set ``position_weight=0`` and
-    ``velocity_weight=0`` to train purely from 2D supervision.
+    Combines position and reprojection losses with configurable weights.
+    Temporal consistency is enforced by the GAN discriminator.
+    Set ``position_weight=0`` to train purely from 2D supervision.
     """
 
     def __init__(
         self,
         position_weight: float = 1.0,
-        velocity_weight: float = 0.1,
-        smoothness_weight: float = 0.05,
         reprojection_weight: float = 0.0,
-        uv_velocity_weight: float = 0.0,
     ) -> None:
         """Initialize the loss module.
 
         Args:
             position_weight: Weight for 3D position loss.
-            velocity_weight: Weight for 3D velocity consistency loss.
-            smoothness_weight: Weight for 3D smoothness loss.
             reprojection_weight: Weight for multi-view reprojection loss.
-            uv_velocity_weight: Weight for 2D UV velocity consistency loss.
 
         """
         super().__init__()
         self.position_weight = position_weight
-        self.velocity_weight = velocity_weight
-        self.smoothness_weight = smoothness_weight
         self.reprojection_weight = reprojection_weight
-        self.uv_velocity_weight = uv_velocity_weight
 
-        # Lazily created when reprojection losses are needed
+        # Lazily created when reprojection loss is needed
         self._projector: DifferentiableProjection | None = None
-        if reprojection_weight > 0 or uv_velocity_weight > 0:
+        if reprojection_weight > 0:
             self._projector = DifferentiableProjection()
 
     @property
@@ -266,36 +146,27 @@ class BLCSLoss(nn.Module):
         Args:
             pred_position: Predicted positions, shape (B, T, 3).
             target_position: Target 3D positions, shape (B, T, 3).
-                Required when ``position_weight > 0`` or ``velocity_weight > 0``.
+                Required when ``position_weight > 0``.
             mask: Visibility mask, shape (B, T).
             target_uv: GT ball UV per camera, ``(B, N, T, 2)``.
             target_vis: Ball visibility per camera, ``(B, N, T)``.
             camera_R .. camera_h: Camera parameters for reprojection.
 
         Returns:
-            dict with keys ``'total'``, ``'position'``, ``'velocity'``,
-            ``'smoothness'``, ``'reprojection'``, ``'uv_velocity'``.
+            dict with keys ``'total'``, ``'position'``, ``'reprojection'``.
 
         """
         device = pred_position.device
         zero = torch.tensor(0.0, device=device)
 
-        # ---- 3D losses ------------------------------------------------
+        # ---- 3D position loss -----------------------------------------
         if self.position_weight > 0 and target_position is not None:
             pos_loss = trajectory_position_loss(pred_position, target_position, mask)
         else:
             pos_loss = zero
 
-        if self.velocity_weight > 0 and target_position is not None:
-            vel_loss = velocity_loss(pred_position, target_position, mask)
-        else:
-            vel_loss = zero
-
-        smooth_loss = smoothness_loss(pred_position, mask)
-
-        # ---- Reprojection losses ---------------------------------------
+        # ---- Reprojection loss ----------------------------------------
         reproj_loss = zero
-        uv_vel_loss = zero
 
         _has_cam = (
             target_uv is not None
@@ -334,45 +205,14 @@ class BLCSLoss(nn.Module):
                 mask=mask,
             )
 
-        if self.uv_velocity_weight > 0 and _has_cam:
-            assert target_uv is not None
-            assert target_vis is not None
-            assert camera_R is not None
-            assert camera_C is not None
-            assert camera_f is not None
-            assert camera_cx is not None
-            assert camera_cy is not None
-            assert camera_w is not None
-            assert camera_h is not None
-            uv_vel_loss = uv_velocity_loss(
-                pred_position=pred_position,
-                target_uv=target_uv,
-                target_vis=target_vis,
-                camera_R=camera_R,
-                camera_C=camera_C,
-                camera_f=camera_f,
-                camera_cx=camera_cx,
-                camera_cy=camera_cy,
-                camera_w=camera_w,
-                camera_h=camera_h,
-                projector=self.projector,
-                mask=mask,
-            )
-
         # ---- Total ----------------------------------------------------
         total = (
             self.position_weight * pos_loss
-            + self.velocity_weight * vel_loss
-            + self.smoothness_weight * smooth_loss
             + self.reprojection_weight * reproj_loss
-            + self.uv_velocity_weight * uv_vel_loss
         )
 
         return {
             "total": total,
             "position": pos_loss,
-            "velocity": vel_loss,
-            "smoothness": smooth_loss,
             "reprojection": reproj_loss,
-            "uv_velocity": uv_vel_loss,
         }

--- a/src/tasks/plcs/training/losses.py
+++ b/src/tasks/plcs/training/losses.py
@@ -1,7 +1,7 @@
 """Loss functions for PLCS training.
 
-Supports frame-level and sequence-level losses, including temporal consistency
-terms for sequential models.
+Supports frame-level and sequence-level losses.
+Temporal consistency is enforced by the GAN discriminator.
 """
 
 from __future__ import annotations
@@ -17,53 +17,19 @@ from src.utils.tensor_utils import masked_mean, normalize_padding_mask
 
 
 @dataclass(frozen=True)
-class TemporalTermConfig:
-    """Configuration for a single temporal consistency term.
-
-    Attributes:
-        weight: Weight applied to this term in the total loss.
-        order: 1 => velocity (1st difference), 2 => acceleration (2nd difference).
-        robust: If True, use SmoothL1 (Huber) loss; else use MSE.
-
-    """
-
-    weight: float = 0.0
-    order: int = 2
-    robust: bool = True
-
-
-@dataclass(frozen=True)
-class TemporalTermsConfig:
-    """Configuration for temporal consistency terms.
-
-    Terms:
-        - position_gt: match GT velocity/acceleration
-        - position_inertia: encourage constant velocity/acceleration-free motion
-        - rotation_gt: match GT angular velocity/acceleration
-        - rotation_inertia: encourage constant angular velocity
-    """
-
-    position_gt: TemporalTermConfig = TemporalTermConfig()
-    position_inertia: TemporalTermConfig = TemporalTermConfig()
-    rotation_gt: TemporalTermConfig = TemporalTermConfig()
-    rotation_inertia: TemporalTermConfig = TemporalTermConfig()
-
-
-@dataclass(frozen=True)
 class PLCSLossConfig:
     """Configuration for PLCS loss weights.
 
     Attributes:
         position_weight: Weight for position loss.
         rotation_weight: Weight for rotation loss.
-        temporal: Temporal term configuration.
+        canonical_pose_weight: Weight for canonical pose loss.
 
     """
 
     position_weight: float = 1.0
     rotation_weight: float = 1.0
     canonical_pose_weight: float = 0.0
-    temporal: TemporalTermsConfig = TemporalTermsConfig()
 
     @classmethod
     def from_dict(cls, cfg: dict) -> PLCSLossConfig:
@@ -76,53 +42,10 @@ class PLCSLossConfig:
             PLCSLossConfig instance.
 
         """
-        if "temporal_weight" in cfg:
-            raise ValueError(
-                "Legacy `temporal_weight` is no longer supported. "
-                "Use `temporal.position_gt.weight` etc. instead."
-            )
-
-        temporal_dict = cfg.get("temporal")
-        temporal_dict = temporal_dict if isinstance(temporal_dict, dict) else {}
-
-        if any(k in temporal_dict for k in ["order", "robust"]):
-            raise ValueError(
-                "Legacy `temporal: {order, robust}` is no longer supported. "
-                "Use `temporal.position_gt` / `temporal.rotation_gt` etc. instead."
-            )
-
-        def _parse_term(d: dict | None) -> TemporalTermConfig:
-            d = d or {}
-            return TemporalTermConfig(
-                weight=float(d.get("weight", 0.0)),
-                order=int(d.get("order", 2)),
-                robust=bool(d.get("robust", True)),
-            )
-
-        temporal_terms_cfg = TemporalTermsConfig(
-            position_gt=_parse_term(temporal_dict.get("position_gt")),
-            position_inertia=_parse_term(temporal_dict.get("position_inertia")),
-            rotation_gt=_parse_term(temporal_dict.get("rotation_gt")),
-            rotation_inertia=_parse_term(temporal_dict.get("rotation_inertia")),
-        )
-
-        # Validate supported orders early
-        for name, term in [
-            ("position_gt", temporal_terms_cfg.position_gt),
-            ("position_inertia", temporal_terms_cfg.position_inertia),
-            ("rotation_gt", temporal_terms_cfg.rotation_gt),
-            ("rotation_inertia", temporal_terms_cfg.rotation_inertia),
-        ]:
-            if term.order not in (1, 2):
-                raise ValueError(
-                    f"temporal.{name}.order must be 1 or 2 (got {term.order})"
-                )
-
         return cls(
             position_weight=cfg.get("position_weight", 1.0),
             rotation_weight=cfg.get("rotation_weight", 1.0),
             canonical_pose_weight=float(cfg.get("canonical_pose_weight", 0.0)),
-            temporal=temporal_terms_cfg,
         )
 
 
@@ -193,154 +116,12 @@ def angular_error(pred: Tensor, target: Tensor) -> Tensor:
     return diff.abs()
 
 
-def _wrap_angle(angle: Tensor) -> Tensor:
-    return torch.atan2(torch.sin(angle), torch.cos(angle))
-
-
-def _sequence_frame_mask(seq_mask: Tensor | None, *, order: int) -> Tensor | None:
-    if seq_mask is None:
-        return None
-    if order == 1:
-        return seq_mask[:, 1:] & seq_mask[:, :-1]
-    return seq_mask[:, 2:] & seq_mask[:, 1:-1] & seq_mask[:, :-2]
-
-
-def position_temporal_match_loss(
-    pred_position: Tensor,
-    target_position: Tensor,
-    cfg: TemporalTermConfig,
-    *,
-    seq_mask: Tensor | None = None,
-) -> Tensor:
-    if pred_position.dim() == 2:
-        return pred_position.new_zeros(())
-
-    pred_vel = pred_position[:, 1:, :] - pred_position[:, :-1, :]  # (B, T-1, 3)
-    target_vel = target_position[:, 1:, :] - target_position[:, :-1, :]
-
-    if cfg.order == 1:
-        diff = pred_vel - target_vel  # (B, T-1, 3)
-        mask = _sequence_frame_mask(seq_mask, order=1)
-    else:
-        pred_acc = pred_vel[:, 1:, :] - pred_vel[:, :-1, :]  # (B, T-2, 3)
-        target_acc = target_vel[:, 1:, :] - target_vel[:, :-1, :]
-        diff = pred_acc - target_acc
-        mask = _sequence_frame_mask(seq_mask, order=2)
-
-    if mask is not None and mask.sum().item() == 0:
-        return pred_position.new_zeros(())
-
-    if cfg.robust:
-        per_elem = nn.functional.smooth_l1_loss(diff, torch.zeros_like(diff), reduction="none")
-    else:
-        per_elem = diff.pow(2)
-
-    per_step = per_elem.mean(dim=-1)  # (B, T-1) or (B, T-2)
-    return masked_mean(per_step, mask, binarize=True, denom_min=1.0)
-
-
-def position_temporal_inertia_loss(
-    pred_position: Tensor,
-    cfg: TemporalTermConfig,
-    *,
-    seq_mask: Tensor | None = None,
-) -> Tensor:
-    if pred_position.dim() == 2:
-        return pred_position.new_zeros(())
-
-    pred_vel = pred_position[:, 1:, :] - pred_position[:, :-1, :]  # (B, T-1, 3)
-
-    if cfg.order == 1:
-        diff = pred_vel
-        mask = _sequence_frame_mask(seq_mask, order=1)
-    else:
-        pred_acc = pred_vel[:, 1:, :] - pred_vel[:, :-1, :]  # (B, T-2, 3)
-        diff = pred_acc
-        mask = _sequence_frame_mask(seq_mask, order=2)
-
-    if mask is not None and mask.sum().item() == 0:
-        return pred_position.new_zeros(())
-
-    if cfg.robust:
-        per_elem = nn.functional.smooth_l1_loss(diff, torch.zeros_like(diff), reduction="none")
-    else:
-        per_elem = diff.pow(2)
-
-    per_step = per_elem.mean(dim=-1)
-    return masked_mean(per_step, mask, binarize=True, denom_min=1.0)
-
-
-def rotation_temporal_match_loss(
-    pred_rotation: Tensor,
-    target_rotation: Tensor,
-    cfg: TemporalTermConfig,
-    *,
-    seq_mask: Tensor | None = None,
-) -> Tensor:
-    if pred_rotation.dim() == 2:
-        return pred_rotation.new_zeros(())
-
-    yaw_pred = torch.atan2(pred_rotation[..., 1], pred_rotation[..., 0])  # (B, T)
-    yaw_target = torch.atan2(target_rotation[..., 1], target_rotation[..., 0])
-
-    dyaw_pred = _wrap_angle(yaw_pred[:, 1:] - yaw_pred[:, :-1])  # (B, T-1)
-    dyaw_target = _wrap_angle(yaw_target[:, 1:] - yaw_target[:, :-1])
-
-    if cfg.order == 1:
-        diff = _wrap_angle(dyaw_pred - dyaw_target)  # (B, T-1)
-        mask = _sequence_frame_mask(seq_mask, order=1)
-    else:
-        ddyaw_pred = _wrap_angle(dyaw_pred[:, 1:] - dyaw_pred[:, :-1])  # (B, T-2)
-        ddyaw_target = _wrap_angle(dyaw_target[:, 1:] - dyaw_target[:, :-1])
-        diff = _wrap_angle(ddyaw_pred - ddyaw_target)
-        mask = _sequence_frame_mask(seq_mask, order=2)
-
-    if mask is not None and mask.sum().item() == 0:
-        return pred_rotation.new_zeros(())
-
-    if cfg.robust:
-        per_step = nn.functional.smooth_l1_loss(diff, torch.zeros_like(diff), reduction="none")
-    else:
-        per_step = diff.pow(2)
-
-    return masked_mean(per_step, mask, binarize=True, denom_min=1.0)
-
-
-def rotation_temporal_inertia_loss(
-    pred_rotation: Tensor,
-    cfg: TemporalTermConfig,
-    *,
-    seq_mask: Tensor | None = None,
-) -> Tensor:
-    if pred_rotation.dim() == 2:
-        return pred_rotation.new_zeros(())
-
-    yaw_pred = torch.atan2(pred_rotation[..., 1], pred_rotation[..., 0])  # (B, T)
-    dyaw_pred = _wrap_angle(yaw_pred[:, 1:] - yaw_pred[:, :-1])  # (B, T-1)
-
-    if cfg.order == 1:
-        diff = dyaw_pred
-        mask = _sequence_frame_mask(seq_mask, order=1)
-    else:
-        diff = _wrap_angle(dyaw_pred[:, 1:] - dyaw_pred[:, :-1])  # (B, T-2)
-        mask = _sequence_frame_mask(seq_mask, order=2)
-
-    if mask is not None and mask.sum().item() == 0:
-        return pred_rotation.new_zeros(())
-
-    if cfg.robust:
-        per_step = nn.functional.smooth_l1_loss(diff, torch.zeros_like(diff), reduction="none")
-    else:
-        per_step = diff.pow(2)
-
-    return masked_mean(per_step, mask, binarize=True, denom_min=1.0)
-
-
 class PLCSLoss(nn.Module):
     """Combined loss for PLCS training.
 
-    Combines position, rotation, and optional temporal consistency losses.
+    Combines position and rotation losses.
     Supports both frame-level (B, 3) and sequence-level (B, T, 3) inputs.
+    Temporal consistency is enforced by the GAN discriminator.
     """
 
     def __init__(
@@ -392,8 +173,7 @@ class PLCSLoss(nn.Module):
             target_rotation: Target rotation.
 
         Returns:
-            dict: Dictionary with 'total', 'position', 'rotation', and
-                'temporal' (if enabled) losses.
+            dict: Dictionary with 'total', 'position', 'rotation', 'canonical_pose'.
 
         """
         zero = pred_position.new_zeros(())
@@ -445,50 +225,9 @@ class PLCSLoss(nn.Module):
                 "pred_canonical_pose is provided."
             )
 
-        temp_loss = zero
-        pos_temp_gt = zero
-        pos_temp_inertia = zero
-        rot_temp_gt = zero
-        rot_temp_inertia = zero
-
-        # Temporal consistency losses (for sequences)
-        cfg = self.config.temporal
-        if cfg.position_gt.weight > 0.0:
-            pos_temp_gt = position_temporal_match_loss(
-                pred_position, target_position, cfg.position_gt, seq_mask=frame_mask
-            )
-            total = total + cfg.position_gt.weight * pos_temp_gt
-            temp_loss = temp_loss + pos_temp_gt
-
-        if cfg.position_inertia.weight > 0.0:
-            pos_temp_inertia = position_temporal_inertia_loss(
-                pred_position, cfg.position_inertia, seq_mask=frame_mask
-            )
-            total = total + cfg.position_inertia.weight * pos_temp_inertia
-            temp_loss = temp_loss + pos_temp_inertia
-
-        if cfg.rotation_gt.weight > 0.0:
-            rot_temp_gt = rotation_temporal_match_loss(
-                pred_rotation, target_rotation, cfg.rotation_gt, seq_mask=frame_mask
-            )
-            total = total + cfg.rotation_gt.weight * rot_temp_gt
-            temp_loss = temp_loss + rot_temp_gt
-
-        if cfg.rotation_inertia.weight > 0.0:
-            rot_temp_inertia = rotation_temporal_inertia_loss(
-                pred_rotation, cfg.rotation_inertia, seq_mask=frame_mask
-            )
-            total = total + cfg.rotation_inertia.weight * rot_temp_inertia
-            temp_loss = temp_loss + rot_temp_inertia
-
         return {
             "total": total,
             "position": pos_loss,
             "rotation": rot_loss,
             "canonical_pose": canonical_pose_loss,
-            "temporal": temp_loss,
-            "position_temporal_gt": pos_temp_gt,
-            "position_temporal_inertia": pos_temp_inertia,
-            "rotation_temporal_gt": rot_temp_gt,
-            "rotation_temporal_inertia": rot_temp_inertia,
         }


### PR DESCRIPTION
## Summary

- **BLCS**: `velocity_loss()`, `smoothness_loss()`, `uv_velocity_loss()` を削除。`BLCSLoss` から `velocity_weight`, `smoothness_weight`, `uv_velocity_weight` パラメータを除去
- **PLCS**: `TemporalTermConfig`, `TemporalTermsConfig` dataclass を削除。`position_temporal_match_loss()`, `position_temporal_inertia_loss()`, `rotation_temporal_match_loss()`, `rotation_temporal_inertia_loss()` を削除。`PLCSLossConfig.from_dict()` の temporal パース処理も除去
- `PLCSLoss.forward()` の return dict から `temporal`, `position_temporal_*`, `rotation_temporal_*` キーを削除
- pre-existing mypy エラー3件 (`blcs/training/lightning_module.py`) も同時に修正

## Motivation

時系列性は GAN の系列 discriminator によって強制されるため、明示的な時系列損失は不要。これらを削除することで損失計算の見通しがよくなる。

Closes #503

## Test plan

- [ ] `python -m mypy --follow-imports=skip src/tasks/blcs/training/{losses,lightning_module}.py src/tasks/plcs/training/losses.py` — エラーなし (CI確認)
- [ ] smoke contract テストはデータセットがあれば通ること (データ不在による既存失敗はスコープ外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)