### PR TITLE
feat(plcs): add pose-naturalness losses and loss-dominance analysis

### DIFF
--- a/src/tasks/plcs/configs/analyze_loss_dominance.yaml
+++ b/src/tasks/plcs/configs/analyze_loss_dominance.yaml
@@ -1,0 +1,20 @@
+defaults:
+  - run: analyze_loss_dominance
+  - _self_
+
+analysis:
+  # Split file (under data.scene_dir) to evaluate, e.g. test / val / train.
+  split: test
+  # Inference device; null selects cuda when available, else cpu.
+  device: null
+  # Limit the number of evaluated scenes (null = all).
+  max_batches: null
+  # Report filename written under run.output_dir.
+  output_filename: loss_dominance_test.json
+
+hydra:
+  run:
+    dir: outputs/hydra/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/tasks/plcs/configs/loss/frame.yaml
+++ b/src/tasks/plcs/configs/loss/frame.yaml
@@ -1,21 +1,13 @@
-# Frame-level PLCS loss configuration (single frame, no temporal loss).
+# Frame-level PLCS loss configuration (single frame).
 position_weight: 1.0
 rotation_weight: 1.0
+
+# Canonical-pose supervision (requires model.predict_canonical_pose: true).
 canonical_pose_weight: 0.0
-temporal:
-  position_gt:
-    weight: 0.0
-    order: 2
-    robust: true
-  position_inertia:
-    weight: 0.0
-    order: 2
-    robust: true
-  rotation_gt:
-    weight: 0.0
-    order: 2
-    robust: true
-  rotation_inertia:
-    weight: 0.0
-    order: 2
-    robust: true
+
+# Pose-naturalness terms (computed on the canonical pose). Disabled by default;
+# enable by setting a positive weight.
+joint_angle_weight: 0.0
+torsion_angle_weight: 0.0
+torso_twist_weight: 0.0
+bone_length_weight: 0.0

--- a/src/tasks/plcs/configs/loss/multiview_sequence.yaml
+++ b/src/tasks/plcs/configs/loss/multiview_sequence.yaml
@@ -1,21 +1,13 @@
 # Multi-view sequence PLCS loss configuration (multi-camera sequential).
 position_weight: 1.0
 rotation_weight: 1.0
+
+# Canonical-pose supervision (requires model.predict_canonical_pose: true).
 canonical_pose_weight: 0.0
-temporal:
-  position_gt:
-    weight: 0.1
-    order: 2
-    robust: true
-  position_inertia:
-    weight: 0.1
-    order: 2
-    robust: true
-  rotation_gt:
-    weight: 0.1
-    order: 2
-    robust: true
-  rotation_inertia:
-    weight: 0.1
-    order: 2
-    robust: true
+
+# Pose-naturalness terms (computed on the canonical pose). Disabled by default;
+# enable by setting a positive weight.
+joint_angle_weight: 0.0
+torsion_angle_weight: 0.0
+torso_twist_weight: 0.0
+bone_length_weight: 0.0

--- a/src/tasks/plcs/configs/loss/sequence.yaml
+++ b/src/tasks/plcs/configs/loss/sequence.yaml
@@ -1,21 +1,13 @@
-# Sequence-level PLCS loss configuration (single camera, with temporal consistency).
+# Sequence-level PLCS loss configuration (single camera).
 position_weight: 1.0
 rotation_weight: 1.0
+
+# Canonical-pose supervision (requires model.predict_canonical_pose: true).
 canonical_pose_weight: 0.0
-temporal:
-  position_gt:
-    weight: 0.1
-    order: 2
-    robust: true
-  position_inertia:
-    weight: 0.1
-    order: 2
-    robust: true
-  rotation_gt:
-    weight: 0.1
-    order: 2
-    robust: true
-  rotation_inertia:
-    weight: 0.1
-    order: 2
-    robust: true
+
+# Pose-naturalness terms (computed on the canonical pose). Disabled by default;
+# enable by setting a positive weight.
+joint_angle_weight: 0.0
+torsion_angle_weight: 0.0
+torso_twist_weight: 0.0
+bone_length_weight: 0.0

--- a/src/tasks/plcs/configs/run/analyze_loss_dominance.yaml
+++ b/src/tasks/plcs/configs/run/analyze_loss_dominance.yaml
@@ -1,0 +1,5 @@
+# Checkpoint + hparams of the trained run to analyze, and where to write the report.
+checkpoint: outputs/plcs/issue_430_multiview_axial_canonical_train/logs/version_0/checkpoints/last.ckpt
+hparams: outputs/plcs/issue_430_multiview_axial_canonical_train/logs/version_0/hparams.yaml
+output_dir: outputs/plcs/issue_430_multiview_axial_canonical_train
+seed: 42

--- a/src/tasks/plcs/scripts/analysis/analyze_loss_dominance.py
+++ b/src/tasks/plcs/scripts/analysis/analyze_loss_dominance.py
@@ -1,0 +1,240 @@
+"""Analyze which PLCS loss term is dominant for a trained checkpoint.
+
+Loads a trained checkpoint together with the ``hparams.yaml`` from its run
+directory, evaluates it on a split, and reports for every registered
+:class:`PLCSLoss` term its raw loss, configured weight, and weighted
+contribution to the total. This shows which term dominates the objective and
+how large the pose-naturalness terms (``joint_angle``, ``torsion_angle``,
+``torso_twist``, ``bone_length``) are relative to the supervised ones.
+
+Usage:
+    python -m src.tasks.plcs.scripts.analysis.analyze_loss_dominance
+    python -m src.tasks.plcs.scripts.analysis.analyze_loss_dominance \
+        run.checkpoint=path/to/last.ckpt run.hparams=path/to/hparams.yaml \
+        analysis.split=test analysis.max_batches=10
+
+Notes:
+    - Analysis settings are loaded from
+      `src/tasks/plcs/configs/analyze_loss_dominance.yaml` via Hydra.
+    - Model weights come from `run.checkpoint`; all loss/metric/data settings
+      come from the run's `run.hparams` (`hparams.yaml`), so the report matches
+      the trained configuration. Temporal losses are intentionally excluded.
+    - The JSON report is written to `run.output_dir/analysis.output_filename`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar, cast
+
+import hydra
+import torch
+from hydra.utils import to_absolute_path
+from omegaconf import DictConfig, OmegaConf
+from torch import Tensor
+
+from src.tasks.plcs.data.datamodule import PLCSDataModule
+from src.tasks.plcs.training.lightning_module import PLCSLightningModule
+from src.tasks.plcs.training.losses import PLCSLoss, PLCSLossConfig
+from src.tasks.plcs.training.metrics import PLCSMetrics
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
+    """Typed wrapper for hydra.main to keep mypy satisfied."""
+    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+
+
+def _load_hparams_config(hparams_path: Path) -> DictConfig:
+    """Load the ``config`` block stored in a Lightning ``hparams.yaml``."""
+    raw = OmegaConf.load(hparams_path)
+    config = raw.get("config", raw)
+    if not isinstance(config, DictConfig):
+        config = OmegaConf.create(config)
+    return config
+
+
+def _running_mean(state: dict[str, float], key: str, value: float, count: int) -> None:
+    prev = state.get(key, 0.0)
+    state[key] = prev + (value - prev) / count
+
+
+def analyze(
+    checkpoint: Path,
+    hparams: Path,
+    split: str,
+    device: torch.device,
+    max_batches: int | None,
+) -> dict[str, Any]:
+    """Run the dominance analysis and return a result dict."""
+    config = _load_hparams_config(hparams)
+
+    # Model weights from the checkpoint, all settings from hparams.yaml.
+    module = PLCSLightningModule.load_from_checkpoint(
+        str(checkpoint),
+        config=config,
+        map_location=device,
+        weights_only=False,
+    )
+    module.eval().to(device)
+    model = module.model
+
+    # PLCSLoss is the single source of truth for which terms exist and their
+    # weights, so the analysis automatically tracks every registered term
+    # (including the pose-naturalness losses) without hard-coded names.
+    loss_fn = PLCSLoss(config=PLCSLossConfig.from_dict(dict(config.get("loss", {}))))
+    term_names = tuple(loss_fn.loss_terms)
+
+    metrics_cfg = config.get("metrics", {})
+    metrics = PLCSMetrics(
+        position_threshold_m=float(metrics_cfg.get("position_threshold_m", 0.5)),
+        angle_threshold_deg=float(metrics_cfg.get("angle_threshold_deg", 15.0)),
+    )
+
+    torch.manual_seed(int(config.get("run", {}).get("seed", 42)))
+    datamodule = PLCSDataModule(config)
+    datamodule.setup("test")
+    if split != "test":
+        datamodule.test_dataset = datamodule._build_dataset(
+            scene_dir=datamodule.scene_dir,
+            split_file=f"{split}.txt",
+            augment=False,
+        )
+    loader = datamodule.test_dataloader()
+
+    raw_loss: dict[str, float] = {}
+    count = 0
+    with torch.no_grad():
+        for batch_idx, batch in enumerate(loader):
+            if max_batches is not None and batch_idx >= max_batches:
+                break
+            batch = {
+                k: v.to(device) if isinstance(v, Tensor) else v
+                for k, v in batch.items()
+            }
+            outputs = model(
+                human_kp=batch["human_kp"],
+                court_kp=batch["court_kp"],
+                human_vis=batch.get("human_vis"),
+                human_mask=batch.get("human_mask"),
+                court_vis=batch.get("court_vis"),
+            )
+            losses = loss_fn(
+                pred_position=outputs["position"],
+                pred_rotation=outputs["rotation"],
+                target_position=batch["position"],
+                target_rotation=batch["rotation"],
+                pred_canonical_pose=outputs.get("canonical_pose"),
+                target_human_kp_3d=batch.get("human_kp_3d"),
+                human_mask=batch.get("human_mask"),
+            )
+            metrics.update(
+                outputs["position"],
+                outputs["rotation"],
+                batch["position"],
+                batch["rotation"],
+                human_mask=batch.get("human_mask"),
+            )
+
+            count += 1
+            for name in term_names:
+                _running_mean(raw_loss, name, float(losses[name].item()), count)
+
+    weights = {name: loss_fn.weight_for(name) for name in term_names}
+    weighted = {name: raw_loss[name] * weights[name] for name in term_names}
+    total_weighted = sum(weighted.values())
+    share = {
+        name: (weighted[name] / total_weighted if total_weighted > 0 else 0.0)
+        for name in term_names
+    }
+
+    return {
+        "checkpoint": str(checkpoint),
+        "hparams": str(hparams),
+        "split": split,
+        "num_batches": count,
+        "terms": list(term_names),
+        "weights": weights,
+        "raw_loss": dict(raw_loss),
+        "weighted_loss": weighted,
+        "weighted_share": share,
+        "total_weighted_loss": total_weighted,
+        "metrics": metrics.compute(),
+    }
+
+
+def _print_report(result: dict[str, Any]) -> None:
+    print("=" * 72)
+    print("PLCS loss dominance analysis")
+    print("=" * 72)
+    print(f"checkpoint : {result['checkpoint']}")
+    print(f"hparams    : {result['hparams']}")
+    print(f"split      : {result['split']}  ({result['num_batches']} batches)")
+    print("-" * 72)
+    print(f"{'term':<16}{'raw':>12}{'weight':>10}{'weighted':>14}{'share':>10}")
+    print("-" * 72)
+    for term in result["terms"]:
+        print(
+            f"{term:<16}"
+            f"{result['raw_loss'][term]:>12.5f}"
+            f"{result['weights'][term]:>10.3f}"
+            f"{result['weighted_loss'][term]:>14.5f}"
+            f"{result['weighted_share'][term] * 100:>9.1f}%"
+        )
+    print("-" * 72)
+    print(
+        f"{'total':<16}{'':>12}{'':>10}"
+        f"{result['total_weighted_loss']:>14.5f}{'100.0%':>10}"
+    )
+    print("-" * 72)
+    dominant = max(result["terms"], key=lambda t: result["weighted_loss"][t])
+    print(f"Dominant (weighted) loss term: {dominant}")
+    print("-" * 72)
+    m = result["metrics"]
+    print(
+        "position_error_m={:.4f}  angular_error_deg={:.2f}  "
+        "pos_acc@0.5m={:.3f}  ang_acc@15deg={:.3f}".format(
+            m.get("position_error_m", 0.0),
+            m.get("angular_error_deg", 0.0),
+            m.get("position_accuracy_0.5m", 0.0),
+            m.get("angle_accuracy_15deg", 0.0),
+        )
+    )
+    print("=" * 72)
+
+
+def _resolve_device(device_cfg: Any) -> torch.device:
+    if device_cfg is not None:
+        return torch.device(str(device_cfg))
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+@hydra_main(
+    config_path="../../configs",
+    config_name="analyze_loss_dominance",
+    version_base="1.3",
+)
+def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry
+    max_batches = cfg.analysis.max_batches
+    result = analyze(
+        checkpoint=Path(to_absolute_path(str(cfg.run.checkpoint))),
+        hparams=Path(to_absolute_path(str(cfg.run.hparams))),
+        split=str(cfg.analysis.split),
+        device=_resolve_device(cfg.analysis.device),
+        max_batches=int(max_batches) if max_batches is not None else None,
+    )
+    _print_report(result)
+
+    out_dir = Path(to_absolute_path(str(cfg.run.output_dir)))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / str(cfg.analysis.output_filename)
+    out_path.write_text(json.dumps(result, indent=2))
+    print(f"Saved JSON report to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(cast(Callable[[], int], main)())

--- a/src/tasks/plcs/training/losses.py
+++ b/src/tasks/plcs/training/losses.py
@@ -6,6 +6,7 @@ Temporal consistency is enforced by the GAN discriminator.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import torch
@@ -13,7 +14,28 @@ import torch.nn as nn
 from torch import Tensor
 
 from src.tasks.plcs.utils.pose_geometry import world_pose_to_canonical_pose
+from src.utils.schema.player import (
+    COCO17_BONE_LENGTH_EDGES as BONE_LENGTH_EDGES,
+)
+from src.utils.schema.player import (
+    COCO17_JOINT_ANGLE_TRIPLETS as JOINT_ANGLE_TRIPLETS,
+)
+from src.utils.schema.player import (
+    COCO17_TORSION_QUADRUPLETS as TORSION_QUADRUPLETS,
+)
+from src.utils.schema.player import (
+    COCO17_TORSO_TWIST_JOINTS as TORSO_TWIST_JOINTS,
+)
 from src.utils.tensor_utils import masked_mean, normalize_padding_mask
+
+# Loss terms that require pred_canonical_pose and target_human_kp_3d.
+CANONICAL_DEPENDENT_TERM_NAMES: tuple[str, ...] = (
+    "canonical_pose",
+    "joint_angle",
+    "torsion_angle",
+    "torso_twist",
+    "bone_length",
+)
 
 
 @dataclass(frozen=True)
@@ -24,38 +46,47 @@ class PLCSLossConfig:
         position_weight: Weight for position loss.
         rotation_weight: Weight for rotation loss.
         canonical_pose_weight: Weight for canonical pose loss.
+        joint_angle_weight: Weight for joint-angle loss.
+        torsion_angle_weight: Weight for limb torsion / dihedral angle loss.
+        torso_twist_weight: Weight for shoulder-hip twist loss.
+        bone_length_weight: Weight for bone-length consistency loss.
 
     """
 
     position_weight: float = 1.0
     rotation_weight: float = 1.0
     canonical_pose_weight: float = 0.0
+    joint_angle_weight: float = 0.0
+    torsion_angle_weight: float = 0.0
+    torso_twist_weight: float = 0.0
+    bone_length_weight: float = 0.0
 
     @classmethod
     def from_dict(cls, cfg: dict) -> PLCSLossConfig:
-        """Create config from dictionary (e.g., loaded from YAML).
-
-        Args:
-            cfg: Configuration dictionary.
-
-        Returns:
-            PLCSLossConfig instance.
-
-        """
+        """Create config from dictionary, e.g. loaded from YAML."""
         return cls(
-            position_weight=cfg.get("position_weight", 1.0),
-            rotation_weight=cfg.get("rotation_weight", 1.0),
+            position_weight=float(cfg.get("position_weight", 1.0)),
+            rotation_weight=float(cfg.get("rotation_weight", 1.0)),
             canonical_pose_weight=float(cfg.get("canonical_pose_weight", 0.0)),
+            joint_angle_weight=float(cfg.get("joint_angle_weight", 0.0)),
+            torsion_angle_weight=float(cfg.get("torsion_angle_weight", 0.0)),
+            torso_twist_weight=float(cfg.get("torso_twist_weight", 0.0)),
+            bone_length_weight=float(cfg.get("bone_length_weight", 0.0)),
         )
 
 
+# ---------------------------------------------------------------------------
+# Basic losses / metrics
+# ---------------------------------------------------------------------------
+
+
 def position_loss(pred: Tensor, target: Tensor, reduction: str = "mean") -> Tensor:
-    """Compute position loss (L1 or smooth L1).
+    """Compute smooth-L1 position loss.
 
     Args:
-        pred: Predicted position, shape (B, 3).
-        target: Target position, shape (B, 3).
-        reduction: Reduction method ('mean', 'sum', 'none').
+        pred: Predicted position, shape ``(..., 3)``.
+        target: Target position, shape ``(..., 3)``.
+        reduction: ``'mean'``, ``'sum'``, or ``'none'``.
 
     Returns:
         Tensor: Position loss.
@@ -65,62 +96,592 @@ def position_loss(pred: Tensor, target: Tensor, reduction: str = "mean") -> Tens
 
 
 def rotation_loss(pred: Tensor, target: Tensor, reduction: str = "mean") -> Tensor:
-    """Compute rotation loss for (cos, sin) representation.
+    """Compute rotation loss for ``(cos, sin)`` yaw representation.
 
-    Uses cosine similarity loss which is appropriate for unit vectors.
+    Uses ``1 - cosine_similarity``. Both prediction and target are normalized
+    for safety.
 
     Args:
-        pred: Predicted (cos, sin), shape (B, 2). Should be normalized.
-        target: Target (cos, sin), shape (B, 2).
-        reduction: Reduction method.
+        pred: Predicted ``(cos, sin)``, shape ``(..., 2)``.
+        target: Target ``(cos, sin)``, shape ``(..., 2)``.
+        reduction: ``'mean'``, ``'sum'``, or ``'none'``.
 
     Returns:
-        Tensor: Rotation loss (1 - cosine similarity).
+        Tensor: Rotation loss.
 
     """
-    # Normalize predictions (should already be normalized, but ensure)
     pred_norm = nn.functional.normalize(pred, dim=-1)
-
-    # Cosine similarity: dot product of unit vectors
-    cos_sim = (pred_norm * target).sum(dim=-1)
-
-    # Loss is 1 - cos_sim (0 when aligned, 2 when opposite)
-    loss = 1.0 - cos_sim
+    target_norm = nn.functional.normalize(target, dim=-1)
+    loss = 1.0 - (pred_norm * target_norm).sum(dim=-1)
 
     if reduction == "mean":
         return loss.mean()
-    elif reduction == "sum":
+    if reduction == "sum":
         return loss.sum()
     return loss
 
 
 def angular_error(pred: Tensor, target: Tensor) -> Tensor:
-    """Compute angular error in radians.
+    """Compute wrapped angular error in radians.
 
     Args:
-        pred: Predicted (cos, sin), shape (B, 2).
-        target: Target (cos, sin), shape (B, 2).
+        pred: Predicted ``(cos, sin)``, shape ``(..., 2)``.
+        target: Target ``(cos, sin)``, shape ``(..., 2)``.
 
     Returns:
-        Tensor: Angular error in radians, shape (B,).
+        Tensor: Absolute angular error in radians, shape ``(...)``.
 
     """
-    # Convert to angles
-    pred_angle = torch.atan2(pred[:, 1], pred[:, 0])
-    target_angle = torch.atan2(target[:, 1], target[:, 0])
-
-    # Angular difference (handle wraparound)
+    pred_angle = torch.atan2(pred[..., 1], pred[..., 0])
+    target_angle = torch.atan2(target[..., 1], target[..., 0])
     diff = pred_angle - target_angle
     diff = torch.atan2(torch.sin(diff), torch.cos(diff))
-
     return diff.abs()
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_vector(v: Tensor, *, eps: float = 1e-8) -> Tensor:
+    """Normalize vectors along the last dimension."""
+    return v / v.norm(dim=-1, keepdim=True).clamp_min(eps)
+
+
+def _wrapped_angle_diff(pred_angle: Tensor, target_angle: Tensor) -> Tensor:
+    """Return signed wrapped angle difference in ``[-pi, pi]``."""
+    diff = pred_angle - target_angle
+    return torch.atan2(torch.sin(diff), torch.cos(diff))
+
+
+def compute_joint_angles(
+    pose: Tensor,
+    triplets: tuple[tuple[int, int, int], ...] = JOINT_ANGLE_TRIPLETS,
+) -> Tensor:
+    """Compute interior joint angles in radians.
+
+    For each triplet ``(a, vertex, c)``, computes the angle at ``vertex``
+    between bones ``vertex -> a`` and ``vertex -> c``.
+
+    The angle is computed with ``atan2(||v1 x v2||, v1 . v2)``, which is
+    stable near 0 and pi.
+
+    Args:
+        pose: Joint positions, shape ``(..., J, 3)``.
+        triplets: Joint index triplets.
+
+    Returns:
+        Tensor: Angles in radians, shape ``(..., len(triplets))``.
+
+    """
+    a_idx = [t[0] for t in triplets]
+    b_idx = [t[1] for t in triplets]
+    c_idx = [t[2] for t in triplets]
+
+    vertex = pose[..., b_idx, :]
+    v1 = pose[..., a_idx, :] - vertex
+    v2 = pose[..., c_idx, :] - vertex
+
+    cross_norm = torch.cross(v1, v2, dim=-1).norm(dim=-1)
+    dot = (v1 * v2).sum(dim=-1)
+    return torch.atan2(cross_norm, dot)
+
+
+def compute_torsion_angles(
+    pose: Tensor,
+    quadruplets: tuple[tuple[int, int, int, int], ...] = TORSION_QUADRUPLETS,
+    *,
+    eps: float = 1e-8,
+) -> Tensor:
+    """Compute signed torsion / dihedral angles in radians.
+
+    For each quadruplet ``(a, b, c, d)``, computes the signed angle between
+    the two planes:
+
+    - plane 1: ``(a, b, c)``
+    - plane 2: ``(b, c, d)``
+
+    This captures 3D bending direction of limbs.
+
+    Args:
+        pose: Joint positions, shape ``(..., J, 3)``.
+        quadruplets: Joint index quadruplets.
+        eps: Numerical stability epsilon.
+
+    Returns:
+        Tensor: Signed torsion angles in radians, shape
+        ``(..., len(quadruplets))``.
+
+    """
+    a_idx = [q[0] for q in quadruplets]
+    b_idx = [q[1] for q in quadruplets]
+    c_idx = [q[2] for q in quadruplets]
+    d_idx = [q[3] for q in quadruplets]
+
+    p0 = pose[..., a_idx, :]
+    p1 = pose[..., b_idx, :]
+    p2 = pose[..., c_idx, :]
+    p3 = pose[..., d_idx, :]
+
+    b0 = p1 - p0
+    b1 = p2 - p1
+    b2 = p3 - p2
+
+    n1 = _normalize_vector(torch.cross(b0, b1, dim=-1), eps=eps)
+    n2 = _normalize_vector(torch.cross(b1, b2, dim=-1), eps=eps)
+    b1n = _normalize_vector(b1, eps=eps)
+
+    # Signed dihedral angle.
+    m1 = torch.cross(n1, b1n, dim=-1)
+    x = (n1 * n2).sum(dim=-1)
+    y = (m1 * n2).sum(dim=-1)
+    return torch.atan2(y, x)
+
+
+def signed_angle_around_axis(
+    v1: Tensor,
+    v2: Tensor,
+    axis: Tensor,
+    *,
+    eps: float = 1e-8,
+) -> Tensor:
+    """Compute signed angle from ``v1`` to ``v2`` around ``axis``.
+
+    The vectors are first projected onto the plane perpendicular to ``axis``.
+    This is useful for measuring body twist around the torso axis.
+
+    Args:
+        v1: First vector, shape ``(..., 3)``.
+        v2: Second vector, shape ``(..., 3)``.
+        axis: Rotation axis, shape ``(..., 3)``.
+        eps: Numerical stability epsilon.
+
+    Returns:
+        Tensor: Signed angle in radians, shape ``(...)``.
+
+    """
+    axis = _normalize_vector(axis, eps=eps)
+
+    v1_proj = v1 - (v1 * axis).sum(dim=-1, keepdim=True) * axis
+    v2_proj = v2 - (v2 * axis).sum(dim=-1, keepdim=True) * axis
+
+    v1_proj = _normalize_vector(v1_proj, eps=eps)
+    v2_proj = _normalize_vector(v2_proj, eps=eps)
+
+    x = (v1_proj * v2_proj).sum(dim=-1)
+    y = (torch.cross(v1_proj, v2_proj, dim=-1) * axis).sum(dim=-1)
+    return torch.atan2(y, x)
+
+
+def compute_torso_twist(
+    pose: Tensor,
+    joints: tuple[int, int, int, int] = TORSO_TWIST_JOINTS,
+) -> Tensor:
+    """Compute shoulder-hip twist angle from COCO-17 pose.
+
+    The twist is the signed angle from the hip axis to the shoulder axis
+    around the torso axis.
+
+    Args:
+        pose: Joint positions, shape ``(..., 17, 3)``.
+        joints: ``(left_shoulder, right_shoulder, left_hip, right_hip)``.
+
+    Returns:
+        Tensor: Signed torso twist angle in radians, shape ``(...)``.
+
+    """
+    left_shoulder_idx, right_shoulder_idx, left_hip_idx, right_hip_idx = joints
+
+    left_shoulder = pose[..., left_shoulder_idx, :]
+    right_shoulder = pose[..., right_shoulder_idx, :]
+    left_hip = pose[..., left_hip_idx, :]
+    right_hip = pose[..., right_hip_idx, :]
+
+    mid_shoulder = 0.5 * (left_shoulder + right_shoulder)
+    mid_hip = 0.5 * (left_hip + right_hip)
+
+    shoulder_axis = right_shoulder - left_shoulder
+    hip_axis = right_hip - left_hip
+    torso_axis = mid_shoulder - mid_hip
+
+    return signed_angle_around_axis(hip_axis, shoulder_axis, torso_axis)
+
+
+def compute_bone_lengths(
+    pose: Tensor,
+    edges: tuple[tuple[int, int], ...] = BONE_LENGTH_EDGES,
+    *,
+    eps: float = 1e-8,
+) -> Tensor:
+    """Compute bone lengths for selected COCO body edges.
+
+    Args:
+        pose: Joint positions, shape ``(..., J, 3)``.
+        edges: Bone edges as ``(joint_a, joint_b)``.
+        eps: Numerical stability epsilon.
+
+    Returns:
+        Tensor: Bone lengths, shape ``(..., len(edges))``.
+
+    """
+    a_idx = [e[0] for e in edges]
+    b_idx = [e[1] for e in edges]
+
+    bone_vec = pose[..., a_idx, :] - pose[..., b_idx, :]
+    return bone_vec.norm(dim=-1).clamp_min(eps)
+
+
+# ---------------------------------------------------------------------------
+# Pose naturalness losses
+# ---------------------------------------------------------------------------
+
+
+def joint_angle_loss(
+    pred_pose: Tensor,
+    target_pose: Tensor,
+    triplets: tuple[tuple[int, int, int], ...] = JOINT_ANGLE_TRIPLETS,
+    *,
+    reduction: str = "mean",
+) -> Tensor:
+    """Compute joint-angle loss between predicted and target poses.
+
+    This compares 12 angles by default:
+
+    - 8 articulated limb angles
+    - 4 torso quadrilateral internal angles
+
+    Args:
+        pred_pose: Predicted joints, shape ``(..., J, 3)``.
+        target_pose: Target joints, shape ``(..., J, 3)``.
+        triplets: Joint-angle triplets.
+        reduction: ``'mean'``, ``'sum'``, or ``'none'``.
+
+    Returns:
+        Tensor: Joint-angle loss. If ``reduction='none'``, returns per-frame
+        loss with shape ``(...)``.
+
+    """
+    pred_angles = compute_joint_angles(pred_pose, triplets)
+    target_angles = compute_joint_angles(target_pose, triplets)
+    per_angle = nn.functional.smooth_l1_loss(
+        pred_angles,
+        target_angles,
+        reduction="none",
+    )
+
+    if reduction == "mean":
+        return per_angle.mean()
+    if reduction == "sum":
+        return per_angle.sum()
+    return per_angle.mean(dim=-1)
+
+
+def torsion_angle_loss(
+    pred_pose: Tensor,
+    target_pose: Tensor,
+    quadruplets: tuple[tuple[int, int, int, int], ...] = TORSION_QUADRUPLETS,
+    *,
+    reduction: str = "mean",
+) -> Tensor:
+    """Compute signed torsion-angle loss between predicted and target poses.
+
+    This captures the 3D bending plane of arms and legs. Angle differences are
+    wrapped into ``[-pi, pi]`` before applying smooth-L1.
+
+    Args:
+        pred_pose: Predicted joints, shape ``(..., J, 3)``.
+        target_pose: Target joints, shape ``(..., J, 3)``.
+        quadruplets: Torsion quadruplets.
+        reduction: ``'mean'``, ``'sum'``, or ``'none'``.
+
+    Returns:
+        Tensor: Torsion-angle loss. If ``reduction='none'``, returns per-frame
+        loss with shape ``(...)``.
+
+    """
+    pred_angles = compute_torsion_angles(pred_pose, quadruplets)
+    target_angles = compute_torsion_angles(target_pose, quadruplets)
+    diff = _wrapped_angle_diff(pred_angles, target_angles)
+
+    per_angle = nn.functional.smooth_l1_loss(
+        diff,
+        torch.zeros_like(diff),
+        reduction="none",
+    )
+
+    if reduction == "mean":
+        return per_angle.mean()
+    if reduction == "sum":
+        return per_angle.sum()
+    return per_angle.mean(dim=-1)
+
+
+def torso_twist_loss(
+    pred_pose: Tensor,
+    target_pose: Tensor,
+    *,
+    reduction: str = "mean",
+) -> Tensor:
+    """Compute shoulder-hip torso twist loss.
+
+    Measures the signed angle from the hip axis to the shoulder axis around
+    the torso axis. This captures upper/lower-body twist in 3D.
+
+    Args:
+        pred_pose: Predicted joints, shape ``(..., 17, 3)``.
+        target_pose: Target joints, shape ``(..., 17, 3)``.
+        reduction: ``'mean'``, ``'sum'``, or ``'none'``.
+
+    Returns:
+        Tensor: Torso twist loss. If ``reduction='none'``, returns per-frame
+        loss with shape ``(...)``.
+
+    """
+    pred_twist = compute_torso_twist(pred_pose)
+    target_twist = compute_torso_twist(target_pose)
+    diff = _wrapped_angle_diff(pred_twist, target_twist)
+
+    per_frame = nn.functional.smooth_l1_loss(
+        diff,
+        torch.zeros_like(diff),
+        reduction="none",
+    )
+
+    if reduction == "mean":
+        return per_frame.mean()
+    if reduction == "sum":
+        return per_frame.sum()
+    return per_frame
+
+
+def bone_length_loss(
+    pred_pose: Tensor,
+    target_pose: Tensor,
+    edges: tuple[tuple[int, int], ...] = BONE_LENGTH_EDGES,
+    *,
+    relative: bool = True,
+    reduction: str = "mean",
+    eps: float = 1e-8,
+) -> Tensor:
+    """Compute bone-length consistency loss.
+
+    By default this uses relative bone-length error:
+
+    ``(pred_length - target_length) / target_length``
+
+    so the loss is dimensionless and does not over-emphasize long bones.
+
+    Args:
+        pred_pose: Predicted joints, shape ``(..., J, 3)``.
+        target_pose: Target joints, shape ``(..., J, 3)``.
+        edges: Bone edges.
+        relative: Whether to use relative length error.
+        reduction: ``'mean'``, ``'sum'``, or ``'none'``.
+        eps: Numerical stability epsilon.
+
+    Returns:
+        Tensor: Bone-length loss. If ``reduction='none'``, returns per-frame
+        loss with shape ``(...)``.
+
+    """
+    pred_lengths = compute_bone_lengths(pred_pose, edges, eps=eps)
+    target_lengths = compute_bone_lengths(target_pose, edges, eps=eps)
+
+    if relative:
+        diff = (pred_lengths - target_lengths) / target_lengths.clamp_min(eps)
+        per_bone = nn.functional.smooth_l1_loss(
+            diff,
+            torch.zeros_like(diff),
+            reduction="none",
+        )
+    else:
+        per_bone = nn.functional.smooth_l1_loss(
+            pred_lengths,
+            target_lengths,
+            reduction="none",
+        )
+
+    if reduction == "mean":
+        return per_bone.mean()
+    if reduction == "sum":
+        return per_bone.sum()
+    return per_bone.mean(dim=-1)
+
+
+# ---------------------------------------------------------------------------
+# PLCS loss registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PLCSLossInputs:
+    """Bundle of tensors shared across PLCS loss terms.
+
+    Attributes:
+        pred_position: Predicted position, ``(B, 3)`` or ``(B, T, 3)``.
+        pred_rotation: Predicted ``(cos, sin)``, ``(B, 2)`` or ``(B, T, 2)``.
+        target_position: Target position, same shape as ``pred_position``.
+        target_rotation: Target ``(cos, sin)``, same shape as ``pred_rotation``.
+        frame_mask: Optional per-frame validity mask for padded sequences.
+        pred_canonical_pose: Predicted canonical joints, ``(..., J, 3)``.
+        target_canonical_pose: Target canonical joints, ``(..., J, 3)``.
+
+    """
+
+    pred_position: Tensor
+    pred_rotation: Tensor
+    target_position: Tensor
+    target_rotation: Tensor
+    frame_mask: Tensor | None = None
+    pred_canonical_pose: Tensor | None = None
+    target_canonical_pose: Tensor | None = None
+
+    @property
+    def zero(self) -> Tensor:
+        """Scalar zero on the same device/dtype as the predictions."""
+        return self.pred_position.new_zeros(())
+
+    @property
+    def has_canonical(self) -> bool:
+        """Whether both predicted and target canonical poses are available."""
+        return (
+            self.pred_canonical_pose is not None
+            and self.target_canonical_pose is not None
+        )
+
+
+def _masked_frame_mean(per_frame: Tensor, frame_mask: Tensor | None) -> Tensor:
+    """Reduce per-frame losses, honoring the padding mask when shapes match."""
+    if frame_mask is not None and per_frame.shape == frame_mask.shape:
+        return masked_mean(per_frame, frame_mask, binarize=True, denom_min=1.0)
+    return per_frame.mean()
+
+
+def position_loss_term(inputs: PLCSLossInputs) -> Tensor:
+    """Position term: masked smooth-L1 between predicted and target positions."""
+    per_frame = nn.functional.smooth_l1_loss(
+        inputs.pred_position,
+        inputs.target_position,
+        reduction="none",
+    ).mean(dim=-1)
+    return _masked_frame_mean(per_frame, inputs.frame_mask)
+
+
+def rotation_loss_term(inputs: PLCSLossInputs) -> Tensor:
+    """Rotation term: masked ``1 - cosine similarity`` on ``(cos, sin)``."""
+    pred_norm = nn.functional.normalize(inputs.pred_rotation, dim=-1)
+    target_norm = nn.functional.normalize(inputs.target_rotation, dim=-1)
+    per_frame = 1.0 - (pred_norm * target_norm).sum(dim=-1)
+    return _masked_frame_mean(per_frame, inputs.frame_mask)
+
+
+def canonical_pose_loss_term(inputs: PLCSLossInputs) -> Tensor:
+    """Canonical-pose term: masked smooth-L1 between canonical joint positions."""
+    if not inputs.has_canonical:
+        return inputs.zero
+
+    per_frame = nn.functional.smooth_l1_loss(
+        inputs.pred_canonical_pose,
+        inputs.target_canonical_pose,
+        reduction="none",
+    ).mean(dim=(-1, -2))
+    return _masked_frame_mean(per_frame, inputs.frame_mask)
+
+
+def joint_angle_loss_term(inputs: PLCSLossInputs) -> Tensor:
+    """Joint-angle term on canonical joints.
+
+    Includes both articulated limb angles and torso quadrilateral angles.
+    """
+    if not inputs.has_canonical:
+        return inputs.zero
+
+    per_frame = joint_angle_loss(
+        inputs.pred_canonical_pose,
+        inputs.target_canonical_pose,
+        reduction="none",
+    )
+    return _masked_frame_mean(per_frame, inputs.frame_mask)
+
+
+def torsion_angle_loss_term(inputs: PLCSLossInputs) -> Tensor:
+    """Limb torsion term on canonical joints.
+
+    Captures whether arms/legs bend in the correct 3D plane.
+    """
+    if not inputs.has_canonical:
+        return inputs.zero
+
+    per_frame = torsion_angle_loss(
+        inputs.pred_canonical_pose,
+        inputs.target_canonical_pose,
+        reduction="none",
+    )
+    return _masked_frame_mean(per_frame, inputs.frame_mask)
+
+
+def torso_twist_loss_term(inputs: PLCSLossInputs) -> Tensor:
+    """Torso twist term on canonical joints.
+
+    Captures shoulder-line vs hip-line twist around the torso axis.
+    """
+    if not inputs.has_canonical:
+        return inputs.zero
+
+    per_frame = torso_twist_loss(
+        inputs.pred_canonical_pose,
+        inputs.target_canonical_pose,
+        reduction="none",
+    )
+    return _masked_frame_mean(per_frame, inputs.frame_mask)
+
+
+def bone_length_loss_term(inputs: PLCSLossInputs) -> Tensor:
+    """Bone-length consistency term on canonical joints."""
+    if not inputs.has_canonical:
+        return inputs.zero
+
+    per_frame = bone_length_loss(
+        inputs.pred_canonical_pose,
+        inputs.target_canonical_pose,
+        reduction="none",
+    )
+    return _masked_frame_mean(per_frame, inputs.frame_mask)
+
+
+# Type of a single loss term: maps shared inputs to a scalar loss tensor.
+PLCSLossTerm = Callable[[PLCSLossInputs], Tensor]
+
+
+# Default registry of loss terms keyed by output name.
+# forward() iterates this mapping, so adding a term is a matter of:
+#   1. defining a function
+#   2. registering it here
+#   3. adding ``<name>_weight`` to PLCSLossConfig
+DEFAULT_LOSS_TERMS: dict[str, PLCSLossTerm] = {
+    "position": position_loss_term,
+    "rotation": rotation_loss_term,
+    "canonical_pose": canonical_pose_loss_term,
+    "joint_angle": joint_angle_loss_term,
+    "torsion_angle": torsion_angle_loss_term,
+    "torso_twist": torso_twist_loss_term,
+    "bone_length": bone_length_loss_term,
+}
 
 
 class PLCSLoss(nn.Module):
     """Combined loss for PLCS training.
 
-    Combines position and rotation losses.
-    Supports both frame-level (B, 3) and sequence-level (B, T, 3) inputs.
+    Each loss term is an independent function with the uniform signature
+    ``(PLCSLossInputs) -> Tensor``. The module holds a ``{name: function}``
+    registry and ``forward`` builds the shared :class:`PLCSLossInputs`, calls
+    each term, and accumulates the weight-scaled sum.
+
+    Supports both frame-level and sequence-level inputs:
+        - Frame-level: ``(B, 3)``, ``(B, 2)``
+        - Sequence-level: ``(B, T, 3)``, ``(B, T, 2)``
+
     Temporal consistency is enforced by the GAN discriminator.
     """
 
@@ -130,14 +691,15 @@ class PLCSLoss(nn.Module):
         *,
         position_weight: float = 1.0,
         rotation_weight: float = 1.0,
+        loss_terms: dict[str, PLCSLossTerm] | None = None,
     ) -> None:
         """Initialize the loss module.
 
         Args:
-            config: Loss configuration (preferred). If provided, overrides
-                position_weight and rotation_weight.
-            position_weight: Weight for position loss (legacy parameter).
-            rotation_weight: Weight for rotation loss (legacy parameter).
+            config: Loss configuration. If provided, overrides legacy weights.
+            position_weight: Legacy position-loss weight.
+            rotation_weight: Legacy rotation-loss weight.
+            loss_terms: Optional custom loss registry.
 
         """
         super().__init__()
@@ -148,6 +710,69 @@ class PLCSLoss(nn.Module):
                 position_weight=position_weight,
                 rotation_weight=rotation_weight,
             )
+
+        self.loss_terms: dict[str, PLCSLossTerm] = (
+            dict(DEFAULT_LOSS_TERMS) if loss_terms is None else dict(loss_terms)
+        )
+
+    def weight_for(self, name: str) -> float:
+        """Return the configured weight for a loss term, or 0.0 if unset."""
+        return float(getattr(self.config, f"{name}_weight", 0.0))
+
+    def _requires_canonical_pose(self) -> bool:
+        """Whether any enabled registered term needs canonical pose tensors."""
+        return any(
+            name in self.loss_terms and self.weight_for(name) > 0.0
+            for name in CANONICAL_DEPENDENT_TERM_NAMES
+        )
+
+    def _build_inputs(
+        self,
+        pred_position: Tensor,
+        pred_rotation: Tensor,
+        target_position: Tensor,
+        target_rotation: Tensor,
+        *,
+        pred_canonical_pose: Tensor | None,
+        target_human_kp_3d: Tensor | None,
+        human_mask: Tensor | None,
+    ) -> PLCSLossInputs:
+        """Build shared loss inputs and target canonical pose."""
+        frame_mask = normalize_padding_mask(human_mask, flatten=False)
+
+        canonical_required = self._requires_canonical_pose()
+        if canonical_required and pred_canonical_pose is None:
+            raise ValueError(
+                "pred_canonical_pose is required when any canonical-dependent "
+                "loss weight is > 0. Enabled canonical-dependent terms include: "
+                f"{CANONICAL_DEPENDENT_TERM_NAMES}."
+            )
+
+        target_canonical_pose: Tensor | None = None
+        if pred_canonical_pose is not None:
+            if target_human_kp_3d is None:
+                if canonical_required:
+                    raise ValueError(
+                        "target_human_kp_3d is required when any "
+                        "canonical-dependent loss weight is > 0 and "
+                        "pred_canonical_pose is provided."
+                    )
+            else:
+                target_canonical_pose = world_pose_to_canonical_pose(
+                    target_human_kp_3d,
+                    target_position,
+                    target_rotation,
+                )
+
+        return PLCSLossInputs(
+            pred_position=pred_position,
+            pred_rotation=pred_rotation,
+            target_position=target_position,
+            target_rotation=target_rotation,
+            frame_mask=frame_mask,
+            pred_canonical_pose=pred_canonical_pose,
+            target_canonical_pose=target_canonical_pose,
+        )
 
     def forward(
         self,
@@ -160,74 +785,38 @@ class PLCSLoss(nn.Module):
         target_human_kp_3d: Tensor | None = None,
         human_mask: Tensor | None = None,
     ) -> dict[str, Tensor]:
-        """Compute combined loss.
-
-        Supports both frame-level and sequence-level inputs:
-            - Frame-level: (B, 3), (B, 2)
-            - Sequence-level: (B, T, 3), (B, T, 2)
+        """Compute combined loss by dispatching to each registered term.
 
         Args:
-            pred_position: Predicted position.
-            pred_rotation: Predicted rotation.
+            pred_position: Predicted position, ``(B, 3)`` or ``(B, T, 3)``.
+            pred_rotation: Predicted ``(cos, sin)``, ``(B, 2)`` or ``(B, T, 2)``.
             target_position: Target position.
-            target_rotation: Target rotation.
+            target_rotation: Target ``(cos, sin)``.
+            pred_canonical_pose: Predicted canonical joints, ``(..., J, 3)``.
+            target_human_kp_3d: Target world/court-space 3D human joints.
+            human_mask: Optional validity mask.
 
         Returns:
-            dict: Dictionary with 'total', 'position', 'rotation', 'canonical_pose'.
+            dict: One entry per registered term plus ``"total"``.
 
         """
-        zero = pred_position.new_zeros(())
-        frame_mask = normalize_padding_mask(human_mask, flatten=False)
-
-        # Position loss (optionally mask padded frames)
-        if pred_position.dim() == 3 and frame_mask is not None:
-            per_elem = nn.functional.smooth_l1_loss(
-                pred_position, target_position, reduction="none"
-            ).mean(dim=-1)  # (B, T)
-            pos_loss = masked_mean(per_elem, frame_mask, binarize=True, denom_min=1.0)
-        else:
-            pos_loss = position_loss(pred_position, target_position)
-
-        # Rotation loss (optionally mask padded frames)
-        if pred_rotation.dim() == 3 and frame_mask is not None:
-            pred_norm = nn.functional.normalize(pred_rotation, dim=-1)
-            cos_sim = (pred_norm * target_rotation).sum(dim=-1)  # (B, T)
-            per_frame = 1.0 - cos_sim
-            rot_loss = masked_mean(per_frame, frame_mask, binarize=True, denom_min=1.0)
-        else:
-            rot_loss = rotation_loss(pred_rotation, target_rotation)
-
-        total = (
-            self.config.position_weight * pos_loss
-            + self.config.rotation_weight * rot_loss
+        inputs = self._build_inputs(
+            pred_position,
+            pred_rotation,
+            target_position,
+            target_rotation,
+            pred_canonical_pose=pred_canonical_pose,
+            target_human_kp_3d=target_human_kp_3d,
+            human_mask=human_mask,
         )
-        canonical_pose_loss = zero
 
-        if pred_canonical_pose is not None and target_human_kp_3d is not None:
-            target_canonical_pose = world_pose_to_canonical_pose(
-                target_human_kp_3d,
-                target_position,
-                target_rotation,
-            )
-            per_frame = nn.functional.smooth_l1_loss(
-                pred_canonical_pose,
-                target_canonical_pose,
-                reduction="none",
-            ).mean(dim=(-1, -2))
-            if frame_mask is not None and per_frame.shape == frame_mask.shape:
-                canonical_pose_loss = masked_mean(per_frame, frame_mask, binarize=True, denom_min=1.0)
-            else:
-                canonical_pose_loss = per_frame.mean()
-            total = total + self.config.canonical_pose_weight * canonical_pose_loss
-        elif pred_canonical_pose is not None and self.config.canonical_pose_weight > 0.0:
-            raise ValueError(
-                "target_human_kp_3d is required when canonical_pose_weight > 0 and "
-                "pred_canonical_pose is provided."
-            )
+        losses: dict[str, Tensor] = {}
+        total = inputs.zero
 
-        return {
-            "total": total,
-            "position": pos_loss,
-            "rotation": rot_loss,
-            "canonical_pose": canonical_pose_loss,
-        }
+        for name, term_fn in self.loss_terms.items():
+            value = term_fn(inputs)
+            losses[name] = value
+            total = total + self.weight_for(name) * value
+
+        losses["total"] = total
+        return losses

--- a/src/utils/schema/player.py
+++ b/src/utils/schema/player.py
@@ -63,6 +63,62 @@ COCO17_SKELETON: list[tuple[int, int]] = [
 ]
 
 # -----------------------------
+# COCO-17 pose-naturalness groupings
+# -----------------------------
+# These index groupings describe geometric relationships between COCO-17 joints
+# used to evaluate how anatomically natural a pose is (e.g. PLCS naturalness
+# losses/metrics). They are kept here so they can be reused across tasks.
+
+# Articulated joints expressed as ``(a, vertex, c)`` triplets. The joint angle
+# is the interior angle at ``vertex`` between bones ``vertex -> a`` and
+# ``vertex -> c``. Includes 8 limb angles + 4 torso quadrilateral angles.
+COCO17_JOINT_ANGLE_TRIPLETS: tuple[tuple[int, int, int], ...] = (
+    (5, 7, 9),  # left elbow: shoulder - elbow - wrist
+    (6, 8, 10),  # right elbow: shoulder - elbow - wrist
+    (11, 13, 15),  # left knee: hip - knee - ankle
+    (12, 14, 16),  # right knee: hip - knee - ankle
+    (7, 5, 11),  # left shoulder: elbow - shoulder - hip
+    (8, 6, 12),  # right shoulder: elbow - shoulder - hip
+    (5, 11, 13),  # left hip: shoulder - hip - knee
+    (6, 12, 14),  # right hip: shoulder - hip - knee
+    (6, 5, 11),  # left shoulder torso angle: right_shoulder - left_shoulder - left_hip
+    (5, 6, 12),  # right shoulder torso angle: left_shoulder - right_shoulder - right_hip
+    (6, 12, 11),  # right hip torso angle: right_shoulder - right_hip - left_hip
+    (5, 11, 12),  # left hip torso angle: left_shoulder - left_hip - right_hip
+)
+
+# 4-point torsion / dihedral angles. For ``(a, b, c, d)`` the torsion is the
+# signed angle between plane ``(a, b, c)`` and plane ``(b, c, d)``, capturing
+# how a limb bends in 3D, not just how much.
+COCO17_TORSION_QUADRUPLETS: tuple[tuple[int, int, int, int], ...] = (
+    (6, 5, 7, 9),  # left arm: opposite shoulder - shoulder - elbow - wrist
+    (5, 6, 8, 10),  # right arm: opposite shoulder - shoulder - elbow - wrist
+    (12, 11, 13, 15),  # left leg: opposite hip - hip - knee - ankle
+    (11, 12, 14, 16),  # right leg: opposite hip - hip - knee - ankle
+)
+
+# Torso twist joints: ``(left_shoulder, right_shoulder, left_hip, right_hip)``.
+# Used to compare the shoulder axis and hip axis twist around the torso axis.
+COCO17_TORSO_TWIST_JOINTS: tuple[int, int, int, int] = (5, 6, 11, 12)
+
+# Body bones used for bone-length consistency. Face edges are intentionally
+# excluded because they are noisy in sports videos.
+COCO17_BONE_LENGTH_EDGES: tuple[tuple[int, int], ...] = (
+    (5, 6),  # shoulder width
+    (11, 12),  # hip width
+    (5, 11),  # left torso side
+    (6, 12),  # right torso side
+    (5, 7),  # left upper arm
+    (7, 9),  # left lower arm
+    (6, 8),  # right upper arm
+    (8, 10),  # right lower arm
+    (11, 13),  # left upper leg
+    (13, 15),  # left lower leg
+    (12, 14),  # right upper leg
+    (14, 16),  # right lower leg
+)
+
+# -----------------------------
 # SMPL-H Joint Definitions
 # -----------------------------
 


### PR DESCRIPTION
## 概要

PLCS の損失体系に **姿勢の自然さ（pose-naturalness）損失** を 4 種追加し、`PLCSLoss` の `{name: 関数}` レジストリに統合しました。あわせて、どの損失が支配的かを `test.txt` で解析するスクリプトを Hydra 化し、損失コンフィグの整理（dead な `temporal:` 削除）を行いました。

## 変更点

### 1. 姿勢の自然さ損失（`canonical_pose` 上で計算）
すべて weight ゲート付き・デフォルト無効（`weight: 0.0`）。`PLCSLoss.forward` はレジストリを反復するだけなので、関数追加 + `<name>_weight` 追加で自動的に有効化できます。

| term | 内容 |
|---|---|
| `joint_angle` | 関節の内角（肘・膝・肩・股 8 + 体幹四角形 4 = 12 角）の差 |
| `torsion_angle` | 四肢の 3D 二面角（曲げる「向き」）の符号付き差 |
| `torso_twist` | 肩ライン vs 腰ラインの体幹軸まわりのねじれ角の差 |
| `bone_length` | ボーン長の整合性（相対誤差） |

### 2. スキーマの共通化
COCO-17 のインデックス・グルーピング（`JOINT_ANGLE_TRIPLETS` / `TORSION_QUADRUPLETS` / `TORSO_TWIST_JOINTS` / `BONE_LENGTH_EDGES`）を `src/utils/schema/player.py` に `COCO17_*` として定義し、`losses.py` からインポート。タスク横断で再利用可能にしました。

### 3. 解析スクリプトの刷新（`analyze_loss_dominance.py`）
- すべてを `PLCSLoss` 経由で計算し、登録された全 term の raw / weighted / share を表示（ハードコード排除）。
- リポジトリの script 規約に準拠（Hydra 化、argparse 廃止、`configs/analyze_loss_dominance.yaml`）。

### 4. コンフィグ整理
`configs/loss/{frame,sequence,multiview_sequence}.yaml` から削除済み temporal 損失の dead な `temporal:` ブロックを除去し、新しい naturalness weight（デフォルト 0.0）を追加。

## 解析結果（`data/plcs/test.txt`・全 100 シーン）

`issue_430_multiview_axial_canonical_train` の `last.ckpt` を、その `hparams.yaml`（`position/rotation/canonical_pose` の weight=1.0、naturalness は weight=0.0）で評価:

| term | raw | weight | weighted | share |
|---|---|---|---|---|
| position | 0.00376 | 1.0 | 0.00376 | 0.7% |
| **rotation** | **0.49346** | 1.0 | **0.49346** | **97.9%** |
| canonical_pose | 0.00696 | 1.0 | 0.00696 | 1.4% |
| joint_angle | 0.06861 | 0.0 | 0.0 | 0.0% |
| torsion_angle | 0.08562 | 0.0 | 0.0 | 0.0% |
| torso_twist | 0.03079 | 0.0 | 0.0 | 0.0% |
| bone_length | 0.01111 | 0.0 | 0.0 | 0.0% |

参考メトリクス: `position_error=0.61m`, `angular_error=49.6°`, `pos_acc@0.5m=0.49`, `ang_acc@15°=0.45`

**所見:**
- **`rotation` が損失の 97.9% を占め支配的**。weight は全項 1.0 だが、`rotation`（`1 - cos`、0〜2 スケール）の生値が `position`/`canonical_pose`（正規化座標の smooth-L1、生値 ~0.003〜0.007）より桁違いに大きいため。`angular_error=49.6°` という低精度とも整合。
- 各項を均等に効かせるには、生スケールに合わせた重み付け（`rotation` を下げる or 他を上げる）が必要。
- naturalness 損失の生値の相対序列は `torsion_angle (0.086) > joint_angle (0.069) > torso_twist (0.031) > bone_length (0.011)`。導入時の初期 weight 設計の目安になります（`bone_length` は既に小さい＝骨格長はよく保たれている）。

## 検証
- ruff / mypy（`--follow-imports=skip`）/ script-reviewer フック通過。
- PLCS 学習スモークテスト 13 passed。
- リファクタ前後の `PLCSLoss` 数値等価性は別途確認済み（既存 3 項）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
