### PR TITLE
fix(training): chunk生成のデッドロック防止とcheckpoint自動削除

### DIFF
--- a/.agents/skills/training-queue/SKILL.md
+++ b/.agents/skills/training-queue/SKILL.md
@@ -33,7 +33,8 @@ Q=.agents/skills/training-queue/scripts/training_queue.sh
 #    attributable in the knowledge graph). --issue is recommended. Humans
 #    launching by hand may omit them.
 bash "$Q" add "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True python -m src.tasks.plcs.scripts.train data=... model=... loss=..." \
-    --name exp_a --provider claude --session "$CLAUDE_CODE_SESSION_ID" --issue 525
+    --name exp_a --provider claude --session "$CLAUDE_CODE_SESSION_ID" --issue 525 \
+    --prune-ckpt
 bash "$Q" add "python -m src.tasks.plcs.scripts.train ..." --name exp_b
 
 # 2. Start the worker. --after-pid makes it wait for a native first run to
@@ -80,6 +81,14 @@ The job also gets `TENNIS_RUN_ID` and `TENNIS_REPRO_DIR` in its environment. The
 training **lightning module** writes test-split inference results to
 `$TENNIS_REPRO_DIR/predictions/{pred_test.npz, metrics.json}` (so checkpoints can
 be deleted and metrics still recomputed). This replaces keeping `*.ckpt` around.
+
+`add --prune-ckpt` opts a job into post-run checkpoint deletion. After a
+successful job, the runner-written `$TENNIS_REPRO_DIR/output_dir.txt` identifies
+that run's checkpoint directory. The worker deletes only its `*.ckpt` files and
+only when the same repro bundle contains a verified
+`predictions/pred_test.npz`. Failed jobs, jobs without the flag, missing/invalid
+prediction bundles, and missing pointers keep their checkpoints. Pruning is
+non-fatal and never removes the prediction bundle.
 
 After a run finishes, register it into the git-tracked knowledge graph with the
 **knowledge-control** skill, which promotes the repro bundle + predictions into

--- a/.agents/skills/training-queue/scripts/prune_ckpts.py
+++ b/.agents/skills/training-queue/scripts/prune_ckpts.py
@@ -22,6 +22,13 @@ Usage:
     .venv/bin/python .../prune_ckpts.py --backfill --delete --device cuda            # + prune
     .venv/bin/python .../prune_ckpts.py --delete                                     # prune already-backfilled
     .venv/bin/python .../prune_ckpts.py --glob 'outputs/plcs/**/*.ckpt'              # scope
+    .venv/bin/python .../prune_ckpts.py --repro-dir .training_queue/repro/<id> --delete  # one run (queue hook)
+
+Single-run mode (``--repro-dir``) gates on the run's own repro bundle instead of
+the global glob: it deletes only the checkpoints pointed at by
+``<repro>/output_dir.txt`` and only when ``<repro>/predictions/pred_test.npz``
+verifies. The training queue's optional ``--prune-ckpt`` flag calls this after a
+successful run.
 """
 
 from __future__ import annotations
@@ -30,6 +37,7 @@ import argparse
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 
 def repo_root() -> Path:
@@ -79,7 +87,72 @@ def verify_npz(path: Path) -> bool:
         return False
 
 
-def build_runner(task: str):
+def prune_from_repro_dir(repro_dir: Path, do_delete: bool) -> int:
+    """Delete one run's checkpoints, gated on its repro bundle (issue #533).
+
+    This powers the training queue's optional post-run auto-prune. A queued run's
+    gitignored ``.training_queue/repro/<jobid>/`` holds both the reproducibility
+    bundle and the test-split predictions (``predictions/pred_test.npz``); the
+    runner writes ``output_dir.txt`` there pointing at the run's checkpoint dir.
+    A checkpoint is removed **only if** a verified ``pred_test.npz`` exists in
+    this repro dir, so every metric stays recomputable; the npz itself is never
+    touched. Conservative and self-contained: any missing precondition keeps the
+    checkpoints and returns 0, so a queue worker never treats a successful run as
+    failed.
+    """
+    npz = repro_dir / "predictions" / "pred_test.npz"
+    if not verify_npz(npz):
+        print(f"KEEP  {repro_dir}  (no verified pred_test.npz; not pruning)")
+        return 0
+    pointer = repro_dir / "output_dir.txt"
+    if not pointer.exists():
+        print(f"KEEP  {repro_dir}  (no output_dir.txt pointer; cannot locate ckpts)")
+        return 0
+    try:
+        pointer_value = pointer.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        print(f"KEEP  {repro_dir}  (cannot read output_dir.txt: {exc})")
+        return 0
+    if not pointer_value:
+        print(f"KEEP  {repro_dir}  (empty output_dir.txt pointer)")
+        return 0
+    ckpt_dir = Path(pointer_value)
+    if not ckpt_dir.is_absolute():
+        ckpt_dir = repo_root() / ckpt_dir
+    ckpts = sorted(ckpt_dir.glob("*.ckpt")) if ckpt_dir.exists() else []
+    if not ckpts:
+        print(f"KEEP  {repro_dir}  (no *.ckpt under {ckpt_dir}; already pruned?)")
+        return 0
+    total = sum(c.stat().st_size for c in ckpts)
+    if not do_delete:
+        print(
+            f"(dry-run) would delete {len(ckpts)} ckpt(s), {human(total)} under {ckpt_dir}"
+        )
+        for c in ckpts:
+            print(f"  {human(c.stat().st_size):>9}  {c}")
+        print("  re-run with --delete to remove (pred_test.npz is verified).")
+        return 0
+    freed = 0
+    deleted = 0
+    for c in ckpts:
+        size = c.stat().st_size
+        try:
+            c.unlink()
+        except OSError as exc:  # noqa: PERF203
+            print(f"KEEP  {c}  (unlink failed: {exc})")
+            continue
+        freed += size
+        deleted += 1
+        print(f"DEL   {c}  (freed {human(size)})")
+    print(
+        f"pruned {deleted}/{len(ckpts)} ckpt(s) for {repro_dir.name}; "
+        f"freed {human(freed)} "
+        f"(pred_test.npz retained at {npz})"
+    )
+    return 0
+
+
+def build_runner(task: str) -> Any:
     if task == "plcs":
         from src.tasks.plcs.training.runner import PLCSTrainingRunner
 
@@ -89,7 +162,7 @@ def build_runner(task: str):
     return BLCSTrainingRunner()
 
 
-def build_module_cls(task: str):
+def build_module_cls(task: str) -> Any:
     if task == "plcs":
         from src.tasks.plcs.training.lightning_module import PLCSLightningModule
 
@@ -130,7 +203,9 @@ def backfill_one(ckpt: Path, task: str, device: str) -> tuple[bool, str]:
 
     # Predictions land next to the checkpoint's version dir.
     os.environ["TENNIS_REPRO_DIR"] = str(version_dir(ckpt))
-    accelerator = "gpu" if device.startswith("cuda") and torch.cuda.is_available() else "cpu"
+    accelerator = (
+        "gpu" if device.startswith("cuda") and torch.cuda.is_available() else "cpu"
+    )
     trainer = pl.Trainer(
         accelerator=accelerator,
         devices=1,
@@ -153,12 +228,37 @@ def backfill_one(ckpt: Path, task: str, device: str) -> tuple[bool, str]:
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--glob", default="outputs/**/*.ckpt", help="ckpt glob (repo-root relative)")
-    p.add_argument("--backfill", action="store_true", help="save test predictions from each ckpt")
-    p.add_argument("--delete", action="store_true", help="delete ckpt when verified npz exists")
+    p.add_argument(
+        "--glob", default="outputs/**/*.ckpt", help="ckpt glob (repo-root relative)"
+    )
+    p.add_argument(
+        "--backfill", action="store_true", help="save test predictions from each ckpt"
+    )
+    p.add_argument(
+        "--delete", action="store_true", help="delete ckpt when verified npz exists"
+    )
     p.add_argument("--device", default="cuda", help="cuda|cpu for backfill")
-    p.add_argument("--limit", type=int, default=0, help="process at most N ckpts (0 = all)")
+    p.add_argument(
+        "--limit", type=int, default=0, help="process at most N ckpts (0 = all)"
+    )
+    p.add_argument(
+        "--repro-dir",
+        type=Path,
+        default=None,
+        help="prune ONE run's ckpts via its .training_queue/repro/<jobid> bundle "
+        "(verified pred_test.npz + output_dir.txt pointer); ignores --glob",
+    )
     args = p.parse_args()
+
+    # Single-run mode (training-queue post-run auto-prune): scoped + self-gating.
+    if args.repro_dir is not None:
+        repro = (
+            args.repro_dir
+            if args.repro_dir.is_absolute()
+            else (Path.cwd() / args.repro_dir)
+        ).resolve()
+        os.chdir(repo_root())
+        return prune_from_repro_dir(repro, args.delete)
 
     root = repo_root()
     os.chdir(root)

--- a/.agents/skills/training-queue/scripts/training_queue.sh
+++ b/.agents/skills/training-queue/scripts/training_queue.sh
@@ -7,7 +7,11 @@
 # starts, so the very first run does NOT have to go through this queue.
 #
 # Subcommands:
-#   add "<command>" [--name NAME]   Enqueue a command (runs in the current CWD).
+#   add "<command>" [--name NAME] [--prune-ckpt]
+#                                   Enqueue a command (runs in the current CWD).
+#                                   --prune-ckpt: after the run succeeds, delete
+#                                   its checkpoints iff the test-split
+#                                   predictions were saved (issue #533).
 #   start [--after-pid PID] [--idle-timeout S]
 #                                   Launch the background worker (nohup-style).
 #   status                          Show worker state + queued/running/done jobs.
@@ -16,6 +20,7 @@
 #   clear                           Remove all pending (not-yet-started) jobs.
 #
 # State dir: $TRAINING_QUEUE_DIR (default: .training_queue under the CWD).
+# Prune python: $TRAINING_QUEUE_PYTHON (default: $VIRTUAL_ENV or repo .venv).
 #
 # Examples:
 #   training_queue.sh add "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
@@ -55,14 +60,57 @@ _worker_running() {
   [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
 }
 
+# Resolve a python that can import numpy (for the post-run ckpt pruner). Prefer
+# an explicit override, then the active venv, then the repo's .venv (resolved via
+# the *main* git dir so it works from a linked worktree too), then python3.
+_queue_python() {
+  if [ -n "${TRAINING_QUEUE_PYTHON:-}" ] && [ -x "${TRAINING_QUEUE_PYTHON}" ]; then
+    printf '%s' "$TRAINING_QUEUE_PYTHON"; return
+  fi
+  if [ -n "${VIRTUAL_ENV:-}" ] && [ -x "${VIRTUAL_ENV}/bin/python" ]; then
+    printf '%s' "${VIRTUAL_ENV}/bin/python"; return
+  fi
+  local common main_root
+  common="$(git -C "$(dirname "$SCRIPT_PATH")" rev-parse --git-common-dir 2>/dev/null || echo '')"
+  if [ -n "$common" ]; then
+    main_root="$(cd "$(dirname "$common")" && pwd)"
+    if [ -x "$main_root/.venv/bin/python" ]; then
+      printf '%s' "$main_root/.venv/bin/python"; return
+    fi
+  fi
+  printf 'python3'
+}
+
+# Opt-in post-run hook: when a job was added with --prune-ckpt and succeeded,
+# delete its checkpoints iff its repro bundle has a verified pred_test.npz.
+# Non-fatal: a prune failure never changes the job's done/failed status.
+_maybe_prune_ckpt() {
+  local job="$1" jobfile="$DONE_DIR/$1"
+  grep -q '^# prune_ckpt: 1$' "$jobfile" 2>/dev/null || return 0
+  local prune repro_root_abs repro py
+  prune="$(dirname "$SCRIPT_PATH")/prune_ckpts.py"
+  if [ ! -f "$prune" ]; then
+    echo "[worker] prune-ckpt skipped: $prune not found"; return 0
+  fi
+  repro_root_abs="$(cd "$REPRO_DIR" 2>/dev/null && pwd)" || {
+    echo "[worker] prune-ckpt skipped: repro dir $REPRO_DIR missing"; return 0
+  }
+  repro="$repro_root_abs/${job%.job}"
+  py="$(_queue_python)"
+  echo "[worker] $(date -Iseconds) prune-ckpt: $job (py=$py repro=$repro)"
+  "$py" "$prune" --repro-dir "$repro" --delete \
+    || echo "[worker] prune-ckpt non-fatal error for $job (rc=$?)"
+}
+
 cmd_add() {
-  local name="" command="" provider="" session="" issue=""
+  local name="" command="" provider="" session="" issue="" prune_ckpt=0
   while [ $# -gt 0 ]; do
     case "$1" in
       --name) name="$2"; shift 2 ;;
       --provider) provider="$2"; shift 2 ;;
       --session) session="$2"; shift 2 ;;
       --issue) issue="$2"; shift 2 ;;
+      --prune-ckpt) prune_ckpt=1; shift ;;
       *) command="$1"; shift ;;
     esac
   done
@@ -91,6 +139,7 @@ cmd_add() {
     echo "# provider: ${provider}"
     echo "# session: ${session}"
     echo "# issue: ${issue}"
+    echo "# prune_ckpt: ${prune_ckpt}"
     echo "cd $(printf '%q' "$PWD")"
     echo "export TENNIS_RUN_ID=$(printf '%q' "$jobid")"
     echo "export TENNIS_REPRO_DIR=$(printf '%q' "$repro_job_abs")"
@@ -228,6 +277,7 @@ cmd_worker() {
     if [ "$rc" -eq 0 ]; then
       mv "$RUNNING_DIR/$job" "$DONE_DIR/$job"
       echo "[worker] $(date -Iseconds) done: $job"
+      _maybe_prune_ckpt "$job"
     else
       echo "exit_code=$rc" >> "$log"
       mv "$RUNNING_DIR/$job" "$FAILED_DIR/$job"
@@ -244,8 +294,13 @@ cmd_start() {
     echo "worker already running (PID $(cat "$WORKER_PID_FILE"))." >&2
     exit 1
   fi
-  # Detached background worker; survives the launching shell.
-  nohup bash "$SCRIPT_PATH" __worker "$@" >> "$WORKER_LOG" 2>&1 &
+  # Detached background worker. Prefer a new session so agent/CI launchers that
+  # tear down their own process group do not kill long-running training jobs.
+  local -a worker_cmd=(bash "$SCRIPT_PATH" __worker "$@")
+  if command -v setsid >/dev/null 2>&1; then
+    worker_cmd=(setsid "${worker_cmd[@]}")
+  fi
+  nohup "${worker_cmd[@]}" >> "$WORKER_LOG" 2>&1 < /dev/null &
   local pid=$!
   echo "$pid" > "$WORKER_PID_FILE"
   echo "worker started (PID $pid). log: $WORKER_LOG"

--- a/src/tasks/base/generate_dataset/parallel_runner.py
+++ b/src/tasks/base/generate_dataset/parallel_runner.py
@@ -11,6 +11,7 @@ remaining arguments broadcast via :func:`itertools.repeat`.
 from __future__ import annotations
 
 import itertools
+import multiprocessing
 from collections.abc import Callable, Iterator
 from concurrent.futures import ProcessPoolExecutor
 from typing import Any
@@ -44,7 +45,16 @@ def run_parallel_scene_generation(
 
     max_workers = min(num_workers, len(scene_indices))
 
-    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+    # Chunk generation runs from a background thread while the training process
+    # has already initialized CUDA and other native thread pools. Forking that
+    # process can inherit locks without their owner threads and deadlock during
+    # generation or ProcessPoolExecutor shutdown. ``spawn`` starts clean worker
+    # interpreters and is safe from non-main threads.
+    mp_context = multiprocessing.get_context("spawn")
+    with ProcessPoolExecutor(
+        max_workers=max_workers,
+        mp_context=mp_context,
+    ) as executor:
         yield from executor.map(
             task_fn,
             scene_indices,

--- a/src/tasks/base/training/runner.py
+++ b/src/tasks/base/training/runner.py
@@ -196,6 +196,30 @@ class BaseTrainingRunner:
         """Build TensorBoard logger."""
         return TensorBoardLogger(save_dir=str(output_dir), name="logs")
 
+    def _record_ckpt_dir_pointer(self, checkpoint_dir: Path) -> None:
+        """Record this run's checkpoint dir into the repro bundle (issue #533).
+
+        When the run is launched via the training queue, ``TENNIS_REPRO_DIR``
+        points at the job's gitignored ``.training_queue/repro/<jobid>/`` staging
+        dir (where the test-split ``pred_test.npz`` also lands). Writing the
+        checkpoint dir there gives the optional post-run ckpt pruner a
+        deterministic repro -> ckpt link, so it can delete *only this run's*
+        checkpoints once the predictions are saved. Best-effort: never raise, so
+        a bookkeeping hiccup cannot abort training.
+        """
+        repro_dir = os.environ.get("TENNIS_REPRO_DIR")
+        if not repro_dir:
+            return
+        try:
+            target = Path(repro_dir)
+            target.mkdir(parents=True, exist_ok=True)
+            resolved_checkpoint_dir = checkpoint_dir.resolve()
+            (target / "output_dir.txt").write_text(
+                f"{resolved_checkpoint_dir}\n", encoding="utf-8"
+            )
+        except OSError:
+            pass
+
     def build_callbacks(
         self, config: Any, datamodule: pl.LightningDataModule, logger: TensorBoardLogger
     ) -> list[Any]:
@@ -206,6 +230,7 @@ class BaseTrainingRunner:
         checkpoint_cfg = config.training.checkpoint
         if checkpoint_cfg.enabled:
             checkpoint_dir = Path(logger.log_dir) / "checkpoints"
+            self._record_ckpt_dir_pointer(checkpoint_dir)
             callbacks.append(
                 ModelCheckpoint(
                     dirpath=checkpoint_dir,

--- a/tests/test_parallel_scene_generation.py
+++ b/tests/test_parallel_scene_generation.py
@@ -1,0 +1,78 @@
+"""Process-pool safety tests for background scene generation."""
+
+from __future__ import annotations
+
+import multiprocessing
+from collections.abc import Iterable
+from typing import Any
+
+import pytest
+
+from src.tasks.base.generate_dataset import parallel_runner
+
+
+def _task(value: int, offset: int) -> int:
+    return value + offset
+
+
+def test_parallel_generation_uses_spawn_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeExecutor:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        def __enter__(self) -> FakeExecutor:
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            return None
+
+        def map(
+            self,
+            task_fn: Any,
+            scene_indices: Iterable[int],
+            repeated_arg: Iterable[int],
+            *,
+            chunksize: int,
+        ) -> Iterable[int]:
+            captured["chunksize"] = chunksize
+            return (
+                task_fn(scene_index, offset)
+                for scene_index, offset in zip(
+                    scene_indices, repeated_arg, strict=False
+                )
+            )
+
+    monkeypatch.setattr(parallel_runner, "ProcessPoolExecutor", FakeExecutor)
+
+    result = list(
+        parallel_runner.run_parallel_scene_generation(
+            _task,
+            [1, 2],
+            10,
+            num_workers=8,
+            chunksize=4,
+        )
+    )
+
+    assert result == [11, 12]
+    assert captured["max_workers"] == 2
+    assert captured["chunksize"] == 4
+    assert captured["mp_context"].get_start_method() == "spawn"
+    assert captured["mp_context"] is multiprocessing.get_context("spawn")
+
+
+def test_parallel_generation_spawn_smoke() -> None:
+    result = list(
+        parallel_runner.run_parallel_scene_generation(
+            _task,
+            [1, 2, 3],
+            10,
+            num_workers=2,
+        )
+    )
+
+    assert result == [11, 12, 13]

--- a/tests/test_training_queue_auto_prune.py
+++ b/tests/test_training_queue_auto_prune.py
@@ -1,0 +1,246 @@
+"""Opt-in training-queue checkpoint pruning tests (issue #545)."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.tasks.base.training.runner import BaseTrainingRunner
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+QUEUE_SCRIPT = REPO_ROOT / ".agents/skills/training-queue/scripts/training_queue.sh"
+PRUNE_SCRIPT = REPO_ROOT / ".agents/skills/training-queue/scripts/prune_ckpts.py"
+
+
+def _run(
+    cwd: Path, env: dict[str, str], *args: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(QUEUE_SCRIPT), *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _wait_for_worker(
+    cwd: Path,
+    env: dict[str, str],
+    *,
+    done: int,
+    failed: int,
+) -> str:
+    status = ""
+    for _ in range(60):
+        status = _run(cwd, env, "status").stdout
+        if (
+            "worker: stopped" in status
+            and f"done={done}" in status
+            and f"failed={failed}" in status
+        ):
+            return status
+        time.sleep(0.5)
+    raise AssertionError(f"worker did not finish: {status}")
+
+
+def _write_valid_npz(repro_dir: Path) -> Path:
+    npz = repro_dir / "predictions" / "pred_test.npz"
+    npz.parent.mkdir(parents=True)
+    np.savez(npz, scene_ids=np.asarray(["scene_001"]))
+    return npz
+
+
+def test_runner_records_absolute_checkpoint_pointer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repro_dir = tmp_path / "repro"
+    checkpoint_dir = tmp_path / "outputs" / "version_0" / "checkpoints"
+    monkeypatch.setenv("TENNIS_REPRO_DIR", str(repro_dir))
+
+    BaseTrainingRunner()._record_ckpt_dir_pointer(checkpoint_dir)
+
+    pointer = repro_dir / "output_dir.txt"
+    assert pointer.read_text(encoding="utf-8") == f"{checkpoint_dir.resolve()}\n"
+
+
+def test_runner_pointer_is_best_effort(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    not_a_directory = tmp_path / "file"
+    not_a_directory.write_text("occupied", encoding="utf-8")
+    monkeypatch.setenv("TENNIS_REPRO_DIR", str(not_a_directory))
+
+    BaseTrainingRunner()._record_ckpt_dir_pointer(tmp_path / "checkpoints")
+
+
+def test_repro_pruner_dry_run_delete_and_keep(tmp_path: Path) -> None:
+    repro_dir = tmp_path / "repro"
+    checkpoint_dir = tmp_path / "outputs" / "version_0" / "checkpoints"
+    checkpoint_dir.mkdir(parents=True)
+    checkpoints = [checkpoint_dir / "best.ckpt", checkpoint_dir / "last.ckpt"]
+    for checkpoint in checkpoints:
+        checkpoint.write_bytes(b"checkpoint")
+    npz = _write_valid_npz(repro_dir)
+    (repro_dir / "output_dir.txt").write_text(f"{checkpoint_dir}\n", encoding="utf-8")
+
+    dry_run = subprocess.run(
+        [sys.executable, str(PRUNE_SCRIPT), "--repro-dir", str(repro_dir)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert dry_run.returncode == 0, dry_run.stderr
+    assert "would delete 2 ckpt(s)" in dry_run.stdout
+    assert all(checkpoint.exists() for checkpoint in checkpoints)
+
+    delete = subprocess.run(
+        [
+            sys.executable,
+            str(PRUNE_SCRIPT),
+            "--repro-dir",
+            str(repro_dir),
+            "--delete",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert delete.returncode == 0, delete.stderr
+    assert "pruned 2/2 ckpt(s)" in delete.stdout
+    assert not any(checkpoint.exists() for checkpoint in checkpoints)
+    assert npz.exists()
+
+    keep_dir = tmp_path / "keep"
+    keep_checkpoint_dir = tmp_path / "outputs" / "version_1" / "checkpoints"
+    keep_checkpoint_dir.mkdir(parents=True)
+    keep_checkpoint = keep_checkpoint_dir / "best.ckpt"
+    keep_checkpoint.write_bytes(b"checkpoint")
+    keep_dir.mkdir()
+    (keep_dir / "output_dir.txt").write_text(
+        f"{keep_checkpoint_dir}\n", encoding="utf-8"
+    )
+    keep = subprocess.run(
+        [
+            sys.executable,
+            str(PRUNE_SCRIPT),
+            "--repro-dir",
+            str(keep_dir),
+            "--delete",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert keep.returncode == 0, keep.stderr
+    assert "no verified pred_test.npz" in keep.stdout
+    assert keep_checkpoint.exists()
+
+
+def test_queue_prunes_only_opted_in_successful_jobs(tmp_path: Path) -> None:
+    repo = tmp_path / "worktree"
+    repo.mkdir()
+    helper = repo / "make_artifacts.py"
+    helper.write_text(
+        "\n".join(
+            [
+                "import sys",
+                "from pathlib import Path",
+                "import numpy as np",
+                "repro = Path(sys.argv[1])",
+                "name = sys.argv[2]",
+                "ckpt_dir = Path(sys.argv[3]) / name / 'checkpoints'",
+                "ckpt_dir.mkdir(parents=True)",
+                "(ckpt_dir / 'best.ckpt').write_bytes(b'checkpoint')",
+                "(repro / 'predictions').mkdir(parents=True)",
+                "np.savez(repro / 'predictions' / 'pred_test.npz', "
+                "scene_ids=np.asarray(['scene_001']))",
+                "(repro / 'output_dir.txt').write_text("
+                "str(ckpt_dir.resolve()) + '\\n')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "make_artifacts.py"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=repo, check=True)
+
+    queue_dir = tmp_path / "shared-queue"
+    output_dir = tmp_path / "outputs"
+    env = {
+        **os.environ,
+        "TRAINING_QUEUE_DIR": str(queue_dir),
+        "TRAINING_QUEUE_PYTHON": sys.executable,
+    }
+
+    def add(name: str, *, prune: bool, fail: bool = False) -> None:
+        command = (
+            f"{shlex.quote(sys.executable)} {shlex.quote(str(helper))} "
+            f'"$TENNIS_REPRO_DIR" {shlex.quote(name)} '
+            f"{shlex.quote(str(output_dir))}"
+        )
+        if fail:
+            command += "; exit 7"
+        args = [
+            "add",
+            command,
+            "--name",
+            name,
+            "--provider",
+            "claude",
+            "--session",
+            "session-545",
+            "--issue",
+            "545",
+        ]
+        if prune:
+            args.append("--prune-ckpt")
+        result = _run(repo, env, *args)
+        assert result.returncode == 0, result.stderr
+
+    add("success_prune", prune=True)
+    add("success_default", prune=False)
+    add("failed_prune", prune=True, fail=True)
+
+    start = _run(repo, env, "start", "--idle-timeout", "2")
+    assert start.returncode == 0, start.stderr
+    _wait_for_worker(repo, env, done=2, failed=1)
+
+    assert not (output_dir / "success_prune" / "checkpoints" / "best.ckpt").exists()
+    assert (output_dir / "success_default" / "checkpoints" / "best.ckpt").exists()
+    assert (output_dir / "failed_prune" / "checkpoints" / "best.ckpt").exists()
+
+    done_jobs = sorted((queue_dir / "done").glob("*.job"))
+    failed_jobs = sorted((queue_dir / "failed").glob("*.job"))
+    assert len(done_jobs) == 2
+    assert len(failed_jobs) == 1
+    headers = {job.name: job.read_text(encoding="utf-8") for job in done_jobs}
+    assert any(
+        "# prune_ckpt: 1" in content and "success_prune" in name
+        for name, content in headers.items()
+    )
+    assert any(
+        "# prune_ckpt: 0" in content and "success_default" in name
+        for name, content in headers.items()
+    )
+    assert "# prune_ckpt: 1" in failed_jobs[0].read_text(encoding="utf-8")
+
+    repro_dirs = sorted((queue_dir / "repro").glob("*"))
+    assert len(repro_dirs) == 3
+    assert all((repro / "run.json").exists() for repro in repro_dirs)
+    assert all(
+        (repro / "predictions" / "pred_test.npz").exists() for repro in repro_dirs
+    )


### PR DESCRIPTION
## 概要

training queueに、test split推論を検証した後だけcheckpointを削除するopt-in機構を追加します。
また、CUDA初期化後のバックグラウンドthreadからscene生成poolを`fork`していたことで発生するデッドロックを、`spawn` contextへ切り替えて解消します。

## 変更内容

- `training_queue.sh add --prune-ckpt`を追加し、成功したジョブのみrun単位でcheckpoint削除を実行
- runnerが`TENNIS_REPRO_DIR/output_dir.txt`へcheckpoint directoryを記録
- `prune_ckpts.py --repro-dir`で同じrepro bundleの`pred_test.npz`を検証してから対象runの`*.ckpt`だけを削除
- workerを`setsid`で独立させ、agent/CIのprocess group終了に巻き込まれないよう修正
- parallel scene生成の`ProcessPoolExecutor`へ`multiprocessing.get_context("spawn")`を明示
- checkpoint pruningとspawn process poolの回帰テストを追加

## 検証

- `.venv/bin/python -m pytest tests/test_parallel_scene_generation.py tests/tasks/test_dataset_generation_contracts.py -q --no-cov`（9 passed）
- `.venv/bin/python -m pytest tests/test_training_queue_auto_prune.py tests/test_training_queue_repro.py tests/test_lightning_test_predictions.py -q --no-cov`（8 passed）
- `ruff`、限定`mypy`、`bash -n`、`git diff --check`成功
- #545のS2/H8をepoch 29 checkpointから再開し、1000 scene生成後の`chunk 0 ready`と次chunk生成開始を実機確認

## 関連Issue

- References #545

## 補足

- `--prune-ckpt`はデフォルトOFFです。
- prediction bundleは削除せず、失敗ジョブ・未検証npz・pointer欠落時はcheckpointを保持します。
- #545の学習キューはこのブランチ上で継続中です。
