### PR TITLE
docs(tasks): src/tasks READMEを統一フォーマットへ刷新 (#504)

### DIFF
--- a/src/tasks/ball_detection/README.md
+++ b/src/tasks/ball_detection/README.md
@@ -1,257 +1,143 @@
 # Ball Detection
 
-テニス動画のRGBフレーム列から、各フレームのボール位置ヒートマップを推定するタスクです。
-複数ボールの教師データ、TrackNet形式データ、YouTubeから作成したデータセットに対応しています。
+> テニス映像のRGBフレーム列から、各フレームのボール位置を推定する時系列ボール検出タスク。
 
-## 設計
+## 概要
 
-データ読み込みは次の責任に分かれています。
+複数フレームの時空間情報を統合し、高速・小物体であるテニスボールのヒートマップと座標・信頼度を出力します。
 
-- `TrackNetDataModule`
-  - splitファイル、ディレクトリ構造、`Label.csv`を解釈する
-  - 固定長の`ClipWindow`を作成する
-- `YouTubeDataModule`
-  - `TrackNetDataModule`を継承する
-  - YouTubeデータセットのsplitエントリ基準だけを変更する
-- `BallDetectionDataset`
-  - データ形式に依存しない`ClipWindow`を受け取る
-  - 画像読み込み、augmentation、heatmap生成、Tensor化を行う
+| 項目 | 内容 |
+|---|---|
+| 入力 | RGBフレーム列 `(B, T, 3, H, W)`（T=8、H=288、W=512 がデフォルト） |
+| 出力 | 正規化ボール座標 `(B, T, 2)` + 信頼度 `(B, T)` + ヒートマップ（任意） |
+| モデル | `stunet` / `conv_next_unet` / `dino_pseudo3d` |
+| データ | TrackNet形式 + YouTube自作（手動アノテーション） |
+| 役割 | 認識パイプラインの上流。2D観測を [BLCS](../blcs/) へ供給 |
 
-新しいデータ形式を追加する場合は、DataModuleで`ClipWindow`へ変換します。
-Dataset側のsample生成処理は共通で再利用できます。
+## Inference
 
-## Sample契約
+```python
+import torch
+from src.tasks.ball_detection.inference.predictor import BallDetectionPredictor
 
-`T`はフレーム数、`K`は`data.max_instances`です。
+predictor = BallDetectionPredictor.load_from_checkpoint(
+    "outputs/ball_detection/stunet/logs/version_0/checkpoints/last.ckpt",
+    device="cuda",
+)
 
-| キー | Sample形状 | Batch形状 | 説明 |
-|---|---:|---:|---|
-| `images` | `(T, 3, H, W)` | `(B, T, 3, H, W)` | RGBフレーム列 |
-| `heatmaps` | `(T, Hh, Wh)` | `(B, T, Hh, Wh)` | 全可視ボールを統合した教師heatmap |
-| `coords` | `(T, K, 2)` | `(B, T, K, 2)` | 元画像ピクセル座標の複数ボールGT |
-| `visibility` | `(T, K)` | `(B, T, K)` | 可視インスタンスmask |
-| `original_size` | `(2,)` | `(B, 2)` | `(width, height)` |
-| `heatmap_size` | `(2,)` | `(B, 2)` | `(width, height)` |
+# (B, T, 3, H, W), float32, 値域 [0, 1]
+images = torch.rand(1, 8, 3, 288, 512)
+result = predictor.predict(images, return_heatmaps=True)
+coords = result["coords"]          # (1, 8, 2) 正規化座標
+visibility = result["visibility"]  # (1, 8)
+```
 
-`coords`の未使用領域は`(0, 0)`、対応する`visibility`は`0`でpaddingされます。
+返り値は全テンソルが CPU 上の `dict[str, Tensor]`。
 
-## データ形式
+| キー | 形状 | dtype | 条件 | 説明 |
+|---|---|---|---|---|
+| `coords` | `(B, T, 2)` | float32 | 常時 | ピーク位置の正規化座標 `(x, y) ∈ [0, 1]` |
+| `visibility` | `(B, T)` | float32 | 常時 | フレームごとのピーク信頼度 |
+| `heatmaps` | `(B, T, H, W)` | float32 | `return_heatmaps=True` | sigmoid後の確率ヒートマップ（解像度はモデル依存、[モデル](#モデル)参照） |
 
-### TrackNet
+`load_from_checkpoint` は単一チェックポイントのみ受け付けます（複数指定は `ValueError`）。
+
+## データ
+
+### TrackNet形式
 
 ```text
 data/tennis/
-├── game1/
-│   ├── Clip1/
-│   │   ├── 000000.jpg
-│   │   ├── 000001.jpg
-│   │   └── Label.csv
-│   └── Clip2/
-└── game2/
+└── game1/
+    ├── Clip1/              # "Clip" / "clip_" で始まるディレクトリ
+    │   ├── 000000.jpg      # 元解像度のフレーム
+    │   └── Label.csv
+    └── Clip2/
 ```
 
-splitファイルには`data.data_dir`からの相対パスを書きます。
+`Label.csv` の必須列は `file name, visibility, x-coordinate, y-coordinate`。任意列 `instance id` / `role` / `ball state` も解釈され、`role=distractor` は学習対象外です。複数ボールは同一 `file name` の複数行で表します。splitファイルには `data.data_dir` からの相対パスを記述します。
 
-```text
-game1
-game2/Clip1
-```
+### YouTube形式
 
-`Label.csv`の必須列は次の4つです。
+`YouTubeDataModule` は `TrackNetDataModule` を継承し、エントリ解決のみ変更します。splitは `data/tennis/youtube/annotations/{train,val,test}.txt`、パスは `data/tennis` からの相対（例 `youtube/frames/video_000001/clip_000001`）です。学習時は `data=youtube_rgb_sequence` を指定します。
 
-```csv
-file name,visibility,x-coordinate,y-coordinate
-000000.jpg,1,320.5,180.0
-000001.jpg,0,0,0
-```
+### Sample契約（学習データ）
 
-複数ボールを保持する場合は、同じ`file name`で複数行を記録します。
-`instance id`、`ball state`、`role`も利用できます。`role=distractor`は学習対象外です。
+`T = model.num_frames`（=8）、`K = data.max_instances`（=16）。
 
-### YouTube
+| キー | 形状 | 説明 |
+|---|---|---|
+| `images` | `(T, 3, 288, 512)` | 正規化済みRGB |
+| `heatmaps` | `(T, 288, 512)` | 全可視ボールを統合したガウス教師heatmap |
+| `coords` | `(T, K, 2)` | 元解像度ピクセル座標の複数ボールGT |
+| `visibility` | `(T, K)` | 可視インスタンスmask（未使用領域は座標 `(0,0)`・vis `0`） |
+| `original_size` / `heatmap_size` | `(2,)` | `(width, height)` |
 
-```text
-data/tennis/youtube/
-├── videos/
-├── frames/
-│   └── video_000001/
-│       ├── raw/
-│       └── clip_000001/
-│           ├── 000000.jpg
-│           └── Label.csv
-├── staging/
-├── annotations/
-│   ├── train.txt
-│   └── val.txt
-└── manifests/
-```
+## データセット生成（YouTube）
 
-学習時はHydraのdata configを切り替えます。
+YouTube動画から学習データを作る3ステップ。CLIは `scripts/youtube/` 配下です。
 
 ```bash
-.venv/bin/python -m src.tasks.ball_detection.scripts.train \
-    data=youtube_rgb_sequence
+# 1. 動画download → H.264変換 → フレーム抽出（configs/prepare_youtube_dataset.yaml）
+.venv/bin/python -m src.tasks.ball_detection.scripts.youtube.prepare_youtube_dataset
+
+# 2a. 候補clipをGUIで選択
+.venv/bin/python -m src.tasks.ball_detection.scripts.youtube.clip_and_predict_youtube_dataset \
+    workflow.video_id=video_000001 workflow.mode=select
+# 2b. 学習済みモデルでアノテーション初期値を予測
+.venv/bin/python -m src.tasks.ball_detection.scripts.youtube.clip_and_predict_youtube_dataset \
+    workflow.video_id=video_000001 workflow.mode=predict
+
+# 3. OpenCV UIで人手確認・確定 → clip/Label.csv/splitを書き出し
+.venv/bin/python -m src.tasks.ball_detection.scripts.youtube.annotate_youtube_ball \
+    annotate.video_id=video_000001
 ```
 
-## 学習と評価
+`predict` の出力は人手確認を効率化する初期値であり、半教師あり学習へ直接投入する疑似ラベルではありません。確定後のデータは通常の教師データとして扱います。
 
-### 学習方式
-
-現在の学習フローは教師あり学習のみです。
-
-YouTubeデータセット作成時のモデル予測は、人手アノテーションの初期値を作るための
-補助機能です。人手で確認してfinalizeしたデータは、通常の教師データとして学習します。
-
-### 学習
+## 学習
 
 ```bash
 .venv/bin/python -m src.tasks.ball_detection.scripts.train
+.venv/bin/python -m src.tasks.ball_detection.scripts.train model=conv_next_unet data.batch_size=4
 ```
 
-```bash
-.venv/bin/python -m src.tasks.ball_detection.scripts.train \
-    model=conv_next_unet \
-    data.batch_size=4
-```
-
-利用可能なモデルは次のとおりです。
-
-- `stunet`
-- `conv_next_unet`
-- `dino_pseudo3d`
+デフォルトは `model=stunet`、`data=rgb_sequence`。`configs/training/default.yaml` は `max_epochs=20`、`lr=1e-4`、`precision=bf16-mixed`、`val/loss` 監視のEarlyStopping（patience=5）。
 
 ### 評価
 
 ```bash
 .venv/bin/python -m src.tasks.ball_detection.scripts.eval \
-    run.checkpoint_path=path/to/checkpoint.ckpt
+    run.checkpoint_path=path/to/checkpoint.ckpt evaluation.splits=[val,test]
 ```
 
-複数の予測peakと複数のGTを抽出し、ハンガリアン法で対応付けて
-`precision`、`recall`、`f1`、`mean_distance_px`を計算します。
+複数の予測ピークと複数GTをハンガリアン法で対応付け（距離閾値4.0px）、`precision` / `recall` / `f1` / `mean_distance_px` を `outputs/ball_detection/eval/` に出力します。
 
-## Preview
-
-### Augmentation
+## 可視化
 
 ```bash
+# ckptでクリップを推論し、予測GIFを生成
+.venv/bin/python -m src.tasks.ball_detection.scripts.visualize \
+    visualization.clip_dir=data/tennis/game1/Clip1 \
+    visualization.checkpoint=path/to/checkpoint.ckpt \
+    visualization.save=assets/ball_detection/prediction.gif
+
+# データ確認用プレビュー（ckpt不要）
+.venv/bin/python -m src.tasks.ball_detection.scripts.preview_heatmaps
 .venv/bin/python -m src.tasks.ball_detection.scripts.preview_augmentation
 ```
 
-```bash
-.venv/bin/python -m src.tasks.ball_detection.scripts.preview_augmentation \
-    preview.split=val \
-    preview.sample_indices=[0,1,2]
-```
+## モデル
 
-PNG、sample metadata、`manifest.json`は次へ保存されます。
+| 名前 | 入力モード / ch | 出力解像度 | 実装 |
+|---|---|---|---|
+| `stunet` | mdd / 2ch | H/2 × W/2 | `models/spatiotemporal_unet.py`（2D+3D Conv U-Net、T≥8 必須） |
+| `conv_next_unet` | mdd / 2ch | H/4 × W/4 | `models/conv_next_unet.py`（ConvNeXt + 因子化Conv3d） |
+| `dino_pseudo3d` | rgb / 3ch | フル解像度 | `models/dino_pseudo3d.py`（DINO backbone + Pseudo-3Dデコーダ） |
 
-```text
-outputs/ball_detection/augmentation_preview/
-```
+`mdd`（Motion Direction Decomposition）はRGBの輝度差分を明暗2chに分解する入力（`models/input_adapter.py`）。`rgb` はRGBをそのまま渡します。
 
-上段が元シーケンス、下段がaugmentationをすべて有効にしたシーケンスです。
+## 補足
 
-### Heatmap
-
-```bash
-.venv/bin/python -m src.tasks.ball_detection.scripts.preview_heatmaps
-```
-
-### Prediction GIF
-
-```bash
-.venv/bin/python -m src.tasks.ball_detection.scripts.visualize \
-    visualization.clip_dir=data/tennis/game1/Clip1 \
-    visualization.save=outputs/ball_detection/prediction.gif
-```
-
-## YouTubeデータセット作成
-
-YouTube関連のCLIは`scripts/youtube/`にまとめています。
-
-### 1. 動画準備とフレーム抽出
-
-```bash
-.venv/bin/python -m \
-    src.tasks.ball_detection.scripts.youtube.prepare_youtube_dataset
-```
-
-`configs/prepare_youtube_dataset.yaml`の`workflow.sources`を読み、
-動画のdownload、H.264への変換、連続フレーム抽出を行います。
-
-### 2. 候補clip選択
-
-```bash
-.venv/bin/python -m \
-    src.tasks.ball_detection.scripts.youtube.clip_and_predict_youtube_dataset \
-    workflow.video_id=video_000001 \
-    workflow.mode=select
-```
-
-### 3. アノテーション初期値のモデル予測
-
-```bash
-.venv/bin/python -m \
-    src.tasks.ball_detection.scripts.youtube.clip_and_predict_youtube_dataset \
-    workflow.video_id=video_000001 \
-    workflow.mode=predict
-```
-
-この予測は人手確認を効率化するための初期値であり、半教師あり学習へ直接投入される
-疑似ラベルではありません。
-
-### 4. 人手確認と確定
-
-```bash
-.venv/bin/python -m \
-    src.tasks.ball_detection.scripts.youtube.annotate_youtube_ball \
-    annotate.video_id=video_000001
-```
-
-全フレームを確認してfinalizeすると、clip、`Label.csv`、splitファイルが
-YouTube学習データセットへ書き出されます。
-
-## 主要ファイル
-
-```text
-src/tasks/ball_detection/
-├── generate_dataset/
-│   ├── annotation_session.py
-│   ├── candidate_workflow.py
-│   └── __init__.py
-├── configs/
-│   ├── data/
-│   │   ├── rgb_sequence.yaml
-│   │   └── youtube_rgb_sequence.yaml
-│   ├── model/
-│   ├── preview_augmentation.yaml
-│   ├── preview_heatmaps.yaml
-│   └── train.yaml
-├── data/
-│   ├── augmentation.py
-│   ├── dataset.py
-│   ├── tracknet_datamodule.py
-│   ├── types.py
-│   └── youtube_datamodule.py
-├── models/
-├── scripts/
-│   ├── eval.py
-│   ├── preview_augmentation.py
-│   ├── preview_heatmaps.py
-│   ├── train.py
-│   ├── visualize.py
-│   └── youtube/
-│       ├── annotate_youtube_ball.py
-│       ├── clip_and_predict_youtube_dataset.py
-│       └── prepare_youtube_dataset.py
-├── training/
-├── visualization/
-```
-
-## 注意点
-
-- プロジェクトコマンドには`.venv/bin/python`を使用します。
-- YouTubeのdownloadには`yt-dlp`、変換には`ffmpeg`が必要です。
-- annotation UIとclip選択UIはOpenCVのGUIを使用します。
-- GPUがない場合は、学習・推論設定のdeviceや`run.gpus`をCPU向けに変更してください。
+- 実行は `.venv/bin/python -m ...`。GPUが無い場合は `run.gpus` や device設定をCPU向けに変更します。
+- YouTube生成は `yt-dlp`（download）・`ffmpeg`（H.264変換）に依存し、clip選択／アノテーションUIはOpenCVのGUIを使用します。

--- a/src/tasks/blcs/README.md
+++ b/src/tasks/blcs/README.md
@@ -1,132 +1,126 @@
 # BLCS (Ball Localization in Court System)
 
-BLCS は、テニスコート座標系におけるボールの 3D 軌道を、2D のボール観測（画像座標）と
-コート情報から推定するためのタスク実装です。
+> 2Dボール観測とコートキーポイントから、コート座標系における3Dボール軌道を推定するタスク。単一カメラ／マルチビューに対応します。
 
-## 目的 / 想定入出力
+## 概要
 
-- **入力**: 2D ボール観測（画像座標シーケンス）+ コートキーポイント
-- **出力**: コート座標系の 3D 位置（軌道）
+複数フレーム（・複数視点）の2D観測を時系列Transformerで統合し、3D位置（と速度）を復元します。
 
-### 入力形式
+| 項目 | 内容 |
+|---|---|
+| 入力 | 2Dボール観測 `ball_uv` + コートキーポイント `court_kp` |
+| 出力 | 3D位置 `position (B, T, 3)` [m] + 速度 `velocity (B, T, 3)` [m/s]（任意） |
+| モデル | `single` / `multiview` / `multiview_axial`（デフォルト） |
+| データ | 物理シミュレーションによる合成生成 |
+| 役割 | 認識パイプラインの下流。[ball_detection](../ball_detection/) と [court_detection](../court_detection/) の2D観測を3D化 |
 
-| モード | 入力テンソル | 形状 | 説明 |
-|--------|-------------|------|------|
-| 単一カメラ | `ball_uv` | `(B, T, 2)` | 2Dボール観測シーケンス |
-| 単一カメラ | `court_kp` | `(B, 20, 2)` | 2Dコートキーポイント |
-| マルチビュー | `ball_uv` | `(B, N, T, 2)` | 複数カメラからの2Dボール観測 |
-| マルチビュー | `court_kp` | `(B, N, T, 20, 2)` | 複数カメラからの2Dコートキーポイント |
+## Inference
 
-### 出力形式
+単一カメラ・マルチビューとも同一の `BLCSPredictor` で扱います。
 
-**Predictor 返り値（`BLCSPredictor.predict()`）:**
+```python
+import torch
+from src.tasks.blcs.inference.predictor import BLCSPredictor
 
-推論結果は `dict[str, torch.Tensor]` 形式で返されます。全てのテンソルは CPU 上にあります。
+predictor = BLCSPredictor.load_from_checkpoint(
+    "outputs/blcs/multiview_axial/logs/version_0/checkpoints/last.ckpt",
+    device="cpu",
+)
 
-| Predictor | キー | 形状 | 型 | 説明 |
-|-----------|------|------|-----|------|
-| `BLCSPredictor` | `position` | `(B, T, 3)` | `torch.Tensor` | 3D軌道。デフォルト（`denormalize=True`）ではメートル単位、`denormalize=False` の場合は正規化座標 |
-| `BLCSPredictor` | `velocity` | `(B, T, 3)` | `torch.Tensor` | 速度ベクトル。デフォルト（`denormalize=True`）かつモデルが出力する場合は m/s 単位。モデルにより含まれない場合あり |
+# 単一カメラ
+ball_uv  = torch.zeros(1, 64, 2)      # (B, T, 2)
+court_kp = torch.zeros(1, 20, 2)      # (B, 20, 2)
+out = predictor.predict(ball_uv, court_kp)          # out["position"]: (1, 64, 3) [m]
 
-`BLCSPredictor` は `blcs` / `blcs_multiview` を単一クラスで扱います。
-`BLCSMultiViewPredictor` は後方互換のためのエイリアスとして残しています。
-
-**注意**:
-- すべてのテンソルは CPU に配置されます（統合側での device 変換は不要）
-- バッチ次元は常に保持されます
-
-## 実行コマンド
-
-### データ生成
-
-```bash
-python -m src.tasks.blcs.scripts.generate_dataset
-
-# 固定8カメラ（四隅+中点）で生成
-# - 四隅は z_min
-# - 中点は z_max
-# - すべてコート中央 (0,0,0) を注視
-# - Y軸方向バッファは fixed_baseline_clear_extra で増やす
-python -m src.tasks.blcs.scripts.generate_dataset \
-    camera.placement_mode=fixed_8 \
-    camera.fixed_baseline_clear_extra=2.0
+# マルチビュー（ball_vis / ball_mask が必須）
+ball_uv   = torch.zeros(1, 4, 64, 2)      # (B, N, T, 2)
+court_kp  = torch.zeros(1, 4, 64, 20, 2)  # (B, N, T, 20, 2)
+ball_vis  = torch.ones(1, 4, 64)          # (B, N, T)
+ball_mask = torch.ones(1, 4, 64)          # (B, N, T)
+out = predictor.predict(ball_uv, court_kp, ball_vis=ball_vis, ball_mask=ball_mask)
 ```
 
-### 学習
+`predict(ball_uv, court_kp, ball_vis=None, ball_mask=None, court_vis=None, denormalize=True)`。返り値は全テンソルが CPU 上の `dict[str, Tensor]`。
+
+| キー | 形状 | dtype | 条件 | 説明 |
+|---|---|---|---|---|
+| `position` | `(B, T, 3)` | float32 | 常時 | `denormalize=True` でメートル、`False` で正規化座標 |
+| `velocity` | `(B, T, 3)` | float32 | モデルが `predict_velocity` で学習された場合 | `denormalize=True` で m/s |
+
+`denormalize=True` のスケールは `COURT_COORD_SCALE_XYZ = (5.485, 11.885, 1.07)`（`src/utils/schema/court.py`）。
+
+### 入力テンソル仕様
+
+| テンソル | 単一カメラ | マルチビュー | 備考 |
+|---|---|---|---|
+| `ball_uv` | `(B, T, 2)` | `(B, N, T, 2)` | 必須 |
+| `court_kp` | `(B, 20, 2)`（`(B, 40)` も可） | `(B, N, T, 20, 2)`（`(B, N, 20, 2)` も可） | 必須 |
+| `ball_vis` | `(B, T)` | `(B, N, T)` | マルチビューでは**必須** |
+| `ball_mask` | `(B, T)` | `(B, N, T)` | マルチビューでは**必須** |
+
+## データセット生成
+
+BLCSはデータを物理シミュレーションで合成生成します（既存データセットなし）。
 
 ```bash
-# 単一カメラモデル
-python -m src.tasks.blcs.scripts.train
-
-# マルチビューモデル（複数カメラ統合）
-python -m src.tasks.blcs.scripts.train \
-    model=multiview \
-    data=multiview
-
-# マルチビュー学習のカスタム設定例
-python -m src.tasks.blcs.scripts.train \
-    model=multiview \
-    data=multiview \
-    data.num_views_range=[2,4] \
-    data.seq_len_range=[30,120] \
-    training.max_epochs=100
+.venv/bin/python -m src.tasks.blcs.scripts.generate_dataset
+.venv/bin/python -m src.tasks.blcs.scripts.generate_dataset generator.num_scenes=500 run.num_workers=4
 ```
 
-### ハイパーパラメータ探索
+- **仕様**: 重力・空気抵抗・マグヌス力・バウンド（`configs/physics/default.yaml`）でラリーをシミュレートし、固定6カメラ（コーナー4 + ベースライン中点2）へ投影。1シーン=1ラリー（最大10ショット）。デフォルト1000シーン、`train/val/test = 0.8/0.1/0.1`。
+- **生成構造**（`data/blcs/scenes/scene_XXXXXX/`）:
 
-```bash
-RUN_ROOT=outputs/blcs/sweep_$(date +%Y-%m-%d_%H-%M-%S) \
-bash src/tasks/blcs/scripts/run_hparam_sweep.sh
+```text
+scene_000000/
+├── meta.json / scalars.json   # num_cameras, fps, rally_length, カメラパラメータ
+├── ball_pos_world.npy         # (T, 3) ワールド座標 [m]
+├── ball_pos_norm.npy          # (T, 3) 正規化座標
+├── ball_vel_world.npy         # (T, 3) 速度 [m/s]
+└── cam_{0..5}_*.npy           # ball_uv (T,2), ball_visible (T,), court_kp_uv (20,2), ...
 ```
 
-## データローディング最適化
-
-- 学習時のバッチ制御は標準の `DataLoader` 設定 (`batch_size`, `num_workers`) を使います。
-
-### 可視化
+## 学習
 
 ```bash
-# 単一カメラ（GT vs Prediction 比較アニメーション）
-python -m src.tasks.blcs.scripts.visualize
+.venv/bin/python -m src.tasks.blcs.scripts.train                              # multiview_axial（デフォルト）
+.venv/bin/python -m src.tasks.blcs.scripts.train model=single   data=single
+.venv/bin/python -m src.tasks.blcs.scripts.train model=multiview data=multiview
+.venv/bin/python -m src.tasks.blcs.scripts.train_chunked                      # オンライン生成のチャンク学習
+```
 
-# 単一カメラ（view指定）
-python -m src.tasks.blcs.scripts.visualize \
-    visualization.animation_view=3d
+`configs/training/default.yaml` は `max_epochs=100`、`lr=1e-4`、warmup=200、cosineスケジューラ、`bf16-mixed`。
 
-# マルチビュー（GT vs Prediction 比較アニメーション）
-python -m src.tasks.blcs.scripts.visualize \
-    visualization=multiview \
-    visualization.scene_path=data/blcs/scenes/scene_000003 \
-    visualization.mode=predict \
-    visualization.checkpoint=outputs/blcs/multiview/logs/version_0/checkpoints/last.ckpt \
-    visualization.cameras=all
+| モデル config | data config | 概要 |
+|---|---|---|
+| `single` | `single` | 単一カメラ（batch=32、seq 64〜1024） |
+| `multiview` | `multiview` | クロスアテンション統合（batch=4、view 4〜6） |
+| `multiview_axial` | `multiview` | 軸別注意（デフォルト） |
 
-# 保存する場合
-python -m src.tasks.blcs.scripts.visualize \
-    visualization=multiview \
-    visualization.mode=predict \
+## 可視化
+
+```bash
+.venv/bin/python -m src.tasks.blcs.scripts.visualize                          # multiview GT（デフォルト）
+.venv/bin/python -m src.tasks.blcs.scripts.visualize visualization=single
+
+# ckptによる GT vs 予測の比較アニメーション
+.venv/bin/python -m src.tasks.blcs.scripts.visualize \
+    visualization=multiview visualization.mode=predict \
     visualization.checkpoint=outputs/blcs/multiview/logs/version_0/checkpoints/last.ckpt \
     visualization.cameras=all \
     visualization.save=outputs/blcs/visualize/compare_multiview.mp4
 ```
 
-可視化スクリプトは `src/tasks/blcs/visualization/orchestrator.py` を通して、
-`visualization.mode=visualize` では `BLCSSceneRenderer.create_animation()`、
-`visualization.mode=predict` では `BLCSSceneRenderer.create_comparison_animation()` を呼び出します。  
-`visualization.animation_view` は `2d|3d` をサポートします。
+`visualization.animation_view` は `2d` / `3d` をサポートします。
 
-## モデルアーキテクチャ
+## モデル
 
-### 単一カメラモデル (`BLCSModel`)
+| 名前 | アーキテクチャ | 実装 |
+|---|---|---|
+| `single` (`blcs`) | Decoder-only Transformer（RoPE + SDPA + SwiGLU + RMSNorm）。`[court(20), ball(T)]` トークン列を自己注意 | `models/blcs_model.py` |
+| `multiview` (`blcs_multiview`) | クエリベースのクロスアテンション（同時刻のマルチビューを統合→時間方向自己注意） | `models/blcs_multiview_model.py` |
+| `multiview_axial` (`blcs_multiview_axial`) | カメラ軸／時間軸の交互self-attention（ローカル時間窓 `time_window_radius`） | `models/blcs_multiview_axial_model.py` |
 
-単一カメラからの2D観測シーケンスを入力として3D軌道を推定。
-Temporal Encoder + MLP ベースの構造。
+## 補足
 
-実装: `src/tasks/blcs/models/blcs_model.py`
-
-### マルチビューモデル (`BLCSMultiViewModel`)
-
-複数カメラからの観測を統合して推定。複数視点からの2D観測を融合することで、
-単一視点より高精度な3D軌道復元を狙う構成。
-
-実装: `src/tasks/blcs/models/blcs_multiview_model.py`
+- 実行は `.venv/bin/python -m ...`。学習をCPUで試す場合は `run.gpus=0`。
+- 生成・学習・可視化はすべて `data/blcs/scenes/` のシーンを起点にします（`train_chunked` はオンライン生成）。

--- a/src/tasks/court_detection/README.md
+++ b/src/tasks/court_detection/README.md
@@ -1,179 +1,129 @@
-# Court Detection (CourtKP20)
+# Court Detection
 
-`src/tasks/court_detection` は、テニス映像からコートのキーポイント（20点）を検出するタスク実装です。
+> テニス映像からコート構造を検出するタスク。キーポイント（`kp`）・セグメンテーション（`seg`）・ライン（`line`）の3タスクを統一実装で扱います。
 
-## 目的 / 想定入出力
+## 概要
 
-- **入力**: テニスコート画像（RGB）
-- **出力**: 20個のコートキーポイントの2D座標 + 可視性フラグ
+`encoder + decoder + 1×1 conv` の共通モデルで3タスクを学習し、`data` / `loss` config の切り替えで用途を選びます。
 
-学習データは `src.tools.annotate_court_keypoints` で生成した JSON アノテーションを前提とします。
+| 項目 | 内容 |
+|---|---|
+| 入力 | RGB画像（任意サイズ、内部で短辺リサイズ） |
+| 出力（`kp`） | コートキーポイント座標 `(14, 2)` ピクセル + ヒートマップ（任意） |
+| タスク | `kp`（14点）/ `seg`（7クラス）/ `line`（1クラス） |
+| モデル | デフォルトEncoder+FPN / Swin-L(DINO)+FPN・UNet / DINOv3+DETR（`seg`専用） |
+| データ | 手動アノテーションJSON |
+| 役割 | 認識パイプラインの上流。コートKPを [BLCS](../blcs/) / [PLCS](../plcs/) へ供給 |
 
-### Predictor 出力形式
+> **注**: 学習モデルが出力するキーポイントは index 0〜13 の **14点**（`configs/model/court_kp.yaml: num_classes=14`）。ネットポスト等を含む20点仕様（`NUM_COURT_KP=20`）はアノテーション用の正準定義で、現行モデルは出力しません。
 
-**Predictor 返り値（`CourtKeypointPredictor.predict()`）:**
-
-推論結果は `dict[str, torch.Tensor]` 形式で返されます。全てのテンソルは CPU 上にあります。
-
-| キー | 形状 | 型 | 説明 |
-|------|------|-----|------|
-| `keypoints` | `(K, 2)` | `torch.Tensor` | キーポイント座標（ピクセル空間）、K=20 |
-| `visibility` | `(K,)` | `torch.Tensor` | 可視性確率（0-1の範囲） |
-| `heatmaps` | `(K, H, W)` | `torch.Tensor` | ヒートマップ（`return_heatmaps=True` の場合のみ） |
-
-**注意**: 
-- すべてのテンソルは CPU に配置されます（統合側での device 変換は不要）
-- キーポイント座標は元画像のサイズにスケーリング済みです
-
-### キーポイント仕様 (CourtKP20)
-
-`src/utils/geometry/court.court_keypoints_3d()` で定義される20点：
-
-| Index | Name | Description |
-|-------|------|-------------|
-| 0 | far_doubles_corner_left | 奥側ダブルスコーナー（左） |
-| 1 | far_doubles_corner_right | 奥側ダブルスコーナー（右） |
-| 2 | near_doubles_corner_left | 手前ダブルスコーナー（左） |
-| 3 | near_doubles_corner_right | 手前ダブルスコーナー（右） |
-| 4 | far_singles_corner_left | 奥側シングルスコーナー（左） |
-| 5 | near_singles_corner_left | 手前シングルスコーナー（左） |
-| 6 | far_singles_corner_right | 奥側シングルスコーナー（右） |
-| 7 | near_singles_corner_right | 手前シングルスコーナー（右） |
-| 8 | far_service_left | 奥側サービスライン端点（左） |
-| 9 | far_service_right | 奥側サービスライン端点（右） |
-| 10 | near_service_left | 手前サービスライン端点（左） |
-| 11 | near_service_right | 手前サービスライン端点（右） |
-| 12 | far_service_T | 奥側サービスT |
-| 13 | near_service_T | 手前サービスT |
-| 14 | net_center | ネット中央（地面） |
-| 15 | net_post_left_base | 左ネットポスト（下） |
-| 16 | net_post_left_top | 左ネットポスト（上） |
-| 17 | net_post_right_base | 右ネットポスト（下） |
-| 18 | net_post_right_top | 右ネットポスト（上） |
-| 19 | center_strap_top | センターストラップ（上） |
-
-**注**: このキーポイント仕様は `src/utils/schema/keypoint_schema.py` の `COURT_KP_NAMES` / `COURT_KP_IDX` として定義されており、プロジェクト全体で参照すべき canonical reference となっています。各モジュール（CourtDetection / PLCS / BLCS / Rendering など）はこの定義を参照することで、indexの解釈が統一されます。
-
-## ディレクトリ構成
-
-```
-src/tasks/court_detection/
-├── configs/                          # Hydra 設定ファイル群
-│   ├── train.yaml                    # 学習メイン設定
-│   ├── visualize.yaml                # 可視化設定
-│   ├── run/                          # 実行時設定
-│   │   └── default.yaml
-│   ├── model/                        # モデル設定
-│   │   └── vit_heatmap.yaml          # ViT encoder/decoder + Heatmap
-│   ├── data/                         # DataModule 設定
-│   │   └── default.yaml
-│   ├── training/                     # 学習ハイパーパラメータ
-│   │   └── default.yaml
-│   ├── loss/                         # 損失関数設定
-│   │   └── default.yaml
-│   └── visualization/
-│       └── default.yaml
-│
-├── scripts/                          # 実行スクリプト
-│   ├── train.py                      # モデル学習
-│   └── visualize.py                  # 推論結果の可視化
-│
-├── models/                           # モデル実装
-│   ├── court_keypoint_model.py       # ViT encoder/decoder モデル
-│   └── components/
-│       ├── backbones.py              # 旧バックボーン実装
-│       └── heads.py                  # 旧ヘッド実装
-│
-├── data/                             # データセット・DataModule
-│   ├── dataset.py                    # Dataset
-│   └── datamodule.py                 # LightningDataModule
-│
-├── training/                         # 学習関連
-│   ├── lightning_module.py           # LightningModule
-│   ├── losses.py                     # 損失関数
-│   └── metrics.py                    # 評価指標
-│
-├── inference/                        # 推論
-│   ├── predictor.py                  # 推論クラス
-│   └── visualization.py              # 可視化ヘルパー
-│
-```
-
-## 主要コンポーネントの関係
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│ train.py                                                        │
-│   ├── data/datamodule.py           (DataModule)                 │
-│   ├── models/court_keypoint_model.py (モデル)                   │
-│   └── → outputs/court_detection/*/checkpoints/                  │
-└─────────────────────────────────────────────────────────────────┘
-                              ↓
-┌─────────────────────────────────────────────────────────────────┐
-│ visualize.py / inference/predictor.py                           │
-│   └── inference/visualization.py   (描画)                       │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-## 実行コマンド
-
-### 学習
-
-```bash
-python -m src.tasks.court_detection.scripts.train
-```
-
-### 可視化
-
-タスク（`kp` / `seg` / `line`）ごとに2パネルのGIFを生成します。`visualization=<task>`
-で切り替え、既定では `assets/court_detection/<task>.gif` に保存します。
-
-```bash
-# Keypoint：RGB + 予測キーポイント ｜ 平均ヒートマップ
-python -m src.tasks.court_detection.scripts.visualize visualization=kp
-
-# Segmentation：RGB ｜ セグメンテーションマップ
-python -m src.tasks.court_detection.scripts.visualize visualization=seg
-
-# Line：RGB ｜ ラインマップ
-python -m src.tasks.court_detection.scripts.visualize visualization=line
-
-# 入力ソースと出力先の上書き（単一画像・ディレクトリ・glob を指定可能）
-python -m src.tasks.court_detection.scripts.visualize visualization=kp \
-    visualization.image_source=data/court/images \
-    visualization.checkpoint=path/to/court-kp.ckpt \
-    visualization.save=assets/court_detection/kp.gif
-```
-
-可視化パイプラインは `io`（フレーム読み込み）→ `adapters`（predictor 入力への変換）→
-`api`（推論）→ `rendering`（描画）→ `orchestrator`（統括）という、blcs / plcs と統一した
-責任分担で構成されています。
-
-<p align="center">
-  <img src="../../../assets/court_detection/kp.gif" width="720" /><br/>
-  <img src="../../../assets/court_detection/seg.gif" width="720" /><br/>
-  <img src="../../../assets/court_detection/line.gif" width="720" />
-</p>
-
-## 手動アノテーション
-
-実映像からアノテーションを作成する場合は `src.tools.annotate_court_keypoints` を使用：
-
-```bash
-python -m src.tools.annotate_court_keypoints \
-    input_path=data/raw/court_image.jpg \
-    output.output_dir=data/court_keypoints
-```
-
-## 外部提供 API
-
-学習済みモデルを用いた推論 API は `src/tasks/court_detection/inference/predictor.py` を参照：
+## Inference
 
 ```python
+import numpy as np
+from PIL import Image
 from src.tasks.court_detection.inference.predictor import CourtKeypointPredictor
 
-predictor = CourtKeypointPredictor.load_from_checkpoint("path/to/checkpoint.ckpt")
-result = predictor.predict(image)
-keypoints = result["keypoints"]
-visibility = result["visibility"]
+predictor = CourtKeypointPredictor.load_from_checkpoint(
+    "outputs/court_detection/kp/logs/version_0/checkpoints/last.ckpt",
+    device="cpu",
+)
+
+image = np.array(Image.open("data/court/images/sample.jpg").convert("RGB"))
+result = predictor.predict(image, return_heatmaps=False)
+keypoints = result["keypoints"]  # (14, 2) 元画像ピクセル座標 [[x0, y0], ...]
 ```
+
+入力は `np.ndarray` / `PIL.Image` / `Tensor` のいずれも可。返り値は全テンソルが CPU 上の `dict[str, Tensor]`。
+
+| キー | 形状 | dtype | 条件 | 説明 |
+|---|---|---|---|---|
+| `keypoints` | `(K, 2)`（K=14） | float32 | 常時 | 元画像スケールのピクセル座標 `(x, y)` |
+| `heatmaps` | `(K, H, W)` | float32 | `return_heatmaps=True` | 前処理後解像度のヒートマップ |
+
+`short_side`（短辺リサイズ長）はckpt内 `config.data.augmentation.val_short_side`（デフォルト640）から自動取得します。
+
+## キーポイント仕様（CourtKP20）
+
+正準定義は `src/utils/schema/court.py` の `COURT_KP_NAMES` / `COURT_KP_IDX`。プロジェクト全体（CourtDetection / PLCS / BLCS / Rendering）がこのindexを共有します。学習モデルが出力するのは下表の **0〜13**。
+
+| Index | Name | Index | Name |
+|---|---|---|---|
+| 0 | far_doubles_left | 7 | near_singles_right |
+| 1 | far_doubles_right | 8 | far_service_left |
+| 2 | near_doubles_left | 9 | far_service_right |
+| 3 | near_doubles_right | 10 | near_service_left |
+| 4 | far_singles_left | 11 | near_service_right |
+| 5 | near_singles_left | 12 | far_service_t |
+| 6 | far_singles_right | 13 | near_service_t |
+
+index 14〜19（`net_center`, `left/right_post_base/top`, `center_strap_top`）はアノテーション専用です。
+
+## データ
+
+学習データは `data/court/data_train.json` / `data/court/data_val.json` のアノテーションJSON。`CourtDetectionDataModule` が `config.data.task` で `kp` / `seg` / `line` を切り替えます。
+
+2形式に対応します。
+
+- **Legacy配列形式**: `[{"id": ..., "kps": [[x0, y0], ...]}]`（`kps` を `(14, 2)` として読込）
+- **Named keypoints形式**（アノテーションツール出力）: `{"items": [{"image_path": ..., "keypoints": [{"index", "name", "x", "y", "visibility"}, ...]}]}`
+
+Sampleの主キーは `image (3, H, W)`（ImageNet正規化）・`heatmap (K, H, W)`・`keypoints (K, 2)`・`image_id`。data configは `configs/data/court_{kp,seg,line}.yaml`。
+
+## データセット生成（アノテーション）
+
+```bash
+# 1. YouTube動画を取得 → AV1/H.264変換 → フレームサンプリング
+#    data/court/youtube/annotations/{train,val}.json を named_keypoints 形式で初期化
+.venv/bin/python -m src.tasks.court_detection.scripts.prepare_youtube_dataset
+
+# 2. OpenCV UIで手動アノテーション（configs/annotate_youtube_keypoints.yaml）
+.venv/bin/python -m src.tasks.court_detection.scripts.annotate_youtube_keypoints
+.venv/bin/python -m src.tasks.court_detection.scripts.annotate_youtube_keypoints annotate.split=val
+```
+
+`homography_auto_fill: true` のとき、4点以上の接地点アノテーションからホモグラフィで残りの地面点を自動補完します。
+
+## 学習
+
+```bash
+.venv/bin/python -m src.tasks.court_detection.scripts.train                          # seg（デフォルト）
+.venv/bin/python -m src.tasks.court_detection.scripts.train data=court_kp   loss=kp
+.venv/bin/python -m src.tasks.court_detection.scripts.train data=court_line loss=line
+.venv/bin/python -m src.tasks.court_detection.scripts.train data=court_kp loss=kp model=court_kp_dino_swin_fpn
+```
+
+`configs/training/default.yaml` は `max_epochs=100`、`lr=1e-3`、`bf16-mixed`、AdamW、EarlyStopping（patience=10）。
+
+利用可能なモデルconfig（`configs/model/`）:
+
+| タスク | デフォルト | Swin-L (DINO) | その他 |
+|---|---|---|---|
+| `kp`（14クラス） | `court_kp` | `court_kp_dino_swin_fpn` / `court_kp_dino_swin_unet` | — |
+| `seg`（7クラス） | `court_seg` | `court_seg_dino_swin_fpn` / `court_seg_dino_swin_unet` | `court_seg_dinov3_detr` |
+| `line`（1クラス） | `court_line` | `court_line_dino_swin_fpn` / `court_line_dino_swin_unet` | — |
+
+## 可視化
+
+```bash
+.venv/bin/python -m src.tasks.court_detection.scripts.visualize                       # kp（デフォルト）
+.venv/bin/python -m src.tasks.court_detection.scripts.visualize visualization=seg
+.venv/bin/python -m src.tasks.court_detection.scripts.visualize visualization=line \
+    visualization.image_source=data/court/images/foo.png
+```
+
+ckptと画像ソースは `configs/visualization/{kp,seg,line}.yaml` で指定し、2パネルのGIF（既定 `assets/court_detection/*.gif`、fps=6）を出力します。
+
+## モデル
+
+| モデル | 対応タスク | 実装 |
+|---|---|---|
+| `CourtHierarchicalModel` | kp / seg / line | `models/hierarchical_model.py`（Encoder×Decoder の組合せ） |
+| `DINOv3DETR` | seg 専用 | `models/dinov3_detr.py`（DINOv3 ViT-B/16 + DETRデコーダ、mask-classification） |
+
+`CourtHierarchicalModel` のEncoderは `CourtDefaultEncoder`（軽量4ステージCNN）と `CourtDINOEncoder`（ResNet50/Swin-L等の事前学習backbone）、Decoderは `CourtFPNDecoder` と `CourtUNetDecoder` を組み合わせます。
+
+## 補足
+
+- 実行は `.venv/bin/python -m ...`。Hydra設定は `configs/` から読み込みます。
+- DINO/DINOv3 backbone使用時は `third_party/dinov3/` と対応する事前学習チェックポイントが必要です。

--- a/src/tasks/plcs/README.md
+++ b/src/tasks/plcs/README.md
@@ -1,250 +1,130 @@
 # PLCS (Player Localization in Court System)
 
-PLCS は、テニスコート座標系におけるプレイヤーの位置・向き（姿勢）を、
-2D の姿勢観測（2D pose キーポイント）から推定するためのタスク実装です。
+> 2D pose（COCO 17点）とコートキーポイントから、コート座標系におけるプレイヤーの3D位置とヨー回転を推定するタスク。
 
-## 目的 / 想定入出力
+## 概要
 
-- **入力**: 2D pose（関節座標）+ コートキーポイント
-- **出力**: コート座標系でのプレイヤー 3D 位置・回転（6DoF）
+複数カメラ・時系列の2D観測をTransformerで統合し、コート座標系の位置と向きを復元します。frame / sequence / multiview の3モードを共通の `PLCSPredictor` で扱います。
 
-### 入力形式
+| 項目 | 内容 |
+|---|---|
+| 入力 | 2D人物キーポイント `human_kp`（COCO17）+ コートキーポイント `court_kp` |
+| 出力 | 3D位置 `position`（正規化 + メートル）+ 回転 `rotation`（cos/sin yaw） |
+| モデル | `frame` / `multiview` / `multiview_axial` |
+| データ | AMASS（ACCAD）モーション + SMPL-H による合成生成 |
+| 役割 | 認識パイプラインの下流。2D pose検出と [court_detection](../court_detection/) の観測を3D化 |
 
-PLCSでは**camera-time順序**を採用しています: `(B, N, T, ...)` の順で、N=カメラ数、T=時系列長です。
+## Inference
 
-| モード | 入力テンソル | 形状 | 説明 |
-|--------|-------------|------|------|
-| 単一カメラ (Frame) | `human_kp` | `(B, 17, 2)` | 2D人物キーポイント |
-| 単一カメラ (Sequence) | `human_kp` | `(B, T, 17, 2)` | 時系列2D人物キーポイント |
-| マルチビュー (Frame) | `human_kp` | `(B, N, 17, 2)` | 複数カメラからの2D人物キーポイント |
-| マルチビュー (Sequence) | `human_kp` | `(B, N, T, 17, 2)` | 複数カメラ×時系列2D人物キーポイント (camera-time順) |
+camera-time順 `(B, N, T, ...)` を正準とし、モデルに応じて内部でスライスされます。
 
-※ コートキーポイント `court_kp` も同様に各モードに対応
+```python
+import torch
+from src.tasks.plcs.inference.predictor import PLCSPredictor
 
-### 出力形式
+predictor = PLCSPredictor.load_from_checkpoint(
+    "outputs/plcs/plcs/logs/version_0/checkpoints/last.ckpt",
+    device="cpu",
+)
 
-**Predictor 返り値（`PLCSPredictor.predict()`）:**
+# Frame モード（単一フレーム・単一カメラ）
+human_kp = torch.zeros(2, 17, 2)   # (B, 17, 2)
+court_kp = torch.zeros(2, 20, 2)   # (B, 20, 2)
+out = predictor.predict(human_kp, court_kp)
+# out["position"] (2, 3) / out["rotation"] (2, 2) / out["position_meters"] (2, 3) / out["yaw_radians"] (2,)
 
-推論結果は `dict[str, torch.Tensor]` 形式で返されます。全てのテンソルは CPU 上にあります。
-
-| キー | 形状（Frame / Sequence） | 型 | 説明 |
-|------|------|-----|------|
-| `position` | `(B, 3)` / `(B, T, 3)` | `torch.Tensor` | 正規化座標での3D位置（常に含まれる） |
-| `rotation` | `(B, 2)` / `(B, T, 2)` | `torch.Tensor` | 回転の (cos, sin) 表現（常に含まれる） |
-| `position_meters` | `(B, 3)` / `(B, T, 3)` | `torch.Tensor` | メートル単位の3D位置（デフォルトで含まれる、`denormalize=False` の場合は含まれない） |
-| `yaw_radians` | `(B,)` / `(B, T)` | `torch.Tensor` | ヨー角（ラジアン）（デフォルトで含まれる、`denormalize=False` の場合は含まれない） |
-
-**注意**: 
-- すべてのテンソルは CPU に配置されます（統合側での device 変換は不要）
-- バッチ次元は常に保持されます
-
-## ディレクトリ構成
-
-```
-src/tasks/plcs/
-├── configs/                          # Hydra 設定ファイル群
-│   ├── train.yaml                    # フレーム学習設定
-│   ├── train_multiview.yaml          # マルチビュー学習設定
-│   ├── generate_dataset.yaml         # データ生成設定
-│   ├── visualize.yaml                # 単一カメラ可視化設定
-│   ├── visualize_multiview.yaml      # マルチビュー可視化設定
-│   ├── run/                          # 実行時設定（seed, gpus, output_dir）
-│   ├── model/
-│   │   ├── frame.yaml                # フレームモデル設定
-│   │   └── multiview.yaml            # マルチビューモデル設定
-│   ├── data/
-│   │   ├── frame.yaml                # フレーム DataModule 設定
-│   │   └── multiview.yaml            # マルチビュー DataModule 設定
-│   ├── training/
-│   │   └── default.yaml              # 学習ハイパーパラメータ
-│   ├── loss/
-│   │   ├── frame.yaml                # フレームロス設定（temporal=0）
-│   │   └── multiview_sequence.yaml   # マルチビューシーケンスロス設定
-│   ├── simulation/
-│   │   └── default.yaml              # シミュレーション設定（シーン数等）
-│   ├── camera/
-│   │   └── default.yaml              # カメラ投影パラメータ
-│   └── visualization/
-│       ├── default.yaml              # 単一カメラ可視化オプション
-│       └── multiview.yaml            # マルチビュー可視化オプション
-│
-├── scripts/                          # 実行スクリプト（Hydra エントリポイント）
-│   ├── generate_dataset.py           # SMPL-H モーションからの合成データ生成
-│   ├── train.py                      # フレーム単位モデル学習
-│   ├── train_sequence.py             # シーケンスモデル学習
-│   ├── train_multiview.py            # マルチビューモデル学習
-│   ├── visualize.py                  # 単一カメラ可視化
-│   └── visualize_multiview.py        # マルチビュー可視化
-│
-├── models/                           # 推定モデル
-│   ├── plcs_model.py                 # PLCSModel: フレーム単位 2D→3D 推定
-│   └── plcs_multiview_model.py       # PLCSMultiViewModel: camera-time 2D RoPE統合
-│
-├── data/                             # データセット・DataModule
-│   ├── dataset.py                    # フレーム Dataset
-│   ├── sequence_dataset.py           # シーケンス Dataset
-│   ├── multiview_dataset.py          # マルチビュー Dataset
-│   └── datamodule.py                 # LightningDataModule（全モード共用）
-│
-├── training/                         # 学習関連
-│   ├── lightning_module.py           # フレーム用 LightningModule
-│   ├── sequence_lightning_module.py  # シーケンス用 LightningModule
-│   ├── multiview_lightning_module.py # マルチビュー用 LightningModule
-│   ├── losses.py                     # 損失関数（位置 MSE、回転損失）
-│   └── metrics.py                    # 評価指標（位置誤差、角度誤差）
-│
-├── inference/                        # 推論
-│   ├── predictor.py                  # フレーム推論
-│   ├── sequence_predictor.py         # シーケンス推論
-│   ├── multiview_predictor.py        # マルチビュー推論
-│   └── visualization.py              # 3D プレーヤー描画
-│
-└── generate_dataset/                 # データセット生成ロジック
-    ├── scene_generator.py            # シーン生成オーケストレータ
-    ├── sampling/
-    │   └── motion_sampler.py         # SMPL-H モーションのサンプリング
-    └── io/
-        └── dataset_io.py             # シーン保存・読込
+# Multiview モード（複数カメラ×時系列）
+human_kp   = torch.zeros(1, 3, 64, 17, 2)  # (B, N, T, 17, 2)
+court_kp   = torch.zeros(1, 3, 64, 20, 2)  # (B, N, T, 20, 2)
+human_mask = torch.ones(1, 3, 64)          # (B, N, T), True=valid
+out = predictor.predict(human_kp, court_kp, human_mask=human_mask)
+# out["position"] (1, 64, 3) / out["rotation"] (1, 64, 2)
 ```
 
-## 主要コンポーネントの関係
+`predict(human_kp, court_kp, human_vis=None, human_mask=None, court_vis=None, denormalize=True)`。返り値は全テンソルが CPU 上の `dict[str, Tensor]`。
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│ generate_dataset.py                                             │
-│   ├── generate_dataset/scene_generator.py                       │
-│   │   ├── sampling/motion_sampler.py  (SMPL-H モーション取得)    │
-│   │   └── 複数カメラ投影 → 2D キーポイント生成                    │
-│   └── → data/plcs/scenes/*.npz（各シーンに複数カメラ情報含む）    │
-└─────────────────────────────────────────────────────────────────┘
-                              ↓
-┌─────────────────────────────────────────────────────────────────┐
-│ train.py / train_multiview.py                                   │
-│   ├── data/datamodule.py           (DataModule)                 │
-│   │   ├── PLCSDataModule           (単一カメラ・フレーム)         │
-│   │   └── PLCSMultiViewDataModule  (マルチビュー)                │
-│   ├── models/                                                   │
-│   │   ├── plcs_model.py            (フレームモデル)              │
-│   │   └── plcs_multiview_model.py  (マルチビューモデル)          │
-│   └── → outputs/plcs/*/logs/version_*/checkpoints/              │
-└─────────────────────────────────────────────────────────────────┘
-                              ↓
-┌─────────────────────────────────────────────────────────────────┐
-│ visualize.py / visualize_multiview.py                           │
-│   ├── inference/predictor.py            (単一カメラ推論)         │
-│   ├── inference/multiview_predictor.py  (マルチビュー推論)       │
-│   └── inference/visualization.py        (描画)                  │
-└─────────────────────────────────────────────────────────────────┘
-```
+| キー | 形状（Frame / Multiview） | 条件 | 説明 |
+|---|---|---|---|
+| `position` | `(B, 3)` / `(B, T, 3)` | 常時 | 正規化コート座標 |
+| `rotation` | `(B, 2)` / `(B, T, 2)` | 常時 | `(cos yaw, sin yaw)`（L2正規化済み） |
+| `position_meters` | `(B, 3)` / `(B, T, 3)` | `denormalize=True` | メートル単位の位置 |
+| `yaw_radians` | `(B,)` / `(B, T)` | `denormalize=True` | ヨー角（ラジアン） |
+| `canonical_pose` | `(B, 17, 3)` / `(B, T, 17, 3)` | `predict_canonical_pose=True` | ヨー正規化ローカル関節 |
 
-## 実行コマンド
+スケールは `COURT_COORD_SCALE_(X,Y,Z) = (5.485, 11.885, 1.07)` [m]（`src/utils/schema/court.py`）。
 
-詳細は本README内の実行コマンド節を参照。
+### 入力テンソル仕様
 
-### データ生成
+| モード（`input_profile`） | `human_kp` | `court_kp` | `human_mask` |
+|---|---|---|---|
+| `frame` | `(B, 17, 2)` | `(B, 20, 2)` | `(B,)` または None |
+| `sequence` | `(B, T, 17, 2)` | `(B, T, 20, 2)` | `(B, T)` |
+| `multiview` | `(B, N, T, 17, 2)` | `(B, N, T, 20, 2)` | `(B, N, T)` |
+
+## データセット生成
+
+PLCSはAMASSモーションを用いて合成生成します（既存データセットなし）。
 
 ```bash
-python -m src.tasks.plcs.scripts.generate_dataset
+.venv/bin/python -m src.tasks.plcs.scripts.generate_dataset
+.venv/bin/python -m src.tasks.plcs.scripts.generate_dataset simulation.num_scenes=10 run.num_workers=4
+
+# 生成データの位置・ヨー・カメラ数分布を集計
+.venv/bin/python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution
 ```
 
-### データ分布の調査（位置・向き・カメラ数）
+- **仕様**: AMASS（ACCAD: running/walking/general）モーションをSMPL-Hで再生し、複数カメラ（1280×720、高さ3〜5m、FOV60°）へ投影。デフォルト1000シーン。
+- **生成構造**（`data/plcs/scenes/scene_XXXXXX/`）:
 
-生成済み PLCS データセット（`data/plcs/scenes/*.npz`）について、プレイヤー位置や yaw の分布、
-原点近傍への偏り（半径しきい値内の割合）などを集計します。
-
-```bash
-python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution
-
-# 出力先やサンプル数の変更例
-python -m src.tasks.plcs.scripts.analysis.analyze_dataset_distribution \
-    run.output_dir=outputs/plcs/analysis/dataset_distribution \
-    analysis.max_scenes=200 \
-    analysis.max_frames_per_scene=256
+```text
+scene_000000/
+├── meta.json / scalars.json   # num_cameras, fps, num_frames, カメラパラメータ
+├── position.npy               # (T, 3) 正規化座標
+├── rotation.npy               # (T, 2) (cos yaw, sin yaw)
+├── canonical_pose_3d.npy      # (T, 17, 3) ヨー正規化ローカル関節
+└── cam_{i}_*.npy              # human_kp_uv (T,17,2), court_kp_uv (T,20,2), *_visible ...
 ```
 
-### 学習
+## 学習
 
 ```bash
-# フレーム単位モデル（単一カメラ）
-python -m src.tasks.plcs.scripts.train
-
-# マルチビューモデル（複数カメラ統合）
-python -m src.tasks.plcs.scripts.train_multiview
-
-# マルチビュー学習のカスタム設定例
-python -m src.tasks.plcs.scripts.train_multiview \
-    data.num_views=4 \
-    data.min_cameras=2 \
-    training.max_epochs=100
+.venv/bin/python -m src.tasks.plcs.scripts.train                  # frame（デフォルト）
+.venv/bin/python -m src.tasks.plcs.scripts.train_chunked          # multiview のチャンク学習（オンライン生成）
+.venv/bin/python -m src.tasks.plcs.scripts.train_chunked data.chunk.scenes_per_chunk=500
 ```
 
-### 可視化
+`model` config は `frame` / `multiview` / `multiview_axial`、`data` config は `frame` / `sequence` / `multiview` / `chunked_multiview`。出力先は `outputs/plcs/${model.name}/`。マルチビュー学習は専用スクリプトではなく `train_chunked.py`（`model=multiview, data=chunked_multiview`）で行います。
+
+## 可視化
 
 ```bash
-# 単一カメラ
-python -m src.tasks.plcs.scripts.visualize
+.venv/bin/python -m src.tasks.plcs.scripts.visualize             # GT表示（デフォルト）
 
-# マルチビュー（Ground Truth）
-python -m src.tasks.plcs.scripts.visualize_multiview \
-    visualization.scene_path=data/plcs/scenes/scene_000003.npz
-
-# マルチビュー（チェックポイントからの予測）
-python -m src.tasks.plcs.scripts.visualize_multiview \
+# ckptによる GT vs 予測の比較
+.venv/bin/python -m src.tasks.plcs.scripts.visualize \
     visualization.mode=predict \
-    visualization.checkpoint=outputs/plcs/multiview/logs/version_0/checkpoints/last.ckpt \
-    visualization.cameras=all
+    visualization.checkpoint=outputs/plcs/plcs/logs/version_0/checkpoints/last.ckpt \
+    visualization.scene_path=data/plcs/scenes/scene_000000 \
+    visualization.animation_view=3d \
+    visualization.save=assets/plcs/pred.gif
 
-# 比較アニメーション出力
-python -m src.tasks.plcs.scripts.visualize_multiview \
-    visualization.mode=predict \
-    visualization.view=animation \
-    visualization.save=comparison.mp4
+# マルチビュー（全カメラ）
+.venv/bin/python -m src.tasks.plcs.scripts.visualize visualization.cameras=all
 ```
 
-## モデルアーキテクチャ
+可視化は単一の `visualize.py` に統合されており、`visualization.cameras=all`（または `0,1,2`）でマルチビューに対応します。`animation_view` は `3d` / `2d_topdown` / `camera`（`predict` モードでは `camera` 不可）。
 
-### フレームモデル (`PLCSModel`)
+## モデル
 
-単一フレーム・単一カメラからの推定。Transformer ベースのトークンモデル。
+| 名前 | アーキテクチャ | 実装 |
+|---|---|---|
+| `frame` (`plcs`) | Llama系 decoder-only Transformer（MHA + SwiGLU + RMSNorm）。`[CLS, Register×4, court(20), player(17)]` トークン列に3軸MROPE | `models/plcs_model.py` |
+| `multiview` (`plcs_multiview`) | 全カメラ×全時間を一括処理するTransformer。3軸MROPE、(camera,time)のCLSをカメラ次元で平均プール | `models/plcs_multiview_model.py` |
+| `multiview_axial` (`plcs_multiview_axial`) | カメラ軸／時間軸の交互self-attention（Axial attention） | `models/plcs_multiview_axial_model.py` |
 
-### マルチビューモデル (`PLCSMultiViewModel`)
+`build_plcs_model(config)` が `config.model.name` でモデルを切り替えます。
 
-複数カメラからの観測を統合して推定。カメラごとに
-`court_m + T * (CLS_po_{m,t}, CLS_ro_{m,t}, player_{m,t}[17])`
-のトークン列を持ち、camera-time 軸の 2D RoPE を適用します。
-推論時は camera-time 入力 `(B, N, T, ...)` を受け取り、時系列全体の位置・回転を推定します。
+## 補足
 
-- **入力**: 複数カメラ×時系列のキーポイント `(B, N, T, 17, 2)`
-- **出力**: 時系列の位置・回転 `(B, T, 3)`, `(B, T, 2)`
-- **動的サンプリング**: `num_views_range`, `seq_len_range` で学習時に範囲からランダムにサンプリング可能
-- **時間一貫性ロス**: 速度・加速度の平滑化による安定した軌道推定
-
-## 設定ファイル
-
-| 用途 | メイン設定 | 補助設定 |
-|------|----------|---------|
-| フレーム学習 | `train.yaml` | `model/frame.yaml`, `data/frame.yaml`, `loss/frame.yaml` |
-| マルチビュー学習 | `train_multiview.yaml` | `model/multiview.yaml`, `data/multiview.yaml`, `loss/multiview_sequence.yaml` |
-| 単一カメラ可視化 | `visualize.yaml` | `visualization/default.yaml` |
-| マルチビュー可視化 | `visualize_multiview.yaml` | `visualization/multiview.yaml` |
-
-各 `data/*.yaml` は標準の `DataLoader` バッチ設定を前提としており、
-`batch_size`, `num_workers`, `pin_memory` を用途ごとに切り替えます。
-
-### ロス設定ファイル
-
-ロス関数のウェイトは `configs/loss/` ディレクトリで管理されています：
-
-時系列一貫性ロスは以下の4項目を個別に重み付けできます（`loss.*.yaml` の `temporal.*.weight`）：
-- `temporal.position_gt`: 位置の速度/加速度を GT に合わせる
-- `temporal.position_inertia`: 位置の慣性（加速度が小さい）を促す
-- `temporal.rotation_gt`: 角度の角速度/角加速度を GT に合わせる
-- `temporal.rotation_inertia`: 回転の慣性（角加速度が小さい）を促す
-
-| ファイル | 用途 | `temporal.position_gt.weight` |
-|---------|------|------------------------------|
-| `frame.yaml` | フレーム単位学習 | 0.0 |
-| `sequence.yaml` | シーケンス学習 | 0.1 |
-| `multiview_sequence.yaml` | マルチビューシーケンス学習 | 0.1 |
-
-詳細なドキュメントは `src/tasks/plcs/scripts/` と `src/tasks/plcs/configs/` を参照。
+- 実行は `.venv/bin/python -m ...`。学習をCPUで試す場合は `run.gpus=0`。
+- データ生成にはAMASSモーション（`data/ACCAD/`）とSMPL-Hモデル（`data/smplx/smplh/`、`smplx` パッケージ）が必要です。


### PR DESCRIPTION
## 概要

issue #504。`src/tasks` 配下4タスクのREADMEを、大規模AI repo風の統一テンプレートへ刷新しました。古い情報・冗長性を排し、コンパクトかつ情報密度の高い構成にしています。

## 統一テンプレート（全タスク共通の節順）

1. **概要** — 解くタスク + at-a-glanceメタ表（入力/出力/モデル/データ/パイプライン上の役割）
2. **Inference** — Python API使用例（ckpt読込→predict）+ 返り値テンソル契約表（形状/dtype/device/条件）
3. **データ** — 使用データの構造（既存DSはここ、生成DSは次節へ）
4. **データセット生成** — 生成タスクのみ（コマンド/仕様/生成データ構造）
5. **学習** — コマンド + モデル/config一覧 + 主要オプション
6. **可視化** — ckptを用いた可視化コマンド
7. **モデル** — アーキテクチャ要約表 + 実装パス
8. **補足** — 依存・注意点

巨大ディレクトリツリーとASCII関係図は陳腐化・冗長の主因のため廃止（646→356行相当）。

## 実装方針

タスクごとにsonnetサブエージェントを立て、コードを直接読んで定量事実（predictorシグネチャ・実テンソル形状・config名・実在コマンド）を検証。現行READMEの事実誤りを多数修正しました。

| タスク | 主な修正 |
|---|---|
| ball_detection | Inference例 + 返り値契約表を追加 |
| court_detection | 出力は **20点ではなく14点**、デフォルト学習タスクは `seg`、kp/seg/lineの3タスク構成を明記 |
| blcs | 不存在の `placement_mode=fixed_8` / `run_hparam_sweep.sh` / `BLCSMultiViewPredictor`エイリアスを除去、`train_chunked` を追記 |
| plcs | 不存在の `sequence/multiview_predictor` / `train_multiview` / `visualize_multiview` を除去、`train_chunked` と `cameras=all` へ修正 |

全タスクで実行コマンドを `.venv/bin/python -m` に統一。

## 受け入れ条件

- [x] すべてのタスクのREADMEが統一フォーマットに従う
- [x] 情報を定量的事実・コードベースに沿って検証
- [x] 冗長性を削減

🤖 Generated with [Claude Code](https://claude.com/claude-code)