### PR TITLE
feat(ball_detection): DINOv3と3軸RoPEの時系列検出器を追加

### DIFF
--- a/src/tasks/ball_detection/README.md
+++ b/src/tasks/ball_detection/README.md
@@ -10,7 +10,7 @@
 |---|---|
 | 入力 | RGBフレーム列 `(B, T, 3, H, W)`（T=8、H=288、W=512 がデフォルト） |
 | 出力 | 正規化ボール座標 `(B, T, 2)` + 信頼度 `(B, T)` + ヒートマップ（任意） |
-| モデル | `stunet` / `conv_next_unet` / `dino_pseudo3d` |
+| モデル | `stunet` / `conv_next_unet` / `dino_pseudo3d` / `dinov3_rope` |
 | データ | TrackNet形式 + YouTube自作（手動アノテーション） |
 | 役割 | 認識パイプラインの上流。2D観測を [BLCS](../blcs/) へ供給 |
 
@@ -146,6 +146,7 @@ YouTube動画から学習データを作る3ステップ。CLIは `scripts/youtu
 ```bash
 .venv/bin/python -m src.tasks.ball_detection.scripts.train
 .venv/bin/python -m src.tasks.ball_detection.scripts.train model=conv_next_unet data.batch_size=4
+.venv/bin/python -m src.tasks.ball_detection.scripts.train model=dinov3_rope data=web_frames
 # augmentation 強度を切り替える（default / light / none）
 .venv/bin/python -m src.tasks.ball_detection.scripts.train data/augmentation=light
 ```
@@ -182,8 +183,11 @@ YouTube動画から学習データを作る3ステップ。CLIは `scripts/youtu
 | `stunet` | mdd / 2ch | H/2 × W/2 | `models/spatiotemporal_unet.py`（2D+3D Conv U-Net、T≥8 必須） |
 | `conv_next_unet` | mdd / 2ch | H/4 × W/4 | `models/conv_next_unet.py`（ConvNeXt + 因子化Conv3d） |
 | `dino_pseudo3d` | rgb / 3ch | フル解像度 | `models/dino_pseudo3d.py`（DINO backbone + Pseudo-3Dデコーダ） |
+| `dinov3_rope` | rgb / 3ch | 288 × 512 | `models/dinov3_rope.py`（DINOv3 ViT-B/16 patch token + `(time,y,x)` 3軸RoPE global self-attention） |
 
 `mdd`（Motion Direction Decomposition）はRGBの輝度差分を明暗2chに分解する入力（`models/input_adapter.py`）。`rgb` はRGBをそのまま渡します。
+
+`dinov3_rope`は`(B,T,3,288,512)`を直接受け取り、各frameの`18×32` patch gridを全時刻でflattenして非causal self-attentionします。時間座標はwindow内の整数順序のみで、FPSやtimestampは使用しません。`model.backbone.train_mode`は`frozen` / `last_n_blocks` / `full`、decoder規模・RoPE・dropout・gradient checkpointingは`configs/model/dinov3_rope.yaml`で設定できます。時間長に依存する学習parameterを持たないため、`T=1`で保存したstate dictを`T>1`へstrict loadできます。
 
 ## 補足
 

--- a/src/tasks/ball_detection/configs/model/dinov3_rope.yaml
+++ b/src/tasks/ball_detection/configs/model/dinov3_rope.yaml
@@ -1,0 +1,30 @@
+name: dinov3_rope
+input_mode: rgb
+input_layout: btchw
+in_channels: 3
+num_classes: 1
+num_frames: 1
+image_size: [288, 512]
+
+backbone:
+  name: dinov3_vitb16
+  repository_path: third_party/dinov3
+  checkpoint_path: third_party/dinov3/checkpoints/dinov3_vitb16_pretrain_lvd1689m-73cec8be.pth
+  strict: true
+  # frozen | last_n_blocks | full
+  train_mode: frozen
+  last_n_blocks: 0
+
+decoder:
+  dim: 256
+  num_layers: 4
+  num_heads: 8
+  ffn_dim: 1024
+  rope_dim: 32
+  # Local integer order only: [time, y, x]. No FPS or timestamps.
+  rope_base: [10000.0, 10000.0, 10000.0]
+  dropout: 0.0
+  gradient_checkpointing: false
+
+heatmap_head:
+  min_channels: 32

--- a/src/tasks/ball_detection/models/__init__.py
+++ b/src/tasks/ball_detection/models/__init__.py
@@ -8,10 +8,12 @@ from torch import nn
 
 from src.tasks.ball_detection.models.conv_next_unet import ConvNeXtUNet
 from src.tasks.ball_detection.models.dino_pseudo3d import DINOPseudo3DBallDetector
+from src.tasks.ball_detection.models.dinov3_rope import DINOv3RoPEBallDetector
 from src.tasks.ball_detection.models.discriminators import (
     build_ball_detection_discriminator,
 )
 from src.tasks.ball_detection.models.input_adapter import (
+    resolve_input_layout,
     resolve_input_mode,
     resolve_model_in_channels,
     to_model_input,
@@ -32,20 +34,24 @@ def build_ball_detection_model(config: DictConfig) -> nn.Module:
         return ConvNeXtUNet.from_config(config)
     if model_name == "dino_pseudo3d":
         return DINOPseudo3DBallDetector.from_config(config)
+    if model_name == "dinov3_rope":
+        return DINOv3RoPEBallDetector.from_config(config)
     raise ValueError(
         "Unknown ball_detection model.name="
         f"'{model_name}'. Supported: "
-        "['stunet', 'conv_next_unet', 'dino_pseudo3d']"
+        "['stunet', 'conv_next_unet', 'dino_pseudo3d', 'dinov3_rope']"
     )
 
 
 __all__ = [
     "ConvNeXtUNet",
     "DINOPseudo3DBallDetector",
+    "DINOv3RoPEBallDetector",
     "SpatioTemporalUNet",
     "build_ball_detection_discriminator",
     "build_ball_detection_model",
     "resolve_input_mode",
+    "resolve_input_layout",
     "resolve_model_in_channels",
     "to_model_input",
 ]

--- a/src/tasks/ball_detection/models/dinov3_rope.py
+++ b/src/tasks/ball_detection/models/dinov3_rope.py
@@ -1,0 +1,409 @@
+"""DINOv3 patch-token ball detector with three-axis rotary attention."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import torch
+from torch import nn
+from torch.utils.checkpoint import checkpoint
+
+from src.utils.models.components import (
+    RMSNorm,
+    TransformerBlock,
+    TransformerBlockConfig,
+    precompute_freqs_cis_nd,
+)
+from src.utils.models.components.rope import RopeBaseLike
+from src.utils.models.loading import (
+    DEFAULT_DINOV3_CHECKPOINT,
+    DEFAULT_DINOV3_REPOSITORY,
+    DINOv3BackboneAdapter,
+    DINOv3TrainMode,
+    configure_dinov3_trainability,
+    load_dinov3_backbone,
+)
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+
+def build_spatiotemporal_positions(
+    *,
+    num_frames: int,
+    patch_height: int,
+    patch_width: int,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    """Build row-major integer ``(time, y, x)`` coordinates for flattened tokens."""
+    if min(num_frames, patch_height, patch_width) <= 0:
+        raise ValueError("num_frames, patch_height, and patch_width must be positive.")
+    time = torch.arange(num_frames, device=device, dtype=torch.long)
+    y_coord = torch.arange(patch_height, device=device, dtype=torch.long)
+    x_coord = torch.arange(patch_width, device=device, dtype=torch.long)
+    time_grid, y_grid, x_grid = torch.meshgrid(
+        time,
+        y_coord,
+        x_coord,
+        indexing="ij",
+    )
+    return torch.stack((time_grid, y_grid, x_grid), dim=-1).reshape(-1, 3)
+
+
+class FrameSharedHeatmapHead(nn.Module):
+    """Apply one spatial upsampling head independently to every time step."""
+
+    def __init__(
+        self,
+        *,
+        in_channels: int,
+        patch_size: int,
+        out_channels: int = 1,
+        min_channels: int = 32,
+    ) -> None:
+        super().__init__()
+        if in_channels <= 0 or out_channels <= 0 or min_channels <= 0:
+            raise ValueError("Heatmap head channel counts must be positive.")
+        if patch_size <= 0 or patch_size & (patch_size - 1):
+            raise ValueError("patch_size must be a positive power of two.")
+
+        layers: list[nn.Module] = []
+        current_channels = in_channels
+        for _ in range(int(math.log2(patch_size))):
+            next_channels = max(min_channels, current_channels // 2)
+            layers.extend(
+                [
+                    nn.ConvTranspose2d(
+                        current_channels,
+                        next_channels,
+                        kernel_size=2,
+                        stride=2,
+                        bias=False,
+                    ),
+                    nn.GroupNorm(1, next_channels),
+                    nn.GELU(),
+                ]
+            )
+            current_channels = next_channels
+        layers.append(nn.Conv2d(current_channels, out_channels, kernel_size=1))
+        self.network = nn.Sequential(*layers)
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        """Map ``(B*T, C, Hp, Wp)`` patch grids to dense frame logits."""
+        if features.ndim != 4:
+            raise ValueError(
+                "Heatmap head expects (B*T, C, Hp, Wp), "
+                f"got {tuple(features.shape)}."
+            )
+        return self.network(features)
+
+
+class DINOv3RoPEBallDetector(nn.Module):
+    """Bidirectional global patch-token decoder for temporal ball detection."""
+
+    def __init__(
+        self,
+        *,
+        in_channels: int = 3,
+        num_classes: int = 1,
+        num_frames: int = 1,
+        image_size: tuple[int, int] = (288, 512),
+        backbone_repository_path: str | Path = DEFAULT_DINOV3_REPOSITORY,
+        backbone_checkpoint_path: str | Path = DEFAULT_DINOV3_CHECKPOINT,
+        backbone_name: str = "dinov3_vitb16",
+        backbone_strict: bool = True,
+        backbone_train_mode: DINOv3TrainMode = "frozen",
+        backbone_last_n_blocks: int = 0,
+        decoder_dim: int = 256,
+        decoder_layers: int = 4,
+        decoder_heads: int = 8,
+        decoder_ffn_dim: int | None = None,
+        decoder_rope_dim: int | None = None,
+        decoder_rope_base: RopeBaseLike = (10_000.0, 10_000.0, 10_000.0),
+        decoder_dropout: float = 0.0,
+        decoder_gradient_checkpointing: bool = False,
+        head_min_channels: int = 32,
+        backbone: DINOv3BackboneAdapter | None = None,
+    ) -> None:
+        super().__init__()
+        self._validate_init_args(
+            in_channels=in_channels,
+            num_classes=num_classes,
+            num_frames=num_frames,
+            image_size=image_size,
+            decoder_dim=decoder_dim,
+            decoder_layers=decoder_layers,
+            decoder_heads=decoder_heads,
+            decoder_rope_dim=decoder_rope_dim,
+            decoder_dropout=decoder_dropout,
+        )
+        self.in_channels = int(in_channels)
+        self.num_classes = int(num_classes)
+        self.num_frames = int(num_frames)
+        self.image_size = tuple(int(value) for value in image_size)
+        self.backbone_train_mode = backbone_train_mode
+        self.decoder_gradient_checkpointing = bool(decoder_gradient_checkpointing)
+        self.decoder_rope_base = decoder_rope_base
+
+        self.backbone = backbone or load_dinov3_backbone(
+            repository_path=backbone_repository_path,
+            checkpoint_path=backbone_checkpoint_path,
+            backbone_name=backbone_name,
+            strict=backbone_strict,
+        )
+        configure_dinov3_trainability(
+            self.backbone,
+            train_mode=self.backbone_train_mode,
+            last_n_blocks=backbone_last_n_blocks,
+        )
+        self.patch_size = self.backbone.patch_size
+        if any(size % self.patch_size != 0 for size in self.image_size):
+            raise ValueError(
+                f"image_size={self.image_size} must be divisible by patch_size={self.patch_size}."
+            )
+
+        self.token_projection = nn.Linear(self.backbone.embed_dim, decoder_dim)
+        self.token_dropout = nn.Dropout(decoder_dropout)
+        block_config = TransformerBlockConfig(
+            dim=decoder_dim,
+            n_heads=decoder_heads,
+            ffn_dim=decoder_ffn_dim,
+            rope_dim=decoder_rope_dim,
+            attn_dropout=decoder_dropout,
+        )
+        self.decoder = nn.ModuleList(
+            TransformerBlock(block_config) for _ in range(decoder_layers)
+        )
+        self.decoder_norm = RMSNorm(decoder_dim)
+        self.heatmap_head = FrameSharedHeatmapHead(
+            in_channels=decoder_dim,
+            patch_size=self.patch_size,
+            out_channels=self.num_classes,
+            min_channels=head_min_channels,
+        )
+
+    @staticmethod
+    def _validate_init_args(
+        *,
+        in_channels: int,
+        num_classes: int,
+        num_frames: int,
+        image_size: tuple[int, int],
+        decoder_dim: int,
+        decoder_layers: int,
+        decoder_heads: int,
+        decoder_rope_dim: int | None,
+        decoder_dropout: float,
+    ) -> None:
+        if in_channels != 3:
+            raise ValueError("DINOv3RoPEBallDetector requires 3-channel RGB input.")
+        for name, value in (
+            ("num_classes", num_classes),
+            ("num_frames", num_frames),
+            ("decoder_dim", decoder_dim),
+            ("decoder_layers", decoder_layers),
+            ("decoder_heads", decoder_heads),
+        ):
+            if value <= 0:
+                raise ValueError(f"{name} must be positive.")
+        if len(image_size) != 2 or min(image_size) <= 0:
+            raise ValueError("image_size must contain two positive integers.")
+        if decoder_dim % decoder_heads != 0:
+            raise ValueError("decoder_dim must be divisible by decoder_heads.")
+        head_dim = decoder_dim // decoder_heads
+        if decoder_rope_dim is not None:
+            if decoder_rope_dim <= 0 or decoder_rope_dim % 2 != 0:
+                raise ValueError("decoder_rope_dim must be a positive even integer.")
+            if decoder_rope_dim > head_dim:
+                raise ValueError(
+                    "decoder_rope_dim cannot exceed the per-head dimension."
+                )
+        if not 0.0 <= decoder_dropout < 1.0:
+            raise ValueError("decoder_dropout must be in [0, 1).")
+
+    @classmethod
+    def from_config(cls, config: DictConfig) -> DINOv3RoPEBallDetector:
+        """Create the model from a composed Hydra config."""
+        model_cfg = config.get("model", {}) or {}
+        backbone_cfg = model_cfg.get("backbone", {}) or {}
+        decoder_cfg = model_cfg.get("decoder", {}) or {}
+        head_cfg = model_cfg.get("heatmap_head", {}) or {}
+        image_size = _parse_pair(
+            model_cfg.get("image_size", [288, 512]),
+            name="model.image_size",
+        )
+        rope_base = _parse_rope_base(decoder_cfg.get("rope_base", 10_000.0))
+        return cls(
+            in_channels=int(model_cfg.get("in_channels", 3)),
+            num_classes=int(model_cfg.get("num_classes", 1)),
+            num_frames=int(model_cfg.get("num_frames", 1)),
+            image_size=image_size,
+            backbone_repository_path=backbone_cfg.get(
+                "repository_path",
+                DEFAULT_DINOV3_REPOSITORY,
+            ),
+            backbone_checkpoint_path=backbone_cfg.get(
+                "checkpoint_path",
+                DEFAULT_DINOV3_CHECKPOINT,
+            ),
+            backbone_name=str(backbone_cfg.get("name", "dinov3_vitb16")),
+            backbone_strict=bool(backbone_cfg.get("strict", True)),
+            backbone_train_mode=cast(
+                DINOv3TrainMode,
+                str(backbone_cfg.get("train_mode", "frozen")),
+            ),
+            backbone_last_n_blocks=int(backbone_cfg.get("last_n_blocks", 0)),
+            decoder_dim=int(decoder_cfg.get("dim", 256)),
+            decoder_layers=int(decoder_cfg.get("num_layers", 4)),
+            decoder_heads=int(decoder_cfg.get("num_heads", 8)),
+            decoder_ffn_dim=_optional_int(decoder_cfg.get("ffn_dim")),
+            decoder_rope_dim=_optional_int(decoder_cfg.get("rope_dim")),
+            decoder_rope_base=rope_base,
+            decoder_dropout=float(decoder_cfg.get("dropout", 0.0)),
+            decoder_gradient_checkpointing=bool(
+                decoder_cfg.get("gradient_checkpointing", False)
+            ),
+            head_min_channels=int(head_cfg.get("min_channels", 32)),
+        )
+
+    def train(self, mode: bool = True) -> DINOv3RoPEBallDetector:
+        """Keep a frozen backbone deterministic while training the decoder."""
+        super().train(mode)
+        if self.backbone_train_mode == "frozen":
+            self.backbone.eval()
+        return self
+
+    def forward(self, frames: torch.Tensor) -> torch.Tensor:
+        """Return logits ``(B, C, T, H, W)`` from ``(B, T, 3, H, W)`` frames."""
+        self._validate_forward_input(frames)
+        batch_size, num_frames, channels, height, width = frames.shape
+        patch_height = height // self.patch_size
+        patch_width = width // self.patch_size
+
+        flat_frames = frames.reshape(
+            batch_size * num_frames,
+            channels,
+            height,
+            width,
+        )
+        patch_tokens = self._extract_patch_tokens(flat_frames)
+        expected_tokens = patch_height * patch_width
+        if patch_tokens.shape[1] != expected_tokens:
+            raise RuntimeError(
+                "DINOv3 patch-token count does not match the input grid: "
+                f"expected {expected_tokens}, got {patch_tokens.shape[1]}."
+            )
+
+        tokens = patch_tokens.reshape(
+            batch_size,
+            num_frames * expected_tokens,
+            self.backbone.embed_dim,
+        )
+        tokens = self.token_dropout(self.token_projection(tokens))
+        positions = build_spatiotemporal_positions(
+            num_frames=num_frames,
+            patch_height=patch_height,
+            patch_width=patch_width,
+            device=frames.device,
+        )
+        rope_dim = self.decoder[0].attn.rope_dim
+        freqs_cis = precompute_freqs_cis_nd(
+            dim=rope_dim,
+            pos=positions,
+            base=self.decoder_rope_base,
+        )
+        for block in self.decoder:
+            if self.decoder_gradient_checkpointing and self.training:
+                tokens = checkpoint(
+                    block,
+                    tokens,
+                    freqs_cis=freqs_cis,
+                    use_reentrant=False,
+                )
+            else:
+                tokens = block(tokens, freqs_cis=freqs_cis)
+        tokens = self.decoder_norm(tokens)
+
+        patch_grids = (
+            tokens.reshape(
+                batch_size,
+                num_frames,
+                patch_height,
+                patch_width,
+                tokens.shape[-1],
+            )
+            .permute(0, 1, 4, 2, 3)
+            .reshape(
+                batch_size * num_frames,
+                tokens.shape[-1],
+                patch_height,
+                patch_width,
+            )
+        )
+        frame_logits = self.heatmap_head(patch_grids)
+        if frame_logits.shape[-2:] != (height, width):
+            raise RuntimeError(
+                "Heatmap head output size does not match the input size: "
+                f"{tuple(frame_logits.shape[-2:])} != {(height, width)}."
+            )
+        return (
+            frame_logits.reshape(
+                batch_size,
+                num_frames,
+                self.num_classes,
+                height,
+                width,
+            )
+            .permute(0, 2, 1, 3, 4)
+            .contiguous()
+        )
+
+    def _extract_patch_tokens(self, flat_frames: torch.Tensor) -> torch.Tensor:
+        if self.backbone_train_mode == "frozen":
+            with torch.no_grad():
+                return self.backbone.forward_features(flat_frames)[
+                    "x_norm_patchtokens"
+                ]
+        return self.backbone.forward_features(flat_frames)["x_norm_patchtokens"]
+
+    def _validate_forward_input(self, frames: torch.Tensor) -> None:
+        if frames.ndim != 5:
+            raise ValueError(
+                "DINOv3RoPEBallDetector expects (B, T, C, H, W), "
+                f"got {tuple(frames.shape)}."
+            )
+        if frames.shape[2] != self.in_channels:
+            raise ValueError(
+                f"Expected {self.in_channels} channels, got {frames.shape[2]}."
+            )
+        if tuple(frames.shape[-2:]) != self.image_size:
+            raise ValueError(
+                f"Expected image_size={self.image_size}, got {tuple(frames.shape[-2:])}."
+            )
+
+
+def _parse_pair(value: Sequence[int], *, name: str) -> tuple[int, int]:
+    parsed = tuple(int(item) for item in value)
+    if len(parsed) != 2:
+        raise ValueError(f"{name} must contain exactly two integers.")
+    return parsed[0], parsed[1]
+
+
+def _parse_rope_base(value: float | Sequence[float]) -> RopeBaseLike:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return tuple(float(item) for item in value)
+    return float(value)
+
+
+def _optional_int(value: Any) -> int | None:
+    return None if value is None else int(value)
+
+
+__all__ = [
+    "DINOv3RoPEBallDetector",
+    "FrameSharedHeatmapHead",
+    "build_spatiotemporal_positions",
+]

--- a/src/tasks/ball_detection/models/input_adapter.py
+++ b/src/tasks/ball_detection/models/input_adapter.py
@@ -39,6 +39,17 @@ def resolve_model_in_channels(model_cfg: Mapping[str, Any] | Any) -> int:
     return in_channels
 
 
+def resolve_input_layout(model_cfg: Mapping[str, Any] | Any) -> str:
+    """Resolve the 5D tensor layout expected by the selected model."""
+    input_layout = str(model_cfg.get("input_layout", "bcthw")).strip().lower()
+    if input_layout not in {"bcthw", "btchw"}:
+        raise ValueError(
+            "model.input_layout must be one of ['bcthw', 'btchw'], "
+            f"got '{input_layout}'."
+        )
+    return input_layout
+
+
 def to_model_input(images: Tensor, model_cfg: Mapping[str, Any] | Any) -> Tensor:
     """Convert ``(B, T, C, H, W)`` RGB frames into the configured model input."""
     if images.ndim != 5:
@@ -48,9 +59,15 @@ def to_model_input(images: Tensor, model_cfg: Mapping[str, Any] | Any) -> Tensor
         )
 
     input_mode = resolve_input_mode(model_cfg)
+    input_layout = resolve_input_layout(model_cfg)
     if input_mode == "rgb":
+        if input_layout == "btchw":
+            return images
         return images.permute(0, 2, 1, 3, 4).contiguous()
-    return _rgb_frames_to_mdd(images, model_cfg)
+    mdd = _rgb_frames_to_mdd(images, model_cfg)
+    if input_layout == "btchw":
+        return mdd.permute(0, 2, 1, 3, 4).contiguous()
+    return mdd
 
 
 def _rgb_frames_to_mdd(images: Tensor, model_cfg: Mapping[str, Any] | Any) -> Tensor:
@@ -94,6 +111,7 @@ def _power_normalize(values: Tensor, gain: float, offset: float) -> Tensor:
 
 __all__ = [
     "resolve_input_mode",
+    "resolve_input_layout",
     "resolve_model_in_channels",
     "to_model_input",
 ]

--- a/src/tasks/court_detection/models/dinov3_detr.py
+++ b/src/tasks/court_detection/models/dinov3_detr.py
@@ -16,95 +16,21 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from src.utils.paths import resolve_project_path
+from src.utils.models.loading import (
+    DEFAULT_DINOV3_CHECKPOINT,
+    DEFAULT_DINOV3_REPOSITORY,
+    DINOv3BackboneAdapter,
+    load_dinov3_backbone,
+)
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
-
-
-_DEFAULT_DINOV3_REPOSITORY = Path("third_party/dinov3")
-_DEFAULT_DINOV3_CHECKPOINT = Path(
-    "third_party/dinov3/checkpoints/dinov3_vitb16_pretrain_lvd1689m-73cec8be.pth"
-)
-
-
-class DINOv3BackboneAdapter(nn.Module):
-    """Expose the patch-token subset of the dynamic DINOv3 hub API."""
-
-    def __init__(self, module: nn.Module) -> None:
-        super().__init__()
-        dynamic_module = cast(Any, module)
-        embed_dim = dynamic_module.embed_dim
-        patch_size = dynamic_module.patch_size
-        if not isinstance(embed_dim, int):
-            raise TypeError("DINOv3 backbone embed_dim must be an integer.")
-        if isinstance(patch_size, tuple):
-            if len(patch_size) != 2 or len(set(patch_size)) != 1:
-                raise ValueError("DINOv3DETR requires square backbone patches.")
-            patch_size = patch_size[0]
-        if not isinstance(patch_size, int):
-            raise TypeError("DINOv3 backbone patch_size must be an integer.")
-
-        self.module = module
-        self.embed_dim = embed_dim
-        self.patch_size = patch_size
-
-    def forward_features(self, inputs: torch.Tensor) -> dict[str, torch.Tensor]:
-        outputs = cast(Any, self.module).forward_features(inputs)
-        if not isinstance(outputs, Mapping):
-            raise TypeError("DINOv3 forward_features must return a mapping.")
-        patch_tokens = outputs.get("x_norm_patchtokens")
-        if not isinstance(patch_tokens, torch.Tensor):
-            raise TypeError(
-                "DINOv3 forward_features did not return tensor patch tokens."
-            )
-        return {"x_norm_patchtokens": patch_tokens}
-
-
-def load_dinov3_backbone(
-    *,
-    repository_path: str | Path = _DEFAULT_DINOV3_REPOSITORY,
-    checkpoint_path: str | Path = _DEFAULT_DINOV3_CHECKPOINT,
-    backbone_name: str = "dinov3_vitb16",
-    strict: bool = True,
-) -> DINOv3BackboneAdapter:
-    """Load a DINOv3 backbone from the vendored repository and local weights."""
-    repository = resolve_project_path(repository_path)
-    checkpoint = resolve_project_path(checkpoint_path)
-    if not repository.is_dir():
-        raise FileNotFoundError(f"DINOv3 repository not found: {repository}")
-    if not checkpoint.is_file():
-        raise FileNotFoundError(f"DINOv3 checkpoint not found: {checkpoint}")
-
-    backbone: nn.Module = torch.hub.load(
-        str(repository),
-        backbone_name,
-        source="local",
-        pretrained=False,
-    )
-    state = torch.load(checkpoint, map_location="cpu", weights_only=True)
-    if isinstance(state, Mapping) and "model" in state:
-        state = state["model"]
-    if not isinstance(state, Mapping):
-        raise TypeError(
-            "DINOv3 checkpoint must contain a state-dict mapping, "
-            f"got {type(state).__name__}."
-        )
-
-    load_result = backbone.load_state_dict(state, strict=strict)
-    if strict and (load_result.missing_keys or load_result.unexpected_keys):
-        raise RuntimeError(
-            "Unexpected DINOv3 checkpoint load result: "
-            f"missing={load_result.missing_keys}, "
-            f"unexpected={load_result.unexpected_keys}."
-        )
-    return DINOv3BackboneAdapter(backbone)
 
 
 class MLP(nn.Module):
@@ -267,8 +193,8 @@ class DINOv3DETR(nn.Module):
         *,
         in_channels: int = 3,
         num_classes: int = 7,
-        backbone_repository_path: str | Path = _DEFAULT_DINOV3_REPOSITORY,
-        backbone_checkpoint_path: str | Path = _DEFAULT_DINOV3_CHECKPOINT,
+        backbone_repository_path: str | Path = DEFAULT_DINOV3_REPOSITORY,
+        backbone_checkpoint_path: str | Path = DEFAULT_DINOV3_CHECKPOINT,
         backbone_name: str = "dinov3_vitb16",
         backbone_strict: bool = True,
         freeze_backbone: bool = True,
@@ -398,11 +324,11 @@ class DINOv3DETR(nn.Module):
             num_classes=int(model_cfg.get("num_classes", 7)),
             backbone_repository_path=backbone_cfg.get(
                 "repository_path",
-                _DEFAULT_DINOV3_REPOSITORY,
+                DEFAULT_DINOV3_REPOSITORY,
             ),
             backbone_checkpoint_path=backbone_cfg.get(
                 "checkpoint_path",
-                _DEFAULT_DINOV3_CHECKPOINT,
+                DEFAULT_DINOV3_CHECKPOINT,
             ),
             backbone_name=str(backbone_cfg.get("name", "dinov3_vitb16")),
             backbone_strict=bool(backbone_cfg.get("strict", True)),

--- a/src/utils/models/loading/__init__.py
+++ b/src/utils/models/loading/__init__.py
@@ -7,11 +7,25 @@ from src.utils.models.loading.dino_backbone import (
     load_dino_backbone,
     resolve_dino_backbone_checkpoint_path,
 )
+from src.utils.models.loading.dinov3 import (
+    DEFAULT_DINOV3_CHECKPOINT,
+    DEFAULT_DINOV3_REPOSITORY,
+    DINOv3BackboneAdapter,
+    DINOv3TrainMode,
+    configure_dinov3_trainability,
+    load_dinov3_backbone,
+)
 
 __all__ = [
+    "DEFAULT_DINOV3_CHECKPOINT",
+    "DEFAULT_DINOV3_REPOSITORY",
     "DINOBackboneMetadata",
+    "DINOv3BackboneAdapter",
+    "DINOv3TrainMode",
     "LoadedDINOBackbone",
+    "configure_dinov3_trainability",
     "get_dino_backbone_metadata",
     "load_dino_backbone",
+    "load_dinov3_backbone",
     "resolve_dino_backbone_checkpoint_path",
 ]

--- a/src/utils/models/loading/dinov3.py
+++ b/src/utils/models/loading/dinov3.py
@@ -1,0 +1,163 @@
+"""Shared DINOv3 patch-token backbone loading and trainability helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import torch
+from torch import nn
+
+from src.utils.paths import resolve_project_path
+
+DEFAULT_DINOV3_REPOSITORY = Path("third_party/dinov3")
+DEFAULT_DINOV3_CHECKPOINT = Path(
+    "third_party/dinov3/checkpoints/dinov3_vitb16_pretrain_lvd1689m-73cec8be.pth"
+)
+DINOv3TrainMode = Literal["frozen", "last_n_blocks", "full"]
+
+
+class DINOv3BackboneAdapter(nn.Module):
+    """Expose validated patch tokens from the dynamic DINOv3 hub API."""
+
+    def __init__(self, module: nn.Module) -> None:
+        super().__init__()
+        dynamic_module = cast(Any, module)
+        embed_dim = dynamic_module.embed_dim
+        patch_size = dynamic_module.patch_size
+        if not isinstance(embed_dim, int):
+            raise TypeError("DINOv3 backbone embed_dim must be an integer.")
+        if isinstance(patch_size, tuple):
+            if len(patch_size) != 2 or len(set(patch_size)) != 1:
+                raise ValueError("DINOv3 patch size must be square.")
+            patch_size = patch_size[0]
+        if not isinstance(patch_size, int):
+            raise TypeError("DINOv3 backbone patch_size must be an integer.")
+        if patch_size <= 0:
+            raise ValueError("DINOv3 backbone patch_size must be positive.")
+
+        self.module = module
+        self.embed_dim = embed_dim
+        self.patch_size = patch_size
+
+    def forward_features(self, inputs: torch.Tensor) -> dict[str, torch.Tensor]:
+        """Return normalized patch tokens with shape ``(B, N, C)``."""
+        outputs = cast(Any, self.module).forward_features(inputs)
+        if not isinstance(outputs, Mapping):
+            raise TypeError("DINOv3 forward_features must return a mapping.")
+        patch_tokens = outputs.get("x_norm_patchtokens")
+        if not isinstance(patch_tokens, torch.Tensor):
+            raise TypeError(
+                "DINOv3 forward_features did not return tensor patch tokens."
+            )
+        if patch_tokens.ndim != 3:
+            raise ValueError(
+                "DINOv3 patch tokens must have shape (B, N, C), "
+                f"got {tuple(patch_tokens.shape)}."
+            )
+        if patch_tokens.shape[-1] != self.embed_dim:
+            raise ValueError(
+                "DINOv3 patch-token width does not match embed_dim: "
+                f"{patch_tokens.shape[-1]} != {self.embed_dim}."
+            )
+        return {"x_norm_patchtokens": patch_tokens}
+
+    def transformer_blocks(self) -> tuple[nn.Module, ...]:
+        """Return the backbone transformer blocks used by ``last_n_blocks``."""
+        blocks = getattr(self.module, "blocks", None)
+        if not isinstance(blocks, (nn.ModuleList, nn.Sequential)):
+            raise TypeError(
+                "DINOv3 backbone must expose blocks as ModuleList or Sequential "
+                "when train_mode='last_n_blocks'."
+            )
+        return tuple(blocks)
+
+
+def load_dinov3_backbone(
+    *,
+    repository_path: str | Path = DEFAULT_DINOV3_REPOSITORY,
+    checkpoint_path: str | Path = DEFAULT_DINOV3_CHECKPOINT,
+    backbone_name: str = "dinov3_vitb16",
+    strict: bool = True,
+) -> DINOv3BackboneAdapter:
+    """Load a DINOv3 backbone from the vendored repository and local weights."""
+    repository = resolve_project_path(repository_path)
+    checkpoint = resolve_project_path(checkpoint_path)
+    if not repository.is_dir():
+        raise FileNotFoundError(f"DINOv3 repository not found: {repository}")
+    if not checkpoint.is_file():
+        raise FileNotFoundError(f"DINOv3 checkpoint not found: {checkpoint}")
+
+    backbone: nn.Module = torch.hub.load(
+        str(repository),
+        backbone_name,
+        source="local",
+        pretrained=False,
+    )
+    state = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    if isinstance(state, Mapping) and "model" in state:
+        state = state["model"]
+    if not isinstance(state, Mapping):
+        raise TypeError(
+            "DINOv3 checkpoint must contain a state-dict mapping, "
+            f"got {type(state).__name__}."
+        )
+
+    load_result = backbone.load_state_dict(state, strict=strict)
+    if strict and (load_result.missing_keys or load_result.unexpected_keys):
+        raise RuntimeError(
+            "Unexpected DINOv3 checkpoint load result: "
+            f"missing={load_result.missing_keys}, "
+            f"unexpected={load_result.unexpected_keys}."
+        )
+    return DINOv3BackboneAdapter(backbone)
+
+
+def configure_dinov3_trainability(
+    backbone: DINOv3BackboneAdapter,
+    *,
+    train_mode: DINOv3TrainMode,
+    last_n_blocks: int = 0,
+) -> None:
+    """Configure ``frozen``, ``last_n_blocks``, or ``full`` backbone training."""
+    if train_mode not in {"frozen", "last_n_blocks", "full"}:
+        raise ValueError(
+            "DINOv3 train_mode must be one of "
+            "['frozen', 'last_n_blocks', 'full'], "
+            f"got {train_mode!r}."
+        )
+
+    backbone.requires_grad_(train_mode == "full")
+    if train_mode != "last_n_blocks":
+        if last_n_blocks < 0:
+            raise ValueError("last_n_blocks must be non-negative.")
+        return
+
+    blocks = backbone.transformer_blocks()
+    if last_n_blocks <= 0:
+        raise ValueError(
+            "last_n_blocks must be positive when train_mode='last_n_blocks'."
+        )
+    if last_n_blocks > len(blocks):
+        raise ValueError(
+            f"last_n_blocks={last_n_blocks} exceeds backbone depth={len(blocks)}."
+        )
+
+    backbone.requires_grad_(False)
+    for block in blocks[-last_n_blocks:]:
+        block.requires_grad_(True)
+    for name in ("norm", "norm_cls"):
+        final_norm = getattr(backbone.module, name, None)
+        if isinstance(final_norm, nn.Module):
+            final_norm.requires_grad_(True)
+
+
+__all__ = [
+    "DEFAULT_DINOV3_CHECKPOINT",
+    "DEFAULT_DINOV3_REPOSITORY",
+    "DINOv3BackboneAdapter",
+    "DINOv3TrainMode",
+    "configure_dinov3_trainability",
+    "load_dinov3_backbone",
+]

--- a/tests/tasks/test_ball_detection_dinov3_rope.py
+++ b/tests/tasks/test_ball_detection_dinov3_rope.py
@@ -1,0 +1,266 @@
+"""Contracts for the DINOv3 patch-token temporal ball detector."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+from torch import nn
+
+from src.tasks.ball_detection.models import build_ball_detection_model
+from src.tasks.ball_detection.models.dinov3_rope import (
+    DINOv3RoPEBallDetector,
+    build_spatiotemporal_positions,
+)
+from src.tasks.ball_detection.models.input_adapter import to_model_input
+from src.utils.models.loading import (
+    DINOv3BackboneAdapter,
+    DINOv3TrainMode,
+    configure_dinov3_trainability,
+    load_dinov3_backbone,
+)
+
+
+class _FakeDINOv3(nn.Module):
+    embed_dim = 24
+    patch_size = 16
+
+    def __init__(self, *, depth: int = 4) -> None:
+        super().__init__()
+        self.patch_embed = nn.Conv2d(
+            3,
+            self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+        )
+        self.blocks = nn.ModuleList(
+            nn.Sequential(
+                nn.LayerNorm(self.embed_dim),
+                nn.Linear(self.embed_dim, self.embed_dim),
+            )
+            for _ in range(depth)
+        )
+        self.norm = nn.LayerNorm(self.embed_dim)
+
+    def forward_features(self, inputs: torch.Tensor) -> Mapping[str, torch.Tensor]:
+        tokens = self.patch_embed(inputs).flatten(2).transpose(1, 2)
+        for block in self.blocks:
+            tokens = tokens + block(tokens)
+        return {"x_norm_patchtokens": self.norm(tokens)}
+
+
+def _make_model(
+    *,
+    num_frames: int = 1,
+    train_mode: DINOv3TrainMode = "frozen",
+    last_n_blocks: int = 0,
+    decoder_layers: int = 2,
+    gradient_checkpointing: bool = False,
+) -> DINOv3RoPEBallDetector:
+    return DINOv3RoPEBallDetector(
+        num_frames=num_frames,
+        image_size=(32, 48),
+        backbone=DINOv3BackboneAdapter(_FakeDINOv3()),
+        backbone_train_mode=train_mode,
+        backbone_last_n_blocks=last_n_blocks,
+        decoder_dim=24,
+        decoder_layers=decoder_layers,
+        decoder_heads=4,
+        decoder_ffn_dim=48,
+        decoder_rope_dim=6,
+        decoder_gradient_checkpointing=gradient_checkpointing,
+        head_min_channels=8,
+    )
+
+
+def test_spatiotemporal_positions_match_token_flatten_order() -> None:
+    positions = build_spatiotemporal_positions(
+        num_frames=2,
+        patch_height=2,
+        patch_width=3,
+    )
+    assert positions.tolist() == [
+        [0, 0, 0],
+        [0, 0, 1],
+        [0, 0, 2],
+        [0, 1, 0],
+        [0, 1, 1],
+        [0, 1, 2],
+        [1, 0, 0],
+        [1, 0, 1],
+        [1, 0, 2],
+        [1, 1, 0],
+        [1, 1, 1],
+        [1, 1, 2],
+    ]
+
+
+def test_forward_shape_supports_single_and_multiple_frames() -> None:
+    for num_frames in (1, 3):
+        model = _make_model(num_frames=num_frames)
+        logits = model(torch.randn(2, num_frames, 3, 32, 48))
+        assert logits.shape == (2, 1, num_frames, 32, 48)
+
+
+def test_default_resolution_head_outputs_288_by_512() -> None:
+    model = DINOv3RoPEBallDetector(
+        image_size=(288, 512),
+        backbone=DINOv3BackboneAdapter(_FakeDINOv3()),
+        decoder_dim=24,
+        decoder_layers=1,
+        decoder_heads=4,
+        decoder_ffn_dim=48,
+        decoder_rope_dim=6,
+        head_min_channels=8,
+    )
+    logits = model(torch.randn(1, 1, 3, 288, 512))
+    assert logits.shape == (1, 1, 1, 288, 512)
+
+
+def test_every_decoder_layer_receives_three_axis_rope() -> None:
+    model = _make_model(num_frames=2, decoder_layers=3)
+    observed: list[torch.Tensor] = []
+    handles = []
+
+    def capture(
+        _module: nn.Module,
+        _args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> None:
+        observed.append(kwargs["freqs_cis"])
+
+    for block in model.decoder:
+        handles.append(
+            block.attn.register_forward_pre_hook(capture, with_kwargs=True)
+        )
+    try:
+        model(torch.randn(1, 2, 3, 32, 48))
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    assert len(observed) == 3
+    assert all(freqs.shape == (12, 3) for freqs in observed)
+
+
+def test_backward_updates_decoder_but_not_frozen_backbone() -> None:
+    model = _make_model(num_frames=2, train_mode="frozen")
+    model.train()
+    model(torch.randn(1, 2, 3, 32, 48)).mean().backward()
+
+    assert all(parameter.grad is None for parameter in model.backbone.parameters())
+    assert model.token_projection.weight.grad is not None
+    assert any(parameter.grad is not None for parameter in model.heatmap_head.parameters())
+
+
+def test_decoder_gradient_checkpointing_supports_backward() -> None:
+    model = _make_model(
+        num_frames=2,
+        train_mode="full",
+        gradient_checkpointing=True,
+    )
+    model.train()
+    model(torch.randn(1, 2, 3, 32, 48)).mean().backward()
+    assert model.token_projection.weight.grad is not None
+    assert any(parameter.grad is not None for parameter in model.backbone.parameters())
+
+
+def test_last_n_blocks_trainability_is_explicit() -> None:
+    adapter = DINOv3BackboneAdapter(_FakeDINOv3(depth=4))
+    configure_dinov3_trainability(
+        adapter,
+        train_mode="last_n_blocks",
+        last_n_blocks=2,
+    )
+    blocks = adapter.transformer_blocks()
+    assert not any(parameter.requires_grad for parameter in blocks[0].parameters())
+    assert not any(parameter.requires_grad for parameter in blocks[1].parameters())
+    assert all(parameter.requires_grad for parameter in blocks[2].parameters())
+    assert all(parameter.requires_grad for parameter in blocks[3].parameters())
+    final_norm = cast(_FakeDINOv3, adapter.module).norm
+    assert all(parameter.requires_grad for parameter in final_norm.parameters())
+
+    configure_dinov3_trainability(adapter, train_mode="full")
+    assert all(parameter.requires_grad for parameter in adapter.parameters())
+
+
+def test_t1_state_dict_loads_strictly_into_multiframe_model() -> None:
+    phase1 = _make_model(num_frames=1)
+    phase2 = _make_model(num_frames=4)
+    load_result = phase2.load_state_dict(phase1.state_dict(), strict=True)
+    assert load_result.missing_keys == []
+    assert load_result.unexpected_keys == []
+
+
+def test_model_factory_and_btchw_input_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = OmegaConf.create(
+        {
+            "model": {
+                "name": "dinov3_rope",
+                "input_mode": "rgb",
+                "input_layout": "btchw",
+                "in_channels": 3,
+                "num_classes": 1,
+                "num_frames": 2,
+                "image_size": [32, 48],
+                "backbone": {
+                    "train_mode": "frozen",
+                    "last_n_blocks": 0,
+                },
+                "decoder": {
+                    "dim": 24,
+                    "num_layers": 1,
+                    "num_heads": 4,
+                    "ffn_dim": 48,
+                    "rope_dim": 6,
+                    "rope_base": [10000.0, 10000.0, 10000.0],
+                },
+                "heatmap_head": {"min_channels": 8},
+            }
+        }
+    )
+    monkeypatch.setattr(
+        "src.tasks.ball_detection.models.dinov3_rope.load_dinov3_backbone",
+        lambda **_kwargs: DINOv3BackboneAdapter(_FakeDINOv3()),
+    )
+    model = build_ball_detection_model(config)
+    images = torch.randn(1, 2, 3, 32, 48)
+    assert to_model_input(images, config.model) is images
+    assert model(images).shape == (1, 1, 2, 32, 48)
+
+
+def test_shared_loader_validates_checkpoint_strictly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "dinov3"
+    repository.mkdir()
+    checkpoint_path = tmp_path / "backbone.pth"
+    expected = _FakeDINOv3()
+    torch.save({"model": expected.state_dict()}, checkpoint_path)
+    monkeypatch.setattr(
+        torch.hub,
+        "load",
+        lambda *_args, **_kwargs: _FakeDINOv3(),
+    )
+
+    loaded = load_dinov3_backbone(
+        repository_path=repository,
+        checkpoint_path=checkpoint_path,
+        strict=True,
+    )
+    assert loaded.embed_dim == 24
+    assert loaded.patch_size == 16
+
+    invalid_checkpoint = tmp_path / "invalid.pth"
+    torch.save({"model": {}}, invalid_checkpoint)
+    with pytest.raises(RuntimeError):
+        load_dinov3_backbone(
+            repository_path=repository,
+            checkpoint_path=invalid_checkpoint,
+            strict=True,
+        )


### PR DESCRIPTION
## 概要

DINOv3 ViT-B/16のpatch tokenを全時刻・全空間で処理し、`(time, y, x)`の3軸RoPEを全decoder layerのQ/Kへ適用する時系列ball detectorを追加します。
`T=1`と可変`T`で同一parameter構造を維持し、frame-shared headから`288x512`のheatmap logitsを出力します。

## 変更内容

- `DINOv3RoPEBallDetector`、global bidirectional Transformer decoder、frame-shared upsampling headを追加
- DINOv3 loaderを`src/utils/models/loading/dinov3.py`へ共有化し、court detectionも同一loaderを利用
- `frozen` / `last_n_blocks` / `full`、decoder規模、3軸RoPE、dropout、gradient checkpointingをHydra config化
- RGBモデルの`btchw` input layoutをinput adapterへ追加
- shape、座標順序、全layer RoPE、gradient、strict checkpoint互換、実checkpoint loadをテスト

## 検証

- `python -m ruff check src tests`
- `python -m mypy --follow-imports=skip ...`（変更対象7ファイル）
- `python -m pytest tests/tasks/test_ball_detection_dinov3_rope.py -q`（10 passed）
- `python -m pytest tests/tasks -q`（69 passed）
- 実DINOv3 ViT-B/16 checkpoint smoke: `(1,2,3,288,512) -> (1,1,2,288,512)`、finite確認

## 関連Issue

- Closes #551
- References #549
- References #554

## 補足

- 時間位置はwindow内の整数順序のみを使用し、FPS/timestampは入力しません。
- `T=8`では4,608 tokenとなるため、decoder gradient checkpointingをconfigで有効化できます。
