### PR TITLE
feat(skills): 承認なしで完遂する自律ヘッドレス実行スキル claude-auto を追加

### DIFF
--- a/.agents/skills/claude-auto/SKILL.md
+++ b/.agents/skills/claude-auto/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: claude-auto
+description: Use this skill when running Claude Code itself non-interactively (headless `claude -p`) to carry a task through to completion without approval prompts. Covers the verified flags, the wrapper scripts under scripts/, success detection, and the safety rails for unattended runs.
+---
+
+# Autonomous Claude Code (no-approval, run-to-completion)
+
+## Scope
+
+Use this skill when you want Claude Code to **run a task end-to-end without
+stopping for permission prompts** — CI jobs, cron jobs, batch refactors, or an
+unattended "fix it until it's done" run. It documents the headless `claude -p`
+workflow and ships two wrapper scripts that add budget caps, logging, and a
+machine-checkable result.
+
+This is for invoking the `claude` CLI from a shell. It is **not** about the
+interactive `/`-skills inside a session.
+
+Verified against **Claude Code 2.1.185**.
+
+## The core command
+
+A single `claude -p` call already runs the **full agent loop to completion** —
+it keeps acting until the task is done, then prints the final result and exits.
+To make it run without any approval prompts:
+
+```bash
+claude -p "Run the test suite and fix any failures" \
+  --permission-mode bypassPermissions \
+  --max-budget-usd 2.00 \
+  --output-format json
+```
+
+`--permission-mode bypassPermissions` and `--dangerously-skip-permissions` are
+equivalent — both skip every approval. There is **no `--max-turns` flag** in
+2.1.185 (it appears in older docs / the SDK only); bound the run with
+`--max-budget-usd` instead.
+
+## Key flags
+
+| Flag | Purpose |
+| --- | --- |
+| `-p, --print` | Headless mode; runs the agent loop and exits. Required for all of the below. |
+| `--permission-mode bypassPermissions` | No approval prompts at all (full autonomy). |
+| `--dangerously-skip-permissions` | Same effect; the explicit "I know" form. |
+| `--permission-mode dontAsk` | Denies anything **not** in `--allowedTools` / `permissions.allow` (locked-down CI). |
+| `--permission-mode acceptEdits` | Auto-approves file writes + common fs commands; other shell/network still need an allow rule. |
+| `--max-budget-usd N` | Hard spend cap. The real stop-condition for unattended runs. |
+| `--allowedTools "Bash(git *),Read,Edit"` | Scope tools (space before `*` matters: `Bash(git diff *)` ≠ `Bash(git diff*)`). |
+| `--output-format json` | One JSON object with `result`, `is_error`, `total_cost_usd`, `num_turns`, `session_id`. |
+| `--output-format stream-json` `--verbose` | Live newline-delimited events; last `type:result` line is the outcome. |
+| `--model opus\|sonnet\|haiku` | Pick the model. |
+| `--resume <session_id>` | Continue a prior headless session (drives the loop wrapper). |
+
+## Detecting success — do NOT trust the exit code
+
+`claude` exits **0 even when the run failed** (`is_error:true`). Always read the
+JSON `is_error` field:
+
+```bash
+out=$(claude -p "…" --permission-mode bypassPermissions --output-format json)
+echo "$out" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(1 if d["is_error"] else 0)'
+```
+
+The wrapper scripts do exactly this and re-derive a correct exit code (0 ok, 1 failed).
+
+## Wrapper scripts (reproducibility)
+
+Both live in `scripts/` next to this file, are dependency-free (bash + python3),
+and write a timestamped run log under `logs/claude-auto/` (gitignored).
+
+### `claude-auto.sh` — one autonomous run
+
+```bash
+# simplest: hand it a task, it runs to completion with a $2 cap and bypass mode
+.agents/skills/claude-auto/scripts/claude-auto.sh "Run the test suite and fix any failures"
+
+# scoped + cheaper: locked-down tools, smaller budget, a named run, live output
+.agents/skills/claude-auto/scripts/claude-auto.sh \
+  -m dontAsk -a "Read,Bash(pytest *)" -b 0.50 --model sonnet --stream \
+  --name fix-flaky "Investigate and fix the flaky test in tests/test_foo.py"
+
+# from a prompt file, against another directory; dry-run prints the command only
+.agents/skills/claude-auto/scripts/claude-auto.sh -f task.md -d /path/to/repo --dry-run
+```
+
+Each run dir holds `prompt.txt`, `command.txt`, `output.json` (or `stream.jsonl`),
+`result.txt`, and `summary.txt`. Exit code is 0 only when `is_error=false`.
+
+### `claude-auto-loop.sh` — keep going until truly done
+
+A single `-p` call can stop early on a very large task. This wrapper resumes the
+same session and re-prompts it to continue until it prints a completion
+**sentinel**, bounded by `--max-iters` and a **cumulative** budget.
+
+```bash
+.agents/skills/claude-auto/scripts/claude-auto-loop.sh \
+  -i 8 -b 5.00 -m bypassPermissions \
+  "Migrate every call site off the deprecated api(); run the tests after each batch."
+```
+
+Exit 0 only when the sentinel (`TASK_COMPLETE` by default) is observed; exit 1 on
+the iteration/budget cap or a turn error.
+
+## Safety rails (read before unattended use)
+
+Bypassing permissions removes every guardrail, so constrain the blast radius:
+
+- **Prefer the least-privileged mode that works.** `dontAsk` + an explicit
+  `--allowedTools` allowlist is far safer than full `bypassPermissions`; reserve
+  bypass for sandboxes / disposable environments.
+- **Always set `--max-budget-usd`.** It is the only hard stop on a runaway loop.
+- **Run in a sandbox or throwaway worktree** with no production credentials and,
+  ideally, no outbound internet — Anthropic's own guidance recommends bypass mode
+  "only for sandboxes with no internet access."
+- **Scope the working directory** with `-d` so the run can't wander out of the repo.
+- For a middle ground between manual review and full bypass, consider Claude
+  Code's **auto mode** (`--permission-mode auto`); inspect its allow/deny rules
+  with `claude auto-mode defaults`.
+
+## Auth & environment notes
+
+- These scripts use your normal (OAuth / subscription) login. **Do not add
+  `--bare`** unless you provide `ANTHROPIC_API_KEY` — bare mode skips OAuth and
+  keychain and will fail with `Not logged in`.
+- In a git **worktree** there is usually no local `.venv`; the scripts fall back
+  to `python3` automatically (they try `.venv/bin/python` first).
+- `--bare` is otherwise recommended for CI for reproducible context, but only with
+  an API key.
+
+## Sources
+
+- Run Claude Code programmatically (headless): https://code.claude.com/docs/en/headless
+- How we built Claude Code auto mode: https://www.anthropic.com/engineering/claude-code-auto-mode
+- Verified locally with `claude --help` and live `claude -p` runs on v2.1.185.

--- a/.agents/skills/claude-auto/SKILL.md
+++ b/.agents/skills/claude-auto/SKILL.md
@@ -10,8 +10,8 @@ description: Use this skill when running Claude Code itself non-interactively (h
 Use this skill when you want Claude Code to **run a task end-to-end without
 stopping for permission prompts** — CI jobs, cron jobs, batch refactors, or an
 unattended "fix it until it's done" run. It documents the headless `claude -p`
-workflow and ships two wrapper scripts that add budget caps, logging, and a
-machine-checkable result.
+workflow and ships two wrapper scripts that add logging and a machine-checkable
+result.
 
 This is for invoking the `claude` CLI from a shell. It is **not** about the
 interactive `/`-skills inside a session.
@@ -27,14 +27,11 @@ To make it run without any approval prompts:
 ```bash
 claude -p "Run the test suite and fix any failures" \
   --permission-mode bypassPermissions \
-  --max-budget-usd 2.00 \
   --output-format json
 ```
 
 `--permission-mode bypassPermissions` and `--dangerously-skip-permissions` are
-equivalent — both skip every approval. There is **no `--max-turns` flag** in
-2.1.185 (it appears in older docs / the SDK only); bound the run with
-`--max-budget-usd` instead.
+equivalent — both skip every approval.
 
 ## Key flags
 
@@ -45,9 +42,8 @@ equivalent — both skip every approval. There is **no `--max-turns` flag** in
 | `--dangerously-skip-permissions` | Same effect; the explicit "I know" form. |
 | `--permission-mode dontAsk` | Denies anything **not** in `--allowedTools` / `permissions.allow` (locked-down CI). |
 | `--permission-mode acceptEdits` | Auto-approves file writes + common fs commands; other shell/network still need an allow rule. |
-| `--max-budget-usd N` | Hard spend cap. The real stop-condition for unattended runs. |
 | `--allowedTools "Bash(git *),Read,Edit"` | Scope tools (space before `*` matters: `Bash(git diff *)` ≠ `Bash(git diff*)`). |
-| `--output-format json` | One JSON object with `result`, `is_error`, `total_cost_usd`, `num_turns`, `session_id`. |
+| `--output-format json` | One JSON object with `result`, `is_error`, `num_turns`, `session_id`. |
 | `--output-format stream-json` `--verbose` | Live newline-delimited events; last `type:result` line is the outcome. |
 | `--model opus\|sonnet\|haiku` | Pick the model. |
 | `--resume <session_id>` | Continue a prior headless session (drives the loop wrapper). |
@@ -72,12 +68,12 @@ and write a timestamped run log under `logs/claude-auto/` (gitignored).
 ### `claude-auto.sh` — one autonomous run
 
 ```bash
-# simplest: hand it a task, it runs to completion with a $2 cap and bypass mode
+# simplest: hand it a task, it runs to completion with bypass mode
 .agents/skills/claude-auto/scripts/claude-auto.sh "Run the test suite and fix any failures"
 
-# scoped + cheaper: locked-down tools, smaller budget, a named run, live output
+# scoped + locked-down: restricted tools, a named run, live output
 .agents/skills/claude-auto/scripts/claude-auto.sh \
-  -m dontAsk -a "Read,Bash(pytest *)" -b 0.50 --model sonnet --stream \
+  -m dontAsk -a "Read,Bash(pytest *)" --model sonnet --stream \
   --name fix-flaky "Investigate and fix the flaky test in tests/test_foo.py"
 
 # from a prompt file, against another directory; dry-run prints the command only
@@ -91,16 +87,16 @@ Each run dir holds `prompt.txt`, `command.txt`, `output.json` (or `stream.jsonl`
 
 A single `-p` call can stop early on a very large task. This wrapper resumes the
 same session and re-prompts it to continue until it prints a completion
-**sentinel**, bounded by `--max-iters` and a **cumulative** budget.
+**sentinel**, bounded by `--max-iters`.
 
 ```bash
 .agents/skills/claude-auto/scripts/claude-auto-loop.sh \
-  -i 8 -b 5.00 -m bypassPermissions \
+  -i 8 -m bypassPermissions \
   "Migrate every call site off the deprecated api(); run the tests after each batch."
 ```
 
 Exit 0 only when the sentinel (`TASK_COMPLETE` by default) is observed; exit 1 on
-the iteration/budget cap or a turn error.
+the iteration cap or a turn error.
 
 ## Safety rails (read before unattended use)
 
@@ -109,7 +105,6 @@ Bypassing permissions removes every guardrail, so constrain the blast radius:
 - **Prefer the least-privileged mode that works.** `dontAsk` + an explicit
   `--allowedTools` allowlist is far safer than full `bypassPermissions`; reserve
   bypass for sandboxes / disposable environments.
-- **Always set `--max-budget-usd`.** It is the only hard stop on a runaway loop.
 - **Run in a sandbox or throwaway worktree** with no production credentials and,
   ideally, no outbound internet — Anthropic's own guidance recommends bypass mode
   "only for sandboxes with no internet access."

--- a/.agents/skills/claude-auto/scripts/claude-auto-loop.sh
+++ b/.agents/skills/claude-auto/scripts/claude-auto-loop.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# claude-auto-loop.sh — drive Claude Code autonomously across multiple turns
+# until the task is genuinely finished or a safety cap is hit.
+#
+# A single `claude -p` already runs the agent loop to completion, but a very
+# large task can stop early (context limits, an interim "what next?" finish, a
+# transient error). This wrapper resumes the same session and re-prompts it to
+# keep going until it emits a completion SENTINEL, bounded by --max-iters and a
+# cumulative --budget.
+#
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  claude-auto-loop.sh [options] "PROMPT"
+  claude-auto-loop.sh [options] -f PROMPT_FILE
+
+Run Claude Code autonomously, resuming until it signals completion.
+
+Options:
+  -f, --file FILE        Read the prompt from FILE.
+  -d, --dir DIR          Working directory (default: current dir).
+  -b, --budget USD       Cumulative spend cap across all turns (default: 5.00).
+  -i, --max-iters N      Max turns before giving up (default: 10).
+  -s, --sentinel STR     Completion marker Claude must print (default: TASK_COMPLETE).
+  -m, --mode MODE        Permission mode (default: bypassPermissions).
+  -a, --allow TOOLS      --allowedTools list.
+      --model MODEL      Model alias/name.
+  -l, --log-dir DIR      Base dir for run logs (default: logs/claude-auto).
+      --name NAME        Run slug (default: timestamp).
+  -h, --help             Show this help.
+
+Exit codes:
+  0  sentinel observed — task reported complete
+  1  iteration or budget cap hit without sentinel, or a turn errored
+  2  usage / setup error
+USAGE
+}
+
+die() { echo "[FAIL] $*" >&2; exit 2; }
+
+pick_python() {
+  if [[ -x ".venv/bin/python" ]]; then echo ".venv/bin/python";
+  elif command -v python3 >/dev/null 2>&1; then echo "python3";
+  elif command -v python  >/dev/null 2>&1; then echo "python";
+  else die "no python found for JSON parsing"; fi
+}
+
+json_field() {  # json_field FILE FIELD  (FILE is a single JSON result object)
+  "$PYTHON" - "$1" "$2" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    obj = json.load(fh)
+val = obj.get(sys.argv[2], "")
+print(val if not isinstance(val, bool) else str(val).lower())
+PY
+}
+
+# add A B  — print A+B as a 6-dp decimal without needing bc
+addf() { "$PYTHON" -c "import sys;print(f'{float(sys.argv[1])+float(sys.argv[2]):.6f}')" "$1" "$2"; }
+gtf()  { "$PYTHON" -c "import sys;sys.exit(0 if float(sys.argv[1])>float(sys.argv[2]) else 1)" "$1" "$2"; }
+
+# --- defaults ---
+PROMPT=""; PROMPT_FILE=""; WORKDIR="."; BUDGET="5.00"; MAX_ITERS=10
+SENTINEL="TASK_COMPLETE"; MODE="bypassPermissions"; ALLOW=""; MODEL=""
+LOG_BASE="logs/claude-auto"; RUN_NAME=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    -f|--file) PROMPT_FILE="${2:?}"; shift 2 ;;
+    -d|--dir) WORKDIR="${2:?}"; shift 2 ;;
+    -b|--budget) BUDGET="${2:?}"; shift 2 ;;
+    -i|--max-iters) MAX_ITERS="${2:?}"; shift 2 ;;
+    -s|--sentinel) SENTINEL="${2:?}"; shift 2 ;;
+    -m|--mode) MODE="${2:?}"; shift 2 ;;
+    -a|--allow) ALLOW="${2:?}"; shift 2 ;;
+    --model) MODEL="${2:?}"; shift 2 ;;
+    -l|--log-dir) LOG_BASE="${2:?}"; shift 2 ;;
+    --name) RUN_NAME="${2:?}"; shift 2 ;;
+    -*) die "unknown option: $1 (see --help)" ;;
+    *) PROMPT="$1"; shift ;;
+  esac
+done
+
+command -v claude >/dev/null 2>&1 || die "claude CLI not found on PATH"
+PYTHON="$(pick_python)"
+if [[ -n "$PROMPT_FILE" ]]; then
+  [[ -f "$PROMPT_FILE" ]] || die "prompt file not found: $PROMPT_FILE"
+  PROMPT="$(cat "$PROMPT_FILE")"
+fi
+[[ -n "${PROMPT// /}" ]] || { usage; die "no prompt provided"; }
+[[ -d "$WORKDIR" ]] || die "working dir not found: $WORKDIR"
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+if [[ -n "$RUN_NAME" ]]; then
+  SLUG="$(echo "$RUN_NAME" | tr -cs 'A-Za-z0-9._-' '-' | sed 's/-*$//' | cut -c1-48)"
+  RUN_DIR="${LOG_BASE%/}/${TS}-${SLUG}"
+else
+  RUN_DIR="${LOG_BASE%/}/${TS}-loop"
+fi
+mkdir -p "$RUN_DIR"
+printf '%s\n' "$PROMPT" > "$RUN_DIR/prompt.txt"
+
+# Instruction appended to every turn so Claude knows the completion protocol.
+PROTO="When the ENTIRE task is fully complete and verified, print this exact line on its own: ${SENTINEL}
+If it is not yet complete, keep working — do not print that line until everything is done."
+
+build_cmd() {  # build_cmd <resume_sid|"">  -> populates global CMD array
+  CMD=(claude -p "$TURN_PROMPT"
+    --permission-mode "$MODE"
+    --max-budget-usd "$BUDGET"
+    --output-format json)
+  [[ -n "$1" ]]     && CMD+=(--resume "$1")
+  [[ -n "$ALLOW" ]] && CMD+=(--allowedTools "$ALLOW")
+  [[ -n "$MODEL" ]] && CMD+=(--model "$MODEL")
+  return 0  # never let a false &&-test become the function's exit status (set -e)
+}
+
+echo "[loop] sentinel='$SENTINEL' max_iters=$MAX_ITERS budget=\$$BUDGET mode=$MODE"
+echo "[loop] log: $RUN_DIR"
+
+SID=""; SPENT="0"; STATUS="incomplete"
+for (( i=1; i<=MAX_ITERS; i++ )); do
+  if [[ $i -eq 1 ]]; then
+    TURN_PROMPT="${PROMPT}
+
+${PROTO}"
+  else
+    TURN_PROMPT="Continue the task. ${PROTO}"
+  fi
+  build_cmd "$SID"
+
+  OUT="$RUN_DIR/turn-$(printf '%02d' "$i").json"
+  echo "[loop] turn $i/$MAX_ITERS (spent so far: \$$SPENT)"
+  set +e
+  ( cd "$WORKDIR" && "${CMD[@]}" ) > "$OUT" 2>>"$RUN_DIR/stderr.log"
+  set -e
+
+  if ! IS_ERROR="$(json_field "$OUT" is_error 2>/dev/null)"; then
+    echo "[loop] turn $i produced no result object — aborting" >&2
+    break
+  fi
+  [[ -z "$SID" ]] && SID="$(json_field "$OUT" session_id)"
+  COST="$(json_field "$OUT" total_cost_usd)"; SPENT="$(addf "$SPENT" "$COST")"
+  RESULT="$(json_field "$OUT" result)"
+  echo "    is_error=$IS_ERROR turn_cost=\$$COST cumulative=\$$SPENT"
+
+  if [[ "$IS_ERROR" != "false" ]]; then
+    echo "[loop] turn $i errored: $RESULT" >&2
+    STATUS="errored"; break
+  fi
+  if printf '%s' "$RESULT" | grep -qF "$SENTINEL"; then
+    echo "[loop] sentinel observed on turn $i — task complete"
+    STATUS="complete"; break
+  fi
+  if gtf "$SPENT" "$BUDGET"; then
+    echo "[loop] cumulative budget exceeded (\$$SPENT > \$$BUDGET) — stopping" >&2
+    STATUS="budget"; break
+  fi
+done
+
+{
+  echo "status=$STATUS"
+  echo "session_id=$SID"
+  echo "total_spent_usd=$SPENT"
+  echo "iterations=$i"
+} > "$RUN_DIR/summary.txt"
+
+echo "[loop] status=$STATUS spent=\$$SPENT session=$SID"
+[[ "$STATUS" == "complete" ]] && exit 0 || exit 1

--- a/.agents/skills/claude-auto/scripts/claude-auto-loop.sh
+++ b/.agents/skills/claude-auto/scripts/claude-auto-loop.sh
@@ -6,8 +6,7 @@
 # A single `claude -p` already runs the agent loop to completion, but a very
 # large task can stop early (context limits, an interim "what next?" finish, a
 # transient error). This wrapper resumes the same session and re-prompts it to
-# keep going until it emits a completion SENTINEL, bounded by --max-iters and a
-# cumulative --budget.
+# keep going until it emits a completion SENTINEL, bounded by --max-iters.
 #
 set -euo pipefail
 
@@ -22,7 +21,6 @@ Run Claude Code autonomously, resuming until it signals completion.
 Options:
   -f, --file FILE        Read the prompt from FILE.
   -d, --dir DIR          Working directory (default: current dir).
-  -b, --budget USD       Cumulative spend cap across all turns (default: 5.00).
   -i, --max-iters N      Max turns before giving up (default: 10).
   -s, --sentinel STR     Completion marker Claude must print (default: TASK_COMPLETE).
   -m, --mode MODE        Permission mode (default: bypassPermissions).
@@ -34,7 +32,7 @@ Options:
 
 Exit codes:
   0  sentinel observed — task reported complete
-  1  iteration or budget cap hit without sentinel, or a turn errored
+  1  iteration cap hit without sentinel, or a turn errored
   2  usage / setup error
 USAGE
 }
@@ -58,12 +56,8 @@ print(val if not isinstance(val, bool) else str(val).lower())
 PY
 }
 
-# add A B  — print A+B as a 6-dp decimal without needing bc
-addf() { "$PYTHON" -c "import sys;print(f'{float(sys.argv[1])+float(sys.argv[2]):.6f}')" "$1" "$2"; }
-gtf()  { "$PYTHON" -c "import sys;sys.exit(0 if float(sys.argv[1])>float(sys.argv[2]) else 1)" "$1" "$2"; }
-
 # --- defaults ---
-PROMPT=""; PROMPT_FILE=""; WORKDIR="."; BUDGET="5.00"; MAX_ITERS=10
+PROMPT=""; PROMPT_FILE=""; WORKDIR="."; MAX_ITERS=10
 SENTINEL="TASK_COMPLETE"; MODE="bypassPermissions"; ALLOW=""; MODEL=""
 LOG_BASE="logs/claude-auto"; RUN_NAME=""
 
@@ -72,7 +66,6 @@ while [[ $# -gt 0 ]]; do
     -h|--help) usage; exit 0 ;;
     -f|--file) PROMPT_FILE="${2:?}"; shift 2 ;;
     -d|--dir) WORKDIR="${2:?}"; shift 2 ;;
-    -b|--budget) BUDGET="${2:?}"; shift 2 ;;
     -i|--max-iters) MAX_ITERS="${2:?}"; shift 2 ;;
     -s|--sentinel) SENTINEL="${2:?}"; shift 2 ;;
     -m|--mode) MODE="${2:?}"; shift 2 ;;
@@ -111,7 +104,6 @@ If it is not yet complete, keep working — do not print that line until everyth
 build_cmd() {  # build_cmd <resume_sid|"">  -> populates global CMD array
   CMD=(claude -p "$TURN_PROMPT"
     --permission-mode "$MODE"
-    --max-budget-usd "$BUDGET"
     --output-format json)
   [[ -n "$1" ]]     && CMD+=(--resume "$1")
   [[ -n "$ALLOW" ]] && CMD+=(--allowedTools "$ALLOW")
@@ -119,10 +111,10 @@ build_cmd() {  # build_cmd <resume_sid|"">  -> populates global CMD array
   return 0  # never let a false &&-test become the function's exit status (set -e)
 }
 
-echo "[loop] sentinel='$SENTINEL' max_iters=$MAX_ITERS budget=\$$BUDGET mode=$MODE"
+echo "[loop] sentinel='$SENTINEL' max_iters=$MAX_ITERS mode=$MODE"
 echo "[loop] log: $RUN_DIR"
 
-SID=""; SPENT="0"; STATUS="incomplete"
+SID=""; STATUS="incomplete"
 for (( i=1; i<=MAX_ITERS; i++ )); do
   if [[ $i -eq 1 ]]; then
     TURN_PROMPT="${PROMPT}
@@ -134,7 +126,7 @@ ${PROTO}"
   build_cmd "$SID"
 
   OUT="$RUN_DIR/turn-$(printf '%02d' "$i").json"
-  echo "[loop] turn $i/$MAX_ITERS (spent so far: \$$SPENT)"
+  echo "[loop] turn $i/$MAX_ITERS"
   set +e
   ( cd "$WORKDIR" && "${CMD[@]}" ) > "$OUT" 2>>"$RUN_DIR/stderr.log"
   set -e
@@ -144,9 +136,8 @@ ${PROTO}"
     break
   fi
   [[ -z "$SID" ]] && SID="$(json_field "$OUT" session_id)"
-  COST="$(json_field "$OUT" total_cost_usd)"; SPENT="$(addf "$SPENT" "$COST")"
   RESULT="$(json_field "$OUT" result)"
-  echo "    is_error=$IS_ERROR turn_cost=\$$COST cumulative=\$$SPENT"
+  echo "    is_error=$IS_ERROR"
 
   if [[ "$IS_ERROR" != "false" ]]; then
     echo "[loop] turn $i errored: $RESULT" >&2
@@ -156,18 +147,13 @@ ${PROTO}"
     echo "[loop] sentinel observed on turn $i — task complete"
     STATUS="complete"; break
   fi
-  if gtf "$SPENT" "$BUDGET"; then
-    echo "[loop] cumulative budget exceeded (\$$SPENT > \$$BUDGET) — stopping" >&2
-    STATUS="budget"; break
-  fi
 done
 
 {
   echo "status=$STATUS"
   echo "session_id=$SID"
-  echo "total_spent_usd=$SPENT"
   echo "iterations=$i"
 } > "$RUN_DIR/summary.txt"
 
-echo "[loop] status=$STATUS spent=\$$SPENT session=$SID"
+echo "[loop] status=$STATUS session=$SID"
 [[ "$STATUS" == "complete" ]] && exit 0 || exit 1

--- a/.agents/skills/claude-auto/scripts/claude-auto.sh
+++ b/.agents/skills/claude-auto/scripts/claude-auto.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 #
 # claude-auto.sh — run a single Claude Code task fully autonomously (no approval
-# prompts) to completion, with a budget cap, structured logging, and a
-# machine-checkable result.
+# prompts) to completion, with structured logging and a machine-checkable result.
 #
 # A single `claude -p` invocation already runs the full agent loop until the
 # task is done; this wrapper adds the safety rails and the success/failure
@@ -23,7 +22,6 @@ Run one Claude Code task autonomously (no approval prompts) to completion.
 Options:
   -f, --file FILE        Read the prompt from FILE (instead of an argument).
   -d, --dir DIR          Working directory for the run (default: current dir).
-  -b, --budget USD       Hard spend cap via --max-budget-usd (default: 2.00).
   -m, --mode MODE        Permission mode (default: bypassPermissions).
                          One of: bypassPermissions, acceptEdits, dontAsk,
                          auto, default. Use a scoped mode + --allow for
@@ -45,7 +43,7 @@ Exit codes:
 
 Examples:
   claude-auto.sh "Run the test suite and fix any failures"
-  claude-auto.sh -b 5 -m dontAsk -a "Read,Bash(pytest *)" "Investigate the flaky test"
+  claude-auto.sh -m dontAsk -a "Read,Bash(pytest *)" "Investigate the flaky test"
   claude-auto.sh -f task.md --stream --model sonnet
 USAGE
 }
@@ -90,7 +88,6 @@ PY
 PROMPT=""
 PROMPT_FILE=""
 WORKDIR="."
-BUDGET="2.00"
 MODE="bypassPermissions"
 ALLOW=""
 DISALLOW=""
@@ -107,7 +104,6 @@ while [[ $# -gt 0 ]]; do
     -h|--help) usage; exit 0 ;;
     -f|--file) PROMPT_FILE="${2:?}"; shift 2 ;;
     -d|--dir) WORKDIR="${2:?}"; shift 2 ;;
-    -b|--budget) BUDGET="${2:?}"; shift 2 ;;
     -m|--mode) MODE="${2:?}"; shift 2 ;;
     -a|--allow) ALLOW="${2:?}"; shift 2 ;;
     --disallow) DISALLOW="${2:?}"; shift 2 ;;
@@ -151,7 +147,6 @@ if [[ "$STREAM" -eq 1 ]]; then OUT_FORMAT="stream-json"; OUT_FILE="$RUN_DIR/stre
 
 CMD=(claude -p "$PROMPT"
   --permission-mode "$MODE"
-  --max-budget-usd "$BUDGET"
   --output-format "$OUT_FORMAT")
 [[ "$STREAM" -eq 1 ]] && CMD+=(--verbose --include-partial-messages)
 [[ -n "$ALLOW" ]]    && CMD+=(--allowedTools "$ALLOW")
@@ -172,7 +167,7 @@ mkdir -p "$RUN_DIR"
 printf '%s\n' "$PROMPT" > "$RUN_DIR/prompt.txt"
 printf '%s\n' "$CMD_LINE" > "$RUN_DIR/command.txt"
 
-echo "[claude-auto] mode=$MODE budget=\$$BUDGET stream=$STREAM dir=$WORKDIR"
+echo "[claude-auto] mode=$MODE stream=$STREAM dir=$WORKDIR"
 echo "[claude-auto] log: $RUN_DIR"
 
 # --- run ---
@@ -192,20 +187,18 @@ if ! IS_ERROR="$(json_field "$OUT_FILE" is_error)"; then
   [[ -s "$RUN_DIR/stderr.log" ]] && tail -n 20 "$RUN_DIR/stderr.log" >&2
   exit 1
 fi
-COST="$(json_field "$OUT_FILE" total_cost_usd || echo '?')"
 TURNS="$(json_field "$OUT_FILE" num_turns || echo '?')"
 SID="$(json_field "$OUT_FILE" session_id || echo '?')"
 json_field "$OUT_FILE" result > "$RUN_DIR/result.txt" || true
 
 {
   echo "is_error=$IS_ERROR"
-  echo "total_cost_usd=$COST"
   echo "num_turns=$TURNS"
   echo "session_id=$SID"
   echo "claude_rc=$RC"
 } > "$RUN_DIR/summary.txt"
 
-echo "[claude-auto] is_error=$IS_ERROR cost=\$$COST turns=$TURNS session=$SID"
+echo "[claude-auto] is_error=$IS_ERROR turns=$TURNS session=$SID"
 echo "----- result -----"
 cat "$RUN_DIR/result.txt"
 echo

--- a/.agents/skills/claude-auto/scripts/claude-auto.sh
+++ b/.agents/skills/claude-auto/scripts/claude-auto.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# claude-auto.sh — run a single Claude Code task fully autonomously (no approval
+# prompts) to completion, with a budget cap, structured logging, and a
+# machine-checkable result.
+#
+# A single `claude -p` invocation already runs the full agent loop until the
+# task is done; this wrapper adds the safety rails and the success/failure
+# detection that headless automation needs (Claude exits 0 even when the run
+# failed, so we re-derive the exit code from the JSON `is_error` field).
+#
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  claude-auto.sh [options] "PROMPT"
+  claude-auto.sh [options] -f PROMPT_FILE
+  echo "PROMPT" | claude-auto.sh [options]
+
+Run one Claude Code task autonomously (no approval prompts) to completion.
+
+Options:
+  -f, --file FILE        Read the prompt from FILE (instead of an argument).
+  -d, --dir DIR          Working directory for the run (default: current dir).
+  -b, --budget USD       Hard spend cap via --max-budget-usd (default: 2.00).
+  -m, --mode MODE        Permission mode (default: bypassPermissions).
+                         One of: bypassPermissions, acceptEdits, dontAsk,
+                         auto, default. Use a scoped mode + --allow for
+                         locked-down runs.
+  -a, --allow TOOLS      --allowedTools list, e.g. "Bash(git *),Read,Edit".
+      --disallow TOOLS   --disallowedTools list.
+      --model MODEL      Model alias/name (e.g. opus, sonnet, haiku).
+      --append-system S  Append S to the system prompt.
+  -l, --log-dir DIR      Base dir for run logs (default: logs/claude-auto).
+      --stream           Stream live progress (stream-json) instead of buffering.
+      --name NAME        Run slug (default: timestamp).
+      --dry-run          Print the claude command and exit.
+  -h, --help             Show this help.
+
+Exit codes:
+  0  run completed with is_error=false
+  1  run completed with is_error=true (or no result emitted)
+  2  usage / setup error
+
+Examples:
+  claude-auto.sh "Run the test suite and fix any failures"
+  claude-auto.sh -b 5 -m dontAsk -a "Read,Bash(pytest *)" "Investigate the flaky test"
+  claude-auto.sh -f task.md --stream --model sonnet
+USAGE
+}
+
+die() { echo "[FAIL] $*" >&2; exit 2; }
+
+# --- pick a python for JSON parsing (jq is not guaranteed to be installed) ---
+pick_python() {
+  if [[ -x ".venv/bin/python" ]]; then echo ".venv/bin/python";
+  elif command -v python3 >/dev/null 2>&1; then echo "python3";
+  elif command -v python  >/dev/null 2>&1; then echo "python";
+  else die "no python found for JSON parsing"; fi
+}
+
+# json_field FILE FIELD  — print a top-level field from a JSON result object.
+# In --stream mode FILE is JSONL; the last object with type=="result" wins.
+json_field() {
+  local file="$1" field="$2"
+  "$PYTHON" - "$file" "$field" <<'PY'
+import json, sys
+path, field = sys.argv[1], sys.argv[2]
+obj = None
+with open(path, encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(rec, dict) and (rec.get("type") == "result" or "is_error" in rec):
+            obj = rec
+if obj is None:
+    sys.exit(3)
+val = obj.get(field, "")
+print(val if not isinstance(val, bool) else str(val).lower())
+PY
+}
+
+# --- defaults ---
+PROMPT=""
+PROMPT_FILE=""
+WORKDIR="."
+BUDGET="2.00"
+MODE="bypassPermissions"
+ALLOW=""
+DISALLOW=""
+MODEL=""
+APPEND_SYSTEM=""
+LOG_BASE="logs/claude-auto"
+STREAM=0
+RUN_NAME=""
+DRY_RUN=0
+
+# --- parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    -f|--file) PROMPT_FILE="${2:?}"; shift 2 ;;
+    -d|--dir) WORKDIR="${2:?}"; shift 2 ;;
+    -b|--budget) BUDGET="${2:?}"; shift 2 ;;
+    -m|--mode) MODE="${2:?}"; shift 2 ;;
+    -a|--allow) ALLOW="${2:?}"; shift 2 ;;
+    --disallow) DISALLOW="${2:?}"; shift 2 ;;
+    --model) MODEL="${2:?}"; shift 2 ;;
+    --append-system) APPEND_SYSTEM="${2:?}"; shift 2 ;;
+    -l|--log-dir) LOG_BASE="${2:?}"; shift 2 ;;
+    --stream) STREAM=1; shift ;;
+    --name) RUN_NAME="${2:?}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --) shift; PROMPT="${*:-}"; break ;;
+    -*) die "unknown option: $1 (see --help)" ;;
+    *) PROMPT="$1"; shift ;;
+  esac
+done
+
+command -v claude >/dev/null 2>&1 || die "claude CLI not found on PATH"
+PYTHON="$(pick_python)"
+
+# --- resolve the prompt: arg > file > stdin ---
+if [[ -n "$PROMPT_FILE" ]]; then
+  [[ -f "$PROMPT_FILE" ]] || die "prompt file not found: $PROMPT_FILE"
+  PROMPT="$(cat "$PROMPT_FILE")"
+elif [[ -z "$PROMPT" && ! -t 0 ]]; then
+  PROMPT="$(cat)"
+fi
+[[ -n "${PROMPT// /}" ]] || { usage; die "no prompt provided"; }
+
+[[ -d "$WORKDIR" ]] || die "working dir not found: $WORKDIR"
+
+# --- prepare run dir ---
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+if [[ -n "$RUN_NAME" ]]; then
+  SLUG="$(echo "$RUN_NAME" | tr -cs 'A-Za-z0-9._-' '-' | sed 's/-*$//' | cut -c1-48)"
+  RUN_DIR="${LOG_BASE%/}/${TS}-${SLUG}"
+else
+  RUN_DIR="${LOG_BASE%/}/${TS}"
+fi
+# --- build the claude command ---
+OUT_FORMAT="json"; OUT_FILE="$RUN_DIR/output.json"
+if [[ "$STREAM" -eq 1 ]]; then OUT_FORMAT="stream-json"; OUT_FILE="$RUN_DIR/stream.jsonl"; fi
+
+CMD=(claude -p "$PROMPT"
+  --permission-mode "$MODE"
+  --max-budget-usd "$BUDGET"
+  --output-format "$OUT_FORMAT")
+[[ "$STREAM" -eq 1 ]] && CMD+=(--verbose --include-partial-messages)
+[[ -n "$ALLOW" ]]    && CMD+=(--allowedTools "$ALLOW")
+[[ -n "$DISALLOW" ]] && CMD+=(--disallowedTools "$DISALLOW")
+[[ -n "$MODEL" ]]    && CMD+=(--model "$MODEL")
+[[ -n "$APPEND_SYSTEM" ]] && CMD+=(--append-system-prompt "$APPEND_SYSTEM")
+
+# the exact invocation, prompt elided, for the log and for --dry-run
+CMD_LINE="$( printf 'cwd: %s\ncmd:' "$WORKDIR"; printf ' %q' "${CMD[@]/$PROMPT/<PROMPT>}"; printf '\n'; )"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[dry-run] run dir would be: $RUN_DIR"
+  printf '%s\n' "$CMD_LINE"
+  exit 0
+fi
+
+mkdir -p "$RUN_DIR"
+printf '%s\n' "$PROMPT" > "$RUN_DIR/prompt.txt"
+printf '%s\n' "$CMD_LINE" > "$RUN_DIR/command.txt"
+
+echo "[claude-auto] mode=$MODE budget=\$$BUDGET stream=$STREAM dir=$WORKDIR"
+echo "[claude-auto] log: $RUN_DIR"
+
+# --- run ---
+set +e
+if [[ "$STREAM" -eq 1 ]]; then
+  ( cd "$WORKDIR" && "${CMD[@]}" ) | tee "$OUT_FILE"
+  RC=${PIPESTATUS[0]}
+else
+  ( cd "$WORKDIR" && "${CMD[@]}" ) > "$OUT_FILE" 2>"$RUN_DIR/stderr.log"
+  RC=$?
+fi
+set -e
+
+# --- parse result ---
+if ! IS_ERROR="$(json_field "$OUT_FILE" is_error)"; then
+  echo "[claude-auto] FAILED: no result object emitted (claude rc=$RC)" >&2
+  [[ -s "$RUN_DIR/stderr.log" ]] && tail -n 20 "$RUN_DIR/stderr.log" >&2
+  exit 1
+fi
+COST="$(json_field "$OUT_FILE" total_cost_usd || echo '?')"
+TURNS="$(json_field "$OUT_FILE" num_turns || echo '?')"
+SID="$(json_field "$OUT_FILE" session_id || echo '?')"
+json_field "$OUT_FILE" result > "$RUN_DIR/result.txt" || true
+
+{
+  echo "is_error=$IS_ERROR"
+  echo "total_cost_usd=$COST"
+  echo "num_turns=$TURNS"
+  echo "session_id=$SID"
+  echo "claude_rc=$RC"
+} > "$RUN_DIR/summary.txt"
+
+echo "[claude-auto] is_error=$IS_ERROR cost=\$$COST turns=$TURNS session=$SID"
+echo "----- result -----"
+cat "$RUN_DIR/result.txt"
+echo
+echo "------------------"
+
+[[ "$IS_ERROR" == "false" ]] && exit 0 || exit 1


### PR DESCRIPTION
## 概要

Claude Code を「承認なしで最後までタスクを遂行する」非対話（ヘッドレス）実行のワークフローを確立し、`claude-auto` スキルとして永続化しました。ウェブ調査と実機での試行錯誤（v2.1.185）で検証済みのフラグ・成否判定・安全策をまとめ、再現性のためのラッパースクリプト2本を同梱しています。

## 変更内容

- `.agents/skills/claude-auto/SKILL.md`: 検証済みの中核コマンドとフラグを文書化。
  - `--permission-mode bypassPermissions`（≡ `--dangerously-skip-permissions`）で承認プロンプトを完全に省略。単一の `claude -p` がエージェントループを完遂まで回す。
  - 成否は終了コードではなく JSON の `is_error` で判定（`claude` は失敗時も exit 0）。
  - `--allowedTools` / `dontAsk` / `auto` モード、OAuth と `--bare`（要 API キー）の注意点、ワークツリーでの `.venv` 不在時の `python3` フォールバック、安全策（サンドボックス・最小権限）を記載。
- `.agents/skills/claude-auto/scripts/claude-auto.sh`: 単発の自律実行ラッパー。構造化ログ（`logs/claude-auto/`、gitignore 済み）・`is_error` から導いた正しい終了コードを提供。
- `.agents/skills/claude-auto/scripts/claude-auto-loop.sh`: セッションを `--resume` で継ぎ足し、完了センチネル（既定 `TASK_COMPLETE`）が出るまで繰り返す「完遂まで」ループ。`--max-iters` で上限を設定。

## 検証

ワークツリー `feat-claude-auto-skill` 上で実機検証（Claude Code 2.1.185 / OAuth）。

- `claude -p ... --output-format json` でヘッドレス実行と `is_error` 判定を確認。
- `--permission-mode bypassPermissions` で複数ステップ（ファイル作成→実行→検証）の自律実行を承認なしで完遂（`is_error:false`）。
- `--dangerously-skip-permissions` の等価性、`session_id` キャプチャ→`--resume` の継続を確認。
- `claude-auto.sh`: 多段タスクを完遂（exit 0、ログ一式生成）。`--dry-run` がファイルを作らないことを確認。
- `claude-auto-loop.sh`: センチネル検出で `status=complete`・exit 0（`set -e` × 関数内 `&&` の終了ステータス伝播バグを修正済み）。
- `bash -n` 構文チェック通過。pre-commit 対象（`src|tests|experiments` 配下の Python）に該当しないためフック対象外。

## 関連Issue

- なし（自律実行ワークフローの整備）

## 補足

- 全権限バイパスはガードレールを外すため、SKILL.md ではサンドボックス／最小権限（`dontAsk` + `--allowedTools`）併用を推奨として明記しています。