### PR TITLE
fix(ball_detection): 評価時にvalidation splitのみ初期化する

### DIFF
--- a/src/tasks/ball_detection/data/tracknet_datamodule.py
+++ b/src/tasks/ball_detection/data/tracknet_datamodule.py
@@ -69,6 +69,7 @@ class TrackNetDataModule(pl.LightningDataModule):
                 split_file=self.train_split_file,
                 augmentation=train_aug,
             )
+        if stage in {"fit", "validate"} or stage is None:
             self.val_dataset = self.create_dataset(
                 split_name="val",
                 split_file=self.val_split_file,

--- a/src/tasks/ball_detection/data/web_datamodule.py
+++ b/src/tasks/ball_detection/data/web_datamodule.py
@@ -155,6 +155,7 @@ class WebBallDataModule(pl.LightningDataModule):
                 "train",
                 BallDetectionAugmentation(aug_cfg),
             )
+        if stage in {"fit", "validate"} or stage is None:
             self.val_dataset = self._create_dataset(
                 "val",
                 BallDetectionAugmentation.from_eval_config(aug_cfg),
@@ -189,7 +190,7 @@ class WebBallDataModule(pl.LightningDataModule):
     def _sample_windows(self, split: str) -> list[tuple[int, ...]]:
         assert self.store is not None
         if self.sample_mode == "temporal":
-            return self.store.temporal_windows(
+            windows: list[tuple[int, ...]] = self.store.temporal_windows(
                 split,
                 num_frames=self.num_frames,
                 frame_step=self.temporal_frame_step,
@@ -197,6 +198,7 @@ class WebBallDataModule(pl.LightningDataModule):
                 max_frame_gap=self.temporal_max_frame_gap,
                 sources=self.sources,
             )
+            return windows
 
         indices = self.store.split_indices(split, sources=self.sources)
         if split == "train" and self.train_negative_fraction is not None:

--- a/tests/tasks/test_dataset_loading_contracts.py
+++ b/tests/tasks/test_dataset_loading_contracts.py
@@ -155,6 +155,42 @@ def test_blcs_ball_trajectory_dataset_getitem_contract() -> None:
     assert sample["ball_uv"].shape[1] == sample["velocity_3d"].shape[0]
 
 
+def test_tracknet_datamodule_validate_stage_only_builds_val(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = {
+        "data": {
+            "split": {
+                "train_file": "train.txt",
+                "val_file": "val.txt",
+                "test_file": "test.txt",
+            },
+        },
+        "model": {"num_frames": 1},
+    }
+    datamodule = TrackNetDataModule(config)
+    calls: list[tuple[str, str]] = []
+    val_dataset = object()
+
+    def create_dataset(
+        *,
+        split_name: str,
+        split_file: str | Path,
+        augmentation: object,
+    ) -> object:
+        del augmentation
+        calls.append((split_name, str(split_file)))
+        return val_dataset
+
+    monkeypatch.setattr(datamodule, "create_dataset", create_dataset)
+    datamodule.setup("validate")
+
+    assert calls == [("val", "val.txt")]
+    assert datamodule.train_dataset is None
+    assert datamodule.val_dataset is val_dataset
+    assert datamodule.test_dataset is None
+
+
 def test_ball_detection_dataset_getitem_contract() -> None:
     data_dir = REPO_ROOT / "data/tennis/tracknet"
     split_file = REPO_ROOT / "src/tasks/ball_detection/configs/data/splits/train.txt"

--- a/tests/tasks/test_web_ball_datamodule.py
+++ b/tests/tasks/test_web_ball_datamodule.py
@@ -218,6 +218,16 @@ def test_web_datamodule_sample_contract(tmp_path: Path) -> None:
     assert tuple(batch["images"].shape) == (2, 4, 3, 64, 96)
 
 
+def test_web_datamodule_validate_stage_does_not_build_train(tmp_path: Path) -> None:
+    _build_store(tmp_path)
+    datamodule = build_ball_detection_datamodule(_config(tmp_path))
+    datamodule.setup("validate")
+
+    assert datamodule.train_dataset is None
+    assert datamodule.val_dataset is not None
+    assert len(datamodule.val_dataset) == 2
+
+
 def test_web_datamodule_temporal_windows(tmp_path: Path) -> None:
     _build_store(tmp_path)
     config = _config(


### PR DESCRIPTION
## 概要

ball detection の評価処理から `setup("validate")` を使用できるよう、TrackNet/Web の DataModule に validation-only 初期化を追加します。
train split が存在しない、またはアクセスさせたくない評価環境でも val split のみを構築できます。

## 変更内容

- `TrackNetDataModule.setup("validate")` で val dataset のみを構築
- `WebBallDataModule.setup("validate")` で val dataset のみを構築
- 両 DataModule で train/test dataset が初期化されないことをテスト
- Web temporal window の戻り値型を明示し、変更ファイル単位の mypy 検証に対応

## 検証

- `.venv/bin/python -m pytest tests/tasks/test_web_ball_datamodule.py tests/tasks/test_dataset_loading_contracts.py -q`（7 passed, 6 skipped）
- `.venv/bin/python -m pytest tests/tasks/test_web_ball_datamodule.py::test_web_datamodule_validate_stage_does_not_build_train tests/tasks/test_dataset_loading_contracts.py::test_tracknet_datamodule_validate_stage_only_builds_val -q`（2 passed）
- `pre-commit run --files ...`（ruff / mypy passed）

## 関連Issue

- Closes #554
- References #543
- References #553
