### PR TITLE
feat(skills): TDD・リファクタリングのスキルとサブエージェントを追加

### DIFF
--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: refactor
+description: Use this skill after an experiment has proven its worth and the throwaway code needs to become clean, reusable src/ code — graduating experiments/ or prototype scripts into src/tasks, src/tennis_scene, or src/utils. It defines behavior-preserving refactoring under a green test bar, dead-code removal, and the repo's quality gates (ruff, mypy, script-conventions). Use it for restructuring existing code, not for adding new behavior.
+---
+
+# Refactoring (tennis-lab)
+
+## Why this skill exists
+
+This is a research lab: we generate a lot of **experimental code fast** — under
+`experiments/`, `experiments_mcmc/`, and ad-hoc `scripts/` — to learn whether an
+idea works. That code is meant to be cheap and disposable. The moment an
+experiment earns a permanent place, the code that produced it usually does *not*
+belong in `src/` as-is. This skill is the bridge: turn proven experiment code
+into clean, typed, tested, reusable modules **without changing what it does**.
+
+Refactoring = changing structure while preserving behavior. If you are changing
+behavior, that is a feature/fix — use [`tdd`](../tdd/SKILL.md) instead. If you
+are only restructuring, the existing behavior is the spec to protect.
+
+## When to use
+
+- An experiment under `experiments/**` proved valuable and its logic should move
+  into `src/tasks/<task>`, `src/tennis_scene`, or `src/utils`.
+- A `src/` module has accreted dead branches, copy-paste, or leftover experiment
+  scaffolding after iteration and needs cleanup.
+- You are extracting a shared helper out of two diverging task copies.
+
+Do **not** use this skill to add features, change numerics, or "improve while I'm
+here" beyond the agreed scope. Mixing behavior change into a refactor is how
+silent regressions enter `src/`.
+
+## The safe refactor loop
+
+1. **Pin behavior first (characterization tests).**
+   Before moving anything, capture the current observable contract with tests per
+   [`tdd`](../tdd/SKILL.md) — shapes, dtypes, output keys, error cases, a CPU
+   smoke step. If the experiment had no tests, this is where they get written.
+   These tests are your safety net; they must be green *before* you touch structure.
+
+2. **One behavior-preserving transform at a time.**
+   Rename, extract function/class, inline, move module, dedupe — apply a single
+   transform, then re-run the pinned tests. Lean on the tools: `ruff check --fix`
+   and `ruff format` for mechanical changes.
+
+3. **Keep behavior and structure in separate commits.**
+   A refactor commit must not change outputs. If you discover a needed behavior
+   change mid-refactor, stop, finish/commit the structural step, then make the
+   behavior change as its own tested commit.
+
+4. **Remove dead code as you go.**
+   Delete superseded experiment branches, unused parameters, commented-out
+   blocks, and now-unreferenced helpers. Confirm with a reference search before
+   deleting (`rg "<symbol>"`), and let the tests confirm nothing depended on it.
+   Do not keep "just in case" code — git history is the backup.
+
+## Graduating experiment code into `src/`
+
+When promoting code out of `experiments/**`:
+
+- **Placement** (per `AGENTS.md`): task-specific logic -> `src/tasks/<task>/...`;
+  cross-task scene logic -> `src/tennis_scene`; reusable helpers -> `src/utils`.
+  Keep a task's `data/` / `models/` / `training/` substructure consistent with
+  its siblings.
+- **Configuration:** replace hardcoded constants and `argparse` with Hydra
+  configs under the matching `configs/` directory. Entry-point scripts under
+  `src/**/scripts/` must satisfy [`script-conventions`](../script-conventions/SKILL.md)
+  (module docstring with Overview -> Usage -> Notes, Hydra config, no `argparse`).
+- **Typing:** add type annotations; `src` is checked under strict mypy
+  (`disallow_untyped_defs`). New public functions need full signatures.
+- **Dependencies:** if a graduated module needs a new package, add it with
+  `uv add <pkg>` — never hand-edit dependency tables.
+- **Leave the experiment** in place (or delete it) deliberately; don't import
+  `src/` code back from `experiments/` to re-create a tangle.
+
+## Definition of done
+
+- The pinned/characterization tests are still green: `.venv/bin/python -m pytest <target>`.
+- `.venv/bin/python -m ruff check src tests` is clean (CI enforces this).
+- `.venv/bin/python -m mypy src` is clean for the modules touched.
+- No dead code remains (no commented-out blocks, unused params, or orphaned
+  helpers introduced by the refactor).
+- Behavior is unchanged: the diff is structure-only, or any behavior change is
+  isolated in its own clearly-labeled, tested commit.
+- Promoted scripts comply with [`script-conventions`](../script-conventions/SKILL.md).
+
+## Notes
+
+- Prefer many small, reviewable commits (`refactor:` prefix) over one large diff;
+  it makes "structure only, behavior identical" auditable.
+- If there are zero tests and writing characterization tests is impractical
+  (heavy GPU/data), at minimum add a CPU smoke contract first — never refactor
+  `src/` blind.
+- Delegate an autonomous cleanup pass to the `refactor-cleaner` subagent
+  (`.claude/agents/refactor-cleaner.md`).
+- Pair with [`tdd`](../tdd/SKILL.md): TDD adds behavior under new tests; refactor
+  changes shape under existing tests. Together they keep `src/` clean as
+  experiments churn.

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: tdd
+description: Use this skill when writing or changing code that will live under src/ (tasks, tennis_scene, utils) or repo tooling, and you want a test-first workflow. It defines the RED -> GREEN -> REFACTOR loop and the tennis-lab testing conventions (contract tests, pytest markers, skip-on-missing-data, CPU smoke, Hydra configs). It does not apply to throwaway experiment code until that code graduates into src/.
+---
+
+# Test-Driven Development (tennis-lab)
+
+## Scope
+
+Use this skill when adding or changing code that other code depends on:
+
+- `src/tasks/*` (model/data/training modules), `src/tennis_scene`, `src/utils`
+- repo tooling whose contract matters (e.g. `.agents/skills/*/scripts`, knowledge/queue helpers)
+
+This skill is deliberately **pragmatic for a research lab**. Exploratory,
+single-use code under `experiments/`, `experiments_mcmc/`, notebooks, and one-off
+plotting scripts is **exempt** — write it fast, learn from it, then bring it
+under test with [`refactor`](../refactor/SKILL.md) when it graduates into `src/`.
+Test the *contract* a piece of code exposes, not the result of a training run.
+
+## The loop: RED -> GREEN -> REFACTOR
+
+1. **RED — write a failing test first.**
+   - Express the contract you want (input -> output shape/dtype/keys, raised
+     errors, invariants). Run it and *watch it fail for the expected reason*.
+   - A test that was never executed in the red state does not count.
+   - `git commit` the red test (or stage it) before implementing — it is the spec.
+
+2. **GREEN — write the minimum code to pass.**
+   - Implement only enough to make the failing test pass. Re-run the *same*
+     target and confirm it is green. Resist adding unrequested behavior.
+
+3. **REFACTOR — clean up under a green bar.**
+   - Improve names, remove duplication, tighten types. Re-run the test after
+     each change; it must stay green. Then run ruff + mypy (see DoD).
+   - For larger cleanups (experiment -> `src/`), hand off to [`refactor`](../refactor/SKILL.md).
+
+Repeat one small contract at a time. Many tiny cycles beat one big one.
+
+## Running tests
+
+Always use the project interpreter (per `AGENTS.md`):
+
+```bash
+.venv/bin/python -m pytest tests/tasks/test_dataset_loading_contracts.py -q   # one file
+.venv/bin/python -m pytest tests/ -k court -q                                  # by keyword
+.venv/bin/python -m pytest -m "unit and not local_data" -q                     # by marker
+```
+
+In a git worktree there may be no `.venv`; fall back to `python -m pytest`.
+`pytest` is configured in `pyproject.toml` (`[tool.pytest.ini_options]`) with
+`testpaths = ["tests"]` and coverage on `src` enabled automatically.
+
+## Conventions (the future habit this skill defines)
+
+### Layout & naming
+- Tests live under `tests/`, mirroring `src/` (e.g. `tests/tasks/...`).
+- Files: `test_*.py`; classes: `Test*`; functions: `test_*`.
+- Name the behavior, not the function: `test_scene_dataset_getitem_returns_fixed_seq_len`.
+- Prefer the **contract test** idiom already used in `tests/tasks/test_*_contracts.py`:
+  one file groups the public contracts of a task (dataset `__getitem__`,
+  model `forward` shapes, runner construction/smoke).
+
+### Markers (declared in `pyproject.toml`)
+Apply exactly one tier marker plus any capability markers:
+
+| Marker | Use for |
+| --- | --- |
+| `unit` | pure functions/classes, no GPU, no disk, fast |
+| `integration` | several components together (datamodule + model, config + runner) |
+| `e2e` | a full workflow end-to-end |
+| `slow` | anything that is not quick; lets others `-m "not slow"` |
+| `local_data` | needs large local datasets/checkpoints — **not runnable in CI** |
+| `cuda` | needs a GPU; must skip cleanly when unavailable |
+
+```python
+import pytest
+pytestmark = pytest.mark.local_data        # whole module
+@pytest.mark.unit                          # single test
+```
+
+### Skip, don't fail, when the environment can't run it
+Tests must stay green on a clean checkout with no datasets and no GPU. Guard
+external prerequisites and `pytest.skip` with a clear reason — copy the existing
+helper style:
+
+```python
+def _require_paths(*paths: Path) -> None:
+    missing = [p for p in paths if not p.exists()]
+    if missing:
+        pytest.skip(f"local dataset assets are missing: {', '.join(map(str, missing))}")
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA unavailable", allow_module_level=True)
+```
+
+### Models / training: assert contracts on CPU, tiny inputs
+Don't assert learned metrics. Assert shapes, dtypes, output keys, and that a
+single step runs. Force CPU and minimal sizes:
+
+- training smoke overrides: `run.gpus=0`, `data.batch_size=1`, tiny dims / 1 step.
+- set `torch.manual_seed(0)` for any test that touches randomness.
+- build Hydra configs the way the smoke tests do, and reset global state:
+
+```python
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+
+GlobalHydra.instance().clear()
+with initialize_config_dir(config_dir=str(config_dir), version_base=None):
+    cfg = compose(config_name="config", overrides=["run.gpus=0", "data.batch_size=1"])
+```
+
+### Coverage
+`--cov=src` runs by default and reports term/html/xml. Treat coverage as a
+*lens for finding untested contracts*, not a hard gate — there is no blanket
+percentage to chase. **CI today runs only `ruff check src tests`, not pytest**,
+so a test that is green only on your machine is not protected by CI: keep new
+tests CPU- and data-free (skip otherwise) so any teammate can reproduce green.
+
+## What to test vs. skip
+
+- **Do test:** dataset `__getitem__` contracts, model `forward` output shapes/keys,
+  datamodule wiring, runner construction + 1-step smoke, data transforms/augmentations,
+  pure `src/utils` helpers, knowledge/queue tooling behavior.
+- **Don't gate on:** notebooks, `experiments/**` exploration, visual/plot output,
+  exact numeric training results, anything requiring network or private assets.
+
+## Definition of done
+
+- The new/changed contract has a test that was seen failing, then passing.
+- `.venv/bin/python -m pytest <target>` is green (or skips for missing data/GPU
+  with a clear reason — never silently passes on an empty collection).
+- `.venv/bin/python -m ruff check src tests` is clean (CI enforces this).
+- `.venv/bin/python -m mypy src` is clean for typed code you touched.
+- Tests run on CPU without local datasets, or `pytest.skip` when they cannot.
+
+## Notes
+
+- New scripts under `src/**/scripts/` or `experiments/**/scripts/` must also
+  satisfy [`script-conventions`](../script-conventions/SKILL.md) (docstring + Hydra, no argparse).
+- Delegate the full test-first cycle to the `tdd-guide` subagent
+  (`.claude/agents/tdd-guide.md`) when you want it driven autonomously.
+- Prefer a few sharp contract tests over many brittle ones; a test that breaks on
+  every refactor is testing implementation, not contract.

--- a/.claude/agents/refactor-cleaner.md
+++ b/.claude/agents/refactor-cleaner.md
@@ -1,0 +1,58 @@
+---
+name: refactor-cleaner
+description: "Use to restructure existing code without changing its behavior — graduating proven experiments/ code into clean src/ modules, deduping diverging copies, or removing dead code/leftover experiment scaffolding. It pins behavior with tests first, applies one behavior-preserving transform at a time, removes dead code, and enforces ruff/mypy/script-conventions. Triggers — refactor, clean up, graduate experiment to src, remove dead code, dedupe. Not for adding new behavior (use tdd-guide for that)."
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: inherit
+---
+
+You are a careful refactoring specialist for the **tennis-lab** ML repository.
+This lab produces experimental code fast; your job is to turn proven experiment
+code into clean, typed, tested `src/` code — and to keep `src/` free of dead
+code — **without changing observable behavior**.
+
+Your authority is the `refactor` skill at `.agents/skills/refactor/SKILL.md`.
+**Read it first** and follow it. Also honor `.agents/skills/tdd/SKILL.md` (for
+pinning behavior), `AGENTS.md` (placement, `.venv/bin/python`, `uv add`), and
+`.agents/skills/script-conventions/SKILL.md` (for promoted scripts).
+
+## Workflow
+
+1. **Pin behavior first.** Identify the current observable contract and ensure
+   characterization tests cover it (shapes/dtypes/keys/errors, a CPU smoke step).
+   If none exist, write them per the tdd skill and get them green *before*
+   touching structure. Never refactor `src/` blind.
+2. **Transform in small steps.** Apply one behavior-preserving change at a time
+   (rename, extract, inline, move, dedupe). Use `ruff check --fix` and
+   `ruff format` for mechanical edits. Re-run the pinned tests after each step.
+3. **Graduate placement when promoting from experiments/**: task logic ->
+   `src/tasks/<task>/...` (keep data/models/training substructure), scene logic
+   -> `src/tennis_scene`, shared helpers -> `src/utils`. Replace hardcoded values
+   and `argparse` with Hydra configs under the matching `configs/`. Add full type
+   annotations (strict mypy). Add deps only via `uv add`.
+4. **Remove dead code.** Delete superseded branches, unused params, commented
+   blocks, and orphaned helpers — but only after `rg "<symbol>"` confirms nothing
+   references them and tests stay green. Git history is the backup; do not keep
+   "just in case" code.
+5. **Gate.** `.venv/bin/python -m pytest <target>`,
+   `.venv/bin/python -m ruff check src tests`, `.venv/bin/python -m mypy src`.
+
+## Boundaries
+
+- Behavior must not change in a refactor. If a behavior change becomes necessary,
+  stop, finish/commit the structural step, and flag the behavior change as
+  separate, tested work (or hand it to `tdd-guide`).
+- Keep structure changes and behavior changes in separate commits.
+- Do not delete code whose references you have not checked, and do not delete
+  tests to make a refactor "pass".
+- Do not import `src/` back into `experiments/` to recreate a tangle.
+- Do not use `--no-verify` or otherwise bypass the quality gates.
+
+## Report back (concise)
+
+Return a summary, not raw logs:
+- What was pinned (characterization tests) and that they were green pre-refactor.
+- Structural changes: what moved/extracted/renamed, what dead code was removed
+  (with evidence it was unreferenced).
+- Where graduated code landed and what configs were added.
+- Final command results: pytest, ruff, mypy. Confirm behavior is unchanged.
+- Any behavior changes intentionally deferred.

--- a/.claude/agents/tdd-guide.md
+++ b/.claude/agents/tdd-guide.md
@@ -1,0 +1,49 @@
+---
+name: tdd-guide
+description: "Use to implement a new behavior or bug fix in src/ (tasks, tennis_scene, utils) or repo tooling test-first. It drives the RED -> GREEN -> REFACTOR loop, writing a failing contract test before any implementation and verifying green + ruff + mypy. Triggers — implement test-first, add with tests, TDD, write failing test then implement. Not for throwaway experiment code under experiments/."
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: inherit
+---
+
+You are a disciplined test-driven development engineer for the **tennis-lab** ML
+repository. You implement one contract at a time, test-first, and you never let
+implementation get ahead of a failing test you have actually run.
+
+Your authority is the `tdd` skill at `.agents/skills/tdd/SKILL.md`. **Read it
+first** and follow its conventions exactly (contract tests, pytest markers,
+skip-on-missing-data, CPU smoke, Hydra config setup, `.venv/bin/python`). Also
+honor `AGENTS.md` and, for any entry-point script, `.agents/skills/script-conventions/SKILL.md`.
+
+## Workflow (per requested contract)
+
+1. **Orient.** Read the target module and its existing tests under `tests/` to
+   match local conventions (naming, markers, fixtures, the contract-test idiom).
+2. **RED.** Write the smallest failing test that expresses the desired contract
+   (input -> output shape/dtype/keys, errors, invariants). Run just that target:
+   `.venv/bin/python -m pytest <path> -q` (fall back to `python -m pytest` if no
+   `.venv`). Confirm it fails *for the expected reason* and quote the failure.
+3. **GREEN.** Write the minimum implementation to pass. Re-run the same target.
+   Confirm green. Do not add behavior the test does not require.
+4. **REFACTOR.** Clean up names/duplication/types while the bar stays green,
+   re-running after each change.
+5. **Gate.** Run `.venv/bin/python -m ruff check src tests` and, for typed code
+   you touched, `.venv/bin/python -m mypy src`. Fix what you broke; do not bypass.
+6. Repeat for the next contract. Keep tests CPU- and data-free, or `pytest.skip`
+   with a clear reason so they reproduce on any checkout (CI runs ruff only).
+
+## Boundaries
+
+- Never write implementation before a test has been seen failing.
+- Do not expand scope: implement only the contract requested. Surface adjacent
+  issues as notes, don't silently fix them.
+- Do not weaken tests to force green, delete other tests, or use `--no-verify`.
+- Do not chase a coverage percentage; cover the contract that matters.
+- Do not touch `experiments/**` exploration code — that is out of scope for TDD.
+
+## Report back (concise)
+
+Return a short summary, not raw logs:
+- Contracts added (file::test names) and the RED failure each started from.
+- Files created/modified.
+- Final command results: pytest target (passed/skipped), ruff, mypy.
+- Any follow-ups or risks you deliberately left out of scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,19 @@
 - When adding dependencies, use `uv add <package>`.
 - When removing dependencies, use `uv remove <package>`.
 - Do not edit dependency definitions manually when `uv` can manage them.
+
+## Testing & refactoring conventions
+
+- Code that graduates into `src/` (tasks, `tennis_scene`, `utils`) or shared
+  tooling is developed **test-first**. Follow `.agents/skills/tdd/SKILL.md`:
+  RED -> GREEN -> REFACTOR, contract tests under `tests/`, the pytest markers in
+  `pyproject.toml` (`unit`/`integration`/`e2e`/`slow`/`local_data`/`cuda`), and
+  `pytest.skip` when datasets/GPU are unavailable so tests stay green on a clean
+  checkout. Exploratory code under `experiments/**` is exempt until it graduates.
+- Run tests with `.venv/bin/python -m pytest <target>`. CI runs only
+  `ruff check src tests`, so keep new tests CPU- and data-free (or skip).
+- After an experiment proves out, refactor it into clean `src/` code with
+  `.agents/skills/refactor/SKILL.md`: pin behavior with tests first, change
+  structure without changing behavior, and remove dead code.
+- For autonomous runs, delegate to the `tdd-guide` and `refactor-cleaner`
+  subagents in `.claude/agents/`.


### PR DESCRIPTION
## 概要

`everything-claude-code` を参考に、本リポジトリの実態（「実験は速く回し、有望になったら src/ に昇格する」運用）に合わせた **TDD スキル**・**リファクタリングスキル**と、それらを自律実行する **サブエージェント** を追加します。テストは既存資産には手を入れず、今後の慣習を定義することに主眼を置いています。

## 変更内容

- `.agents/skills/tdd/SKILL.md`: RED → GREEN → REFACTOR ループと tennis-lab のテスト慣習（contract test、pytest マーカー `unit/integration/e2e/slow/local_data/cuda`、データ/GPU 不在時は `pytest.skip`、CPU スモーク `run.gpus=0`/`batch_size=1`、Hydra 設定の組み方、`.venv/bin/python` 実行）を定義。`experiments/**` の探索コードは昇格まで対象外と明記。
- `.agents/skills/refactor/SKILL.md`: 有望な実験コードを「振る舞いを変えずに」型付き・テスト付きの `src/` モジュールへ昇格させる手順。先に振る舞いをテストで固定 → 構造変更 → デッドコード除去、`ruff`/`mypy`/`script-conventions` をゲートに。
- `.claude/agents/tdd-guide.md` / `.claude/agents/refactor-cleaner.md`: 責務を絞った Claude ネイティブ形式のサブエージェント（`.github/agents`・`.codex/agents` と並ぶ Claude 用エージェント置き場）。各スキルを自律実行する。
- `AGENTS.md`: テスト・リファクタリングの慣習セクションを追加し、上記スキル/サブエージェントへ誘導。

## 検証

サブエージェント（general-purpose）を立てて以下を検証し、PASS。

- 4 ファイルの YAML フロントマターが厳密パース可能・必須キー（skills: `name`/`description`、agents: `+tools`/`model`）・`name` がパスと一致。
- スキル内の相対参照（`../tdd`・`../refactor`・`../script-conventions`、`.claude/agents/*`）がすべて実在。
- スキルの事実主張が実設定と一致：`pyproject.toml` のマーカー・`testpaths`・`python_files`・coverage 既定、CI（`.github/workflows/ci.yml`）が `ruff check src tests` のみで pytest を回さない点。
- 既存 contract テストの作法（`_require_paths`+`skip`、`pytestmark=local_data`、Hydra `compose/initialize_config_dir`、CPU スモーク）と整合。
- スキルが指示する手順で RED → GREEN → REFACTOR を一時ディレクトリで実走（RED は ImportError で失敗、GREEN/REFACTOR は pass）。
- `.venv/bin/python -m ruff check src tests` がクリーン（src/tests への Python 追加なし）。

検証で見つかった `tdd-guide.md` の description 内コロンによる YAML パース不正を修正済み（値を引用符で囲み、両エージェントの triggers 記法をコロン無しに統一）。

## 関連Issue


## 補足

- 作業は worktree（`feat/tdd-refactor-skills`）上で実施。
- サブエージェントは新規セッションから `subagent_type` として利用可能になる（本セッションのレジストリには未登録のため、検証は general-purpose に役割を与えて実行）。
