### PR TITLE
feat(ball_detection): 新旧モデルの自動評価パイプラインを追加

### DIFF
--- a/src/tasks/ball_detection/README.md
+++ b/src/tasks/ball_detection/README.md
@@ -161,6 +161,16 @@ YouTube動画から学習データを作る3ステップ。CLIは `scripts/youtu
 
 複数の予測ピークと複数GTをハンガリアン法で対応付け（距離閾値4.0px）、`precision` / `recall` / `f1` / `mean_distance_px` を `outputs/ball_detection/eval/` に出力します。
 
+複数checkpointを同一条件で比較する場合はmanifest評価を使用します。
+
+```bash
+.venv/bin/python -m src.tasks.ball_detection.scripts.evaluate_manifest
+.venv/bin/python -m src.tasks.ball_detection.scripts.evaluate_manifest \
+    manifest_path=src/tasks/ball_detection/configs/evaluation/ball_detector_comparison.yaml
+```
+
+manifestはcheckpoint、`expected_model_name`、TrackNet/Webの固定`val`/`test` split、`architecture-controlled` / `full-strategy`カテゴリを列挙します。未作成checkpointは`enabled: false`のまま定義できます。実行結果はjob単位のJSON、`summary.json`、`comparison.csv`、カテゴリ別`comparison.md`として保存されます。全体/source別の検出指標、明示的負例frame FPR、latency、throughput、peak VRAM、checkpoint/config/git/split/schema provenanceを記録します。成功済みjobはfingerprintが一致すれば再利用され、失敗または変更されたjobだけが再実行されます。
+
 ## 可視化
 
 ```bash

--- a/src/tasks/ball_detection/configs/evaluate_manifest.yaml
+++ b/src/tasks/ball_detection/configs/evaluate_manifest.yaml
@@ -1,0 +1,13 @@
+manifest_path: src/tasks/ball_detection/configs/evaluation/ball_detector_comparison.yaml
+
+# null uses values from the manifest.
+output_dir: null
+resume: null
+fail_fast: null
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/tasks/ball_detection/configs/evaluation/ball_detector_comparison.yaml
+++ b/src/tasks/ball_detection/configs/evaluation/ball_detector_comparison.yaml
@@ -1,0 +1,57 @@
+schema: ball_detection_evaluation_manifest_v1
+output_dir: outputs/ball_detection/evaluation
+device: auto
+resume: true
+fail_fast: false
+
+metrics:
+  peak_threshold: 0.5
+  ball_distance_threshold: 4.0
+  nms_kernel: 9
+  max_predictions_per_frame: 8
+
+performance:
+  warmup_batches: 1
+  max_batches_per_split: null
+
+datasets:
+  tracknet:
+    config: rgb_sequence
+    splits: [val, test]
+    overrides:
+      batch_size: 4
+      num_workers: 4
+  web:
+    config: web_frames
+    splits: [test]
+    overrides:
+      batch_size: 8
+      num_workers: 4
+      sampling:
+        mode: static
+
+models:
+  - id: convnext-tracknet
+    category: architecture-controlled
+    checkpoint: outputs/ball_detection/convnext/logs/version_0/checkpoints/last.ckpt
+    expected_model_name: conv_next_unet
+    datasets: [tracknet]
+    strict: true
+
+  # Enable after a TrackNet-only DINOv3 run is available.
+  - id: dinov3-tracknet
+    enabled: false
+    category: architecture-controlled
+    checkpoint: outputs/ball_detection/dinov3_rope_tracknet/checkpoints/last.ckpt
+    expected_model_name: dinov3_rope
+    datasets: [tracknet]
+    strict: true
+
+  # Enable after Web-static + temporal training is available.
+  - id: dinov3-full
+    enabled: false
+    category: full-strategy
+    checkpoint: outputs/ball_detection/dinov3_rope_full/checkpoints/last.ckpt
+    expected_model_name: dinov3_rope
+    datasets: [tracknet, web]
+    strict: true

--- a/src/tasks/ball_detection/evaluation/__init__.py
+++ b/src/tasks/ball_detection/evaluation/__init__.py
@@ -1,0 +1,17 @@
+"""Automated, reproducible evaluation for ball-detection checkpoints."""
+
+from src.tasks.ball_detection.evaluation.contracts import (
+    DatasetSpec,
+    EvaluationManifest,
+    ModelSpec,
+    load_evaluation_manifest,
+)
+from src.tasks.ball_detection.evaluation.runner import EvaluationPipeline
+
+__all__ = [
+    "DatasetSpec",
+    "EvaluationManifest",
+    "EvaluationPipeline",
+    "ModelSpec",
+    "load_evaluation_manifest",
+]

--- a/src/tasks/ball_detection/evaluation/adapters.py
+++ b/src/tasks/ball_detection/evaluation/adapters.py
@@ -1,0 +1,112 @@
+"""Common prediction adapters for heterogeneous ball-detector checkpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from src.tasks.ball_detection.models.input_adapter import to_model_input
+from src.tasks.ball_detection.training.lightning_module import (
+    BallDetectionLightningModule,
+)
+
+
+class BallPredictionAdapter(Protocol):
+    """Minimal prediction contract consumed by the evaluation runner."""
+
+    device: torch.device
+
+    def predict_heatmaps(
+        self,
+        images: Tensor,
+        *,
+        target_size_hw: tuple[int, int],
+    ) -> Tensor:
+        """Return probability heatmaps with shape ``(B, T, H, W)``."""
+        ...
+
+
+class LightningBallPredictionAdapter:
+    """Adapt any registered Lightning ball detector to one heatmap contract."""
+
+    def __init__(
+        self,
+        module: BallDetectionLightningModule,
+        *,
+        device: torch.device,
+    ) -> None:
+        self.module = module.to(device).eval()
+        self.device = device
+        self.model_config = module.config.get("model", {}) or {}
+
+    @classmethod
+    def load(
+        cls,
+        checkpoint_path: str | Path,
+        *,
+        device: torch.device,
+        strict: bool,
+        weights_only: bool,
+    ) -> LightningBallPredictionAdapter:
+        """Load a Lightning checkpoint and expose the common adapter."""
+        module = BallDetectionLightningModule.load_from_checkpoint(
+            str(checkpoint_path),
+            map_location=device,
+            strict=strict,
+            weights_only=weights_only,
+        )
+        return cls(module, device=device)
+
+    def predict_heatmaps(
+        self,
+        images: Tensor,
+        *,
+        target_size_hw: tuple[int, int],
+    ) -> Tensor:
+        """Run model-specific input adaptation and validate output shape."""
+        if images.ndim != 5:
+            raise ValueError(
+                "Evaluation images must have shape (B, T, C, H, W), "
+                f"got {tuple(images.shape)}."
+            )
+        images = images.to(self.device, non_blocking=True)
+        model_input = to_model_input(images, self.model_config)
+        logits = self.module.model(model_input)
+        expected_prefix = (images.shape[0], 1, images.shape[1])
+        if logits.ndim != 5 or tuple(logits.shape[:3]) != expected_prefix:
+            raise ValueError(
+                "Ball detector output shape mismatch: expected prefix "
+                f"{expected_prefix}, got {tuple(logits.shape)}."
+            )
+        logits = logits.squeeze(1)
+        if logits.shape[-2:] != target_size_hw:
+            batch_size, num_frames = logits.shape[:2]
+            logits = F.interpolate(
+                logits.reshape(batch_size * num_frames, 1, *logits.shape[-2:]),
+                size=target_size_hw,
+                mode="bilinear",
+                align_corners=False,
+            ).reshape(batch_size, num_frames, *target_size_hw)
+        return torch.sigmoid(logits)
+
+
+def resolve_evaluation_device(device: str) -> torch.device:
+    """Resolve ``auto`` and fail clearly for unavailable explicit CUDA."""
+    normalized = device.strip().lower()
+    if normalized == "auto":
+        return torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    resolved = torch.device(device)
+    if resolved.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError(f"CUDA evaluation requested but unavailable: {device}")
+    return resolved
+
+
+__all__ = [
+    "BallPredictionAdapter",
+    "LightningBallPredictionAdapter",
+    "resolve_evaluation_device",
+]

--- a/src/tasks/ball_detection/evaluation/configuration.py
+++ b/src/tasks/ball_detection/evaluation/configuration.py
@@ -1,0 +1,144 @@
+"""Checkpoint and dataset configuration resolution for evaluation jobs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import torch
+from omegaconf import DictConfig, OmegaConf
+
+from src.tasks.ball_detection.evaluation.contracts import DatasetSpec, MetricsSpec
+from src.utils.paths import resolve_project_path
+
+_CONFIG_ROOT = Path("src/tasks/ball_detection/configs")
+
+
+def read_checkpoint_config(checkpoint_path: str | Path) -> DictConfig:
+    """Read the saved Hydra config without constructing the model."""
+    resolved = resolve_project_path(checkpoint_path)
+    if not resolved.is_file():
+        raise FileNotFoundError(f"Checkpoint not found: {resolved}")
+    try:
+        checkpoint = torch.load(
+            resolved,
+            map_location="cpu",
+            weights_only=False,
+            mmap=True,
+        )
+    except RuntimeError as error:
+        if "mmap" not in str(error).lower():
+            raise
+        checkpoint = torch.load(
+            resolved,
+            map_location="cpu",
+            weights_only=False,
+        )
+    if not isinstance(checkpoint, dict):
+        raise TypeError("Lightning checkpoint root must be a mapping.")
+    hyper_parameters = checkpoint.get("hyper_parameters")
+    if not isinstance(hyper_parameters, dict):
+        raise ValueError("Checkpoint does not contain hyper_parameters.")
+    config = hyper_parameters.get("config")
+    if config is None:
+        raise ValueError("Checkpoint hyper_parameters do not contain config.")
+    return OmegaConf.create(config)
+
+
+def validate_checkpoint_model_name(
+    checkpoint_config: DictConfig,
+    *,
+    expected_model_name: str,
+) -> str:
+    """Fail early when a manifest entry names the wrong architecture."""
+    actual_name = str((checkpoint_config.get("model", {}) or {}).get("name", ""))
+    if actual_name != expected_model_name:
+        raise ValueError(
+            "Checkpoint/model config mismatch: "
+            f"expected model.name={expected_model_name!r}, got {actual_name!r}."
+        )
+    return actual_name
+
+
+def build_evaluation_config(
+    *,
+    checkpoint_config: DictConfig,
+    dataset_spec: DatasetSpec,
+    metrics_spec: MetricsSpec,
+) -> DictConfig:
+    """Combine checkpoint model settings with a fixed evaluation dataset."""
+    data_config = load_data_config(
+        dataset_spec.config,
+        overrides=dataset_spec.overrides,
+    )
+    evaluation_config = OmegaConf.create(
+        OmegaConf.to_container(checkpoint_config, resolve=True)
+    )
+    evaluation_config.data = data_config
+    evaluation_config.metrics = OmegaConf.create(
+        {
+            "peak_threshold": metrics_spec.peak_threshold,
+            "ball_distance_threshold": metrics_spec.ball_distance_threshold,
+            "nms_kernel": metrics_spec.nms_kernel,
+            "max_predictions_per_frame": metrics_spec.max_predictions_per_frame,
+        }
+    )
+    return evaluation_config
+
+
+def load_data_config(
+    config_name_or_path: str,
+    *,
+    overrides: dict[str, Any] | None = None,
+) -> DictConfig:
+    """Load one ball-detection data config including its augmentation default."""
+    candidate = Path(config_name_or_path)
+    if candidate.suffix:
+        config_path = resolve_project_path(candidate)
+    else:
+        config_path = resolve_project_path(
+            _CONFIG_ROOT / "data" / f"{config_name_or_path}.yaml"
+        )
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Data config not found: {config_path}")
+
+    loaded = OmegaConf.load(config_path)
+    container = OmegaConf.to_container(loaded, resolve=False)
+    if not isinstance(container, dict):
+        raise TypeError(f"Data config must be a mapping: {config_path}")
+    defaults = container.pop("defaults", [])
+    data_config = OmegaConf.create(container)
+
+    augmentation_name = _augmentation_default_name(defaults)
+    if augmentation_name is not None:
+        augmentation_path = config_path.parent / "augmentation" / (
+            f"{augmentation_name}.yaml"
+        )
+        if not augmentation_path.is_file():
+            raise FileNotFoundError(
+                f"Data augmentation config not found: {augmentation_path}"
+            )
+        data_config = OmegaConf.merge(
+            {"augmentation": OmegaConf.load(augmentation_path)},
+            data_config,
+        )
+    if overrides:
+        data_config = OmegaConf.merge(data_config, OmegaConf.create(overrides))
+    return data_config
+
+
+def _augmentation_default_name(defaults: object) -> str | None:
+    if not isinstance(defaults, list):
+        raise TypeError("data config defaults must be a list.")
+    for entry in defaults:
+        if isinstance(entry, dict) and "augmentation" in entry:
+            return str(entry["augmentation"])
+    return None
+
+
+__all__ = [
+    "build_evaluation_config",
+    "load_data_config",
+    "read_checkpoint_config",
+    "validate_checkpoint_model_name",
+]

--- a/src/tasks/ball_detection/evaluation/contracts.py
+++ b/src/tasks/ball_detection/evaluation/contracts.py
@@ -1,0 +1,285 @@
+"""Typed manifest contracts for automated ball-detector evaluation."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from omegaconf import OmegaConf
+
+from src.utils.paths import resolve_project_path
+
+EvaluationCategory = Literal["architecture-controlled", "full-strategy"]
+_CATEGORIES = {"architecture-controlled", "full-strategy"}
+_ALLOWED_SPLITS = {"val", "test"}
+_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+@dataclass(frozen=True)
+class MetricsSpec:
+    """Detection thresholds shared by every comparison job."""
+
+    peak_threshold: float = 0.5
+    ball_distance_threshold: float = 4.0
+    nms_kernel: int = 9
+    max_predictions_per_frame: int = 8
+
+
+@dataclass(frozen=True)
+class PerformanceSpec:
+    """Inference timing controls."""
+
+    warmup_batches: int = 1
+    max_batches_per_split: int | None = None
+
+
+@dataclass(frozen=True)
+class DatasetSpec:
+    """One fixed evaluation dataset and its allowed splits."""
+
+    id: str
+    config: str
+    splits: tuple[str, ...]
+    overrides: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """One checkpoint and the datasets on which it must be evaluated."""
+
+    id: str
+    category: EvaluationCategory
+    checkpoint: Path
+    expected_model_name: str
+    datasets: tuple[str, ...]
+    enabled: bool = True
+    strict: bool = True
+    weights_only: bool = False
+
+
+@dataclass(frozen=True)
+class EvaluationManifest:
+    """Top-level evaluation manifest."""
+
+    schema: str
+    output_dir: Path
+    device: str
+    resume: bool
+    fail_fast: bool
+    metrics: MetricsSpec
+    performance: PerformanceSpec
+    datasets: dict[str, DatasetSpec]
+    models: tuple[ModelSpec, ...]
+
+
+def load_evaluation_manifest(path: str | Path) -> EvaluationManifest:
+    """Load and validate an evaluation manifest from YAML."""
+    manifest_path = resolve_project_path(path)
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Evaluation manifest not found: {manifest_path}")
+    raw = OmegaConf.to_container(OmegaConf.load(manifest_path), resolve=True)
+    if not isinstance(raw, dict):
+        raise TypeError("Evaluation manifest root must be a mapping.")
+
+    schema = str(raw.get("schema", ""))
+    if schema != "ball_detection_evaluation_manifest_v1":
+        raise ValueError(
+            "Unsupported evaluation manifest schema: "
+            f"{schema!r}; expected 'ball_detection_evaluation_manifest_v1'."
+        )
+    datasets = _parse_datasets(raw.get("datasets"))
+    models = _parse_models(raw.get("models"), datasets)
+    metrics_raw = _mapping(raw.get("metrics", {}), name="metrics")
+    performance_raw = _mapping(raw.get("performance", {}), name="performance")
+    metrics = MetricsSpec(
+        peak_threshold=float(metrics_raw.get("peak_threshold", 0.5)),
+        ball_distance_threshold=float(
+            metrics_raw.get("ball_distance_threshold", 4.0)
+        ),
+        nms_kernel=int(metrics_raw.get("nms_kernel", 9)),
+        max_predictions_per_frame=int(
+            metrics_raw.get("max_predictions_per_frame", 8)
+        ),
+    )
+    performance = PerformanceSpec(
+        warmup_batches=int(performance_raw.get("warmup_batches", 1)),
+        max_batches_per_split=_optional_int(
+            performance_raw.get("max_batches_per_split")
+        ),
+    )
+    _validate_thresholds(metrics, performance)
+
+    output_dir = resolve_project_path(
+        str(raw.get("output_dir", "outputs/ball_detection/evaluation"))
+    )
+    return EvaluationManifest(
+        schema=schema,
+        output_dir=output_dir,
+        device=str(raw.get("device", "auto")),
+        resume=bool(raw.get("resume", True)),
+        fail_fast=bool(raw.get("fail_fast", False)),
+        metrics=metrics,
+        performance=performance,
+        datasets=datasets,
+        models=models,
+    )
+
+
+def _parse_datasets(value: object) -> dict[str, DatasetSpec]:
+    raw_datasets = _mapping(value, name="datasets")
+    if not raw_datasets:
+        raise ValueError("Evaluation manifest must define at least one dataset.")
+    parsed: dict[str, DatasetSpec] = {}
+    for dataset_id, raw_spec in raw_datasets.items():
+        _validate_identifier(str(dataset_id), name="dataset id")
+        spec = _mapping(raw_spec, name=f"datasets.{dataset_id}")
+        splits = tuple(str(split) for split in _list(spec.get("splits"), "splits"))
+        if not splits:
+            raise ValueError(f"datasets.{dataset_id}.splits must not be empty.")
+        unsupported = set(splits).difference(_ALLOWED_SPLITS)
+        if unsupported:
+            raise ValueError(
+                f"datasets.{dataset_id} contains forbidden splits "
+                f"{sorted(unsupported)}; evaluation may only access val/test."
+            )
+        if len(set(splits)) != len(splits):
+            raise ValueError(f"datasets.{dataset_id}.splits contains duplicates.")
+        overrides = _mapping(
+            spec.get("overrides", {}),
+            name=f"datasets.{dataset_id}.overrides",
+        )
+        parsed[str(dataset_id)] = DatasetSpec(
+            id=str(dataset_id),
+            config=str(spec.get("config", "")).strip(),
+            splits=splits,
+            overrides=overrides,
+        )
+        if not parsed[str(dataset_id)].config:
+            raise ValueError(f"datasets.{dataset_id}.config must not be empty.")
+    return parsed
+
+
+def _parse_models(
+    value: object,
+    datasets: dict[str, DatasetSpec],
+) -> tuple[ModelSpec, ...]:
+    raw_models = _list(value, "models")
+    if not raw_models:
+        raise ValueError("Evaluation manifest must define at least one model.")
+    parsed: list[ModelSpec] = []
+    seen_ids: set[str] = set()
+    for index, raw_model in enumerate(raw_models):
+        spec = _mapping(raw_model, name=f"models[{index}]")
+        model_id = str(spec.get("id", "")).strip()
+        if not model_id:
+            raise ValueError(f"models[{index}].id must not be empty.")
+        _validate_identifier(model_id, name=f"models[{index}].id")
+        if model_id in seen_ids:
+            raise ValueError(f"Duplicate model id: {model_id!r}.")
+        seen_ids.add(model_id)
+        category = str(spec.get("category", ""))
+        if category not in _CATEGORIES:
+            raise ValueError(
+                f"models[{index}].category must be one of {sorted(_CATEGORIES)}, "
+                f"got {category!r}."
+            )
+        dataset_ids = tuple(
+            str(dataset_id)
+            for dataset_id in _list(spec.get("datasets"), "datasets")
+        )
+        if not dataset_ids:
+            raise ValueError(f"models[{index}].datasets must not be empty.")
+        if len(set(dataset_ids)) != len(dataset_ids):
+            raise ValueError(f"models[{index}].datasets contains duplicates.")
+        missing = set(dataset_ids).difference(datasets)
+        if missing:
+            raise ValueError(
+                f"models[{index}] references unknown datasets {sorted(missing)}."
+            )
+        checkpoint_value = str(spec.get("checkpoint", "")).strip()
+        if not checkpoint_value:
+            raise ValueError(f"models[{index}].checkpoint must not be empty.")
+        checkpoint = resolve_project_path(checkpoint_value)
+        parsed.append(
+            ModelSpec(
+                id=model_id,
+                category=cast(EvaluationCategory, category),
+                checkpoint=checkpoint,
+                expected_model_name=str(
+                    spec.get("expected_model_name", "")
+                ).strip(),
+                datasets=dataset_ids,
+                enabled=bool(spec.get("enabled", True)),
+                strict=bool(spec.get("strict", True)),
+                weights_only=bool(spec.get("weights_only", False)),
+            )
+        )
+        if not parsed[-1].expected_model_name:
+            raise ValueError(
+                f"models[{index}].expected_model_name must not be empty."
+            )
+    return tuple(parsed)
+
+
+def _validate_thresholds(
+    metrics: MetricsSpec,
+    performance: PerformanceSpec,
+) -> None:
+    if metrics.peak_threshold < 0:
+        raise ValueError("metrics.peak_threshold must be non-negative.")
+    if metrics.ball_distance_threshold < 0:
+        raise ValueError("metrics.ball_distance_threshold must be non-negative.")
+    if metrics.nms_kernel <= 0 or metrics.nms_kernel % 2 == 0:
+        raise ValueError("metrics.nms_kernel must be a positive odd integer.")
+    if metrics.max_predictions_per_frame <= 0:
+        raise ValueError("metrics.max_predictions_per_frame must be positive.")
+    if performance.warmup_batches < 0:
+        raise ValueError("performance.warmup_batches must be non-negative.")
+    if (
+        performance.max_batches_per_split is not None
+        and performance.max_batches_per_split <= 0
+    ):
+        raise ValueError(
+            "performance.max_batches_per_split must be positive when set."
+        )
+
+
+def _mapping(value: object, *, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{name} must be a mapping.")
+    return {str(key): item for key, item in value.items()}
+
+
+def _list(value: object, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise TypeError(f"{name} must be a list.")
+    return value
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, (int, str)):
+        raise TypeError("Expected an integer or null.")
+    return int(value)
+
+
+def _validate_identifier(value: str, *, name: str) -> None:
+    if not _ID_PATTERN.fullmatch(value):
+        raise ValueError(
+            f"{name} must contain only letters, digits, '.', '_', and '-', "
+            f"got {value!r}."
+        )
+
+
+__all__ = [
+    "DatasetSpec",
+    "EvaluationCategory",
+    "EvaluationManifest",
+    "MetricsSpec",
+    "ModelSpec",
+    "PerformanceSpec",
+    "load_evaluation_manifest",
+]

--- a/src/tasks/ball_detection/evaluation/dataset_provenance.py
+++ b/src/tasks/ball_detection/evaluation/dataset_provenance.py
@@ -1,0 +1,106 @@
+"""Sequential source labels and split provenance for evaluation datasets."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from torch.utils.data import Dataset
+
+from src.tasks.ball_detection.data.web_datamodule import WebBallDetectionDataset
+from src.utils.io import load_json
+from src.utils.paths import resolve_project_path
+
+
+class SequentialSourceResolver:
+    """Recover source names for val/test loaders that use sequential sampling."""
+
+    def __init__(self, dataset: Dataset[Any], *, default_source: str) -> None:
+        self.dataset = dataset
+        self.default_source = default_source
+        self.cursor = 0
+
+    def next(self, batch_size: int) -> list[str]:
+        """Return source names for the next sequential batch."""
+        start = self.cursor
+        stop = start + batch_size
+        if stop > len(self.dataset):
+            raise RuntimeError(
+                "Evaluation dataloader yielded more samples than its dataset."
+            )
+        self.cursor = stop
+        if not isinstance(self.dataset, WebBallDetectionDataset):
+            return [self.default_source] * batch_size
+
+        sources: list[str] = []
+        for window in self.dataset.windows[start:stop]:
+            indices = tuple(int(frame_name) for frame_name in window.frame_names)
+            window_sources = {
+                self.dataset.store.source_name(index) for index in indices
+            }
+            if len(window_sources) != 1:
+                raise RuntimeError(
+                    "A web evaluation window spans multiple sources: "
+                    f"{sorted(window_sources)}."
+                )
+            sources.append(next(iter(window_sources)))
+        return sources
+
+
+def build_split_provenance(
+    *,
+    data_config: Any,
+    split: str,
+    dataset: Dataset[Any],
+) -> dict[str, Any]:
+    """Record schema and fixed split identity without reading train data."""
+    source = str(data_config.get("source", "tracknet"))
+    data_dir = resolve_project_path(str(data_config.get("data_dir", "")))
+    if isinstance(dataset, WebBallDetectionDataset):
+        manifest_path = data_dir / "manifest.json"
+        manifest = load_json(manifest_path)
+        if not isinstance(manifest, dict):
+            raise TypeError(f"Web manifest must be a mapping: {manifest_path}")
+        return {
+            "source": source,
+            "schema": str(manifest.get("schema", dataset.store.schema_version)),
+            "data_dir": str(data_dir),
+            "split": split,
+            "manifest_path": str(manifest_path),
+            "manifest_sha256": sha256_file(manifest_path),
+            "sample_count": len(dataset),
+        }
+
+    split_config = data_config.get("split", {}) or {}
+    split_key = f"{split}_file"
+    split_path = resolve_project_path(str(split_config.get(split_key, "")))
+    if not split_path.is_file():
+        raise FileNotFoundError(
+            f"Configured {split} split file not found: {split_path}"
+        )
+    return {
+        "source": source,
+        "schema": "tracknet_label_csv_v1",
+        "data_dir": str(data_dir),
+        "split": split,
+        "split_file": str(split_path),
+        "split_sha256": sha256_file(split_path),
+        "sample_count": len(dataset),
+    }
+
+
+def sha256_file(path: str | Path) -> str:
+    """Return a streaming SHA-256 digest for provenance and resume checks."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+__all__ = [
+    "SequentialSourceResolver",
+    "build_split_provenance",
+    "sha256_file",
+]

--- a/src/tasks/ball_detection/evaluation/evaluator.py
+++ b/src/tasks/ball_detection/evaluation/evaluator.py
@@ -1,0 +1,324 @@
+"""Execute one checkpoint/dataset/split evaluation job."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Protocol
+
+import pytorch_lightning as pl
+import torch
+from omegaconf import DictConfig, OmegaConf
+from torch import Tensor
+from torch.utils.data import DataLoader, SequentialSampler
+
+from src.tasks.ball_detection.data import build_ball_detection_datamodule
+from src.tasks.ball_detection.evaluation.adapters import (
+    BallPredictionAdapter,
+    LightningBallPredictionAdapter,
+)
+from src.tasks.ball_detection.evaluation.configuration import (
+    build_evaluation_config,
+    read_checkpoint_config,
+    validate_checkpoint_model_name,
+)
+from src.tasks.ball_detection.evaluation.contracts import (
+    DatasetSpec,
+    EvaluationManifest,
+    ModelSpec,
+)
+from src.tasks.ball_detection.evaluation.dataset_provenance import (
+    SequentialSourceResolver,
+    build_split_provenance,
+    sha256_file,
+)
+from src.tasks.ball_detection.evaluation.metrics import StratifiedBallMetrics
+
+
+class JobEvaluator(Protocol):
+    """Injectable interface used by the resumable pipeline."""
+
+    def evaluate(
+        self,
+        *,
+        model: ModelSpec,
+        dataset: DatasetSpec,
+        split: str,
+        manifest: EvaluationManifest,
+    ) -> dict[str, Any]:
+        """Evaluate one job and return a JSON-compatible payload."""
+        ...
+
+
+class DefaultJobEvaluator:
+    """Load registered Lightning models and evaluate fixed val/test splits."""
+
+    def __init__(self, *, device: torch.device) -> None:
+        self.device = device
+        self._checkpoint_configs: dict[Path, DictConfig] = {}
+        self._checkpoint_hashes: dict[Path, str] = {}
+        self._adapter_key: tuple[Path, bool, bool] | None = None
+        self._adapter: LightningBallPredictionAdapter | None = None
+
+    def evaluate(
+        self,
+        *,
+        model: ModelSpec,
+        dataset: DatasetSpec,
+        split: str,
+        manifest: EvaluationManifest,
+    ) -> dict[str, Any]:
+        checkpoint_config = self._checkpoint_config(model.checkpoint)
+        validate_checkpoint_model_name(
+            checkpoint_config,
+            expected_model_name=model.expected_model_name,
+        )
+        evaluation_config = build_evaluation_config(
+            checkpoint_config=checkpoint_config,
+            dataset_spec=dataset,
+            metrics_spec=manifest.metrics,
+        )
+        datamodule = build_ball_detection_datamodule(evaluation_config)
+        dataloader = build_evaluation_dataloader(datamodule, split)
+        if not isinstance(dataloader.sampler, SequentialSampler):
+            raise RuntimeError(
+                "Evaluation dataloaders must use sequential sampling to preserve "
+                "source provenance."
+            )
+
+        adapter = self._prediction_adapter(model)
+        split_result = evaluate_dataloader(
+            adapter=adapter,
+            dataloader=dataloader,
+            data_config=evaluation_config.data,
+            split=split,
+            manifest=manifest,
+        )
+        checkpoint_hash = self._checkpoint_hash(model.checkpoint)
+        split_result["provenance"] = {
+            "command": " ".join(sys.argv),
+            "git_revision": _git_revision(),
+            "git_dirty": _git_dirty(),
+            "checkpoint_path": str(model.checkpoint),
+            "checkpoint_sha256": checkpoint_hash,
+            "model_name": model.expected_model_name,
+            "resolved_config": OmegaConf.to_container(
+                evaluation_config,
+                resolve=True,
+            ),
+            "dataset": split_result.pop("dataset_provenance"),
+        }
+        return split_result
+
+    def _checkpoint_config(self, path: Path) -> DictConfig:
+        if path not in self._checkpoint_configs:
+            self._checkpoint_configs[path] = read_checkpoint_config(path)
+        return self._checkpoint_configs[path]
+
+    def _checkpoint_hash(self, path: Path) -> str:
+        if path not in self._checkpoint_hashes:
+            self._checkpoint_hashes[path] = sha256_file(path)
+        return self._checkpoint_hashes[path]
+
+    def _prediction_adapter(
+        self,
+        model: ModelSpec,
+    ) -> LightningBallPredictionAdapter:
+        key = (model.checkpoint, model.strict, model.weights_only)
+        if self._adapter is None or self._adapter_key != key:
+            self._adapter = None
+            if self.device.type == "cuda":
+                torch.cuda.empty_cache()
+            self._adapter = LightningBallPredictionAdapter.load(
+                model.checkpoint,
+                device=self.device,
+                strict=model.strict,
+                weights_only=model.weights_only,
+            )
+            self._adapter_key = key
+        return self._adapter
+
+
+def build_evaluation_dataloader(
+    datamodule: pl.LightningDataModule,
+    split: str,
+) -> DataLoader[Any]:
+    """Construct only the requested val/test dataset; never initialize train."""
+    if split == "val":
+        datamodule.setup(stage="validate")
+        return datamodule.val_dataloader()
+    if split == "test":
+        datamodule.setup(stage="test")
+        return datamodule.test_dataloader()
+    raise ValueError(f"Evaluation split must be val or test, got {split!r}.")
+
+
+def evaluate_dataloader(
+    *,
+    adapter: BallPredictionAdapter,
+    dataloader: DataLoader[Any],
+    data_config: Any,
+    split: str,
+    manifest: EvaluationManifest,
+) -> dict[str, Any]:
+    """Evaluate one sequential dataloader with metrics and inference timing."""
+    dataset = dataloader.dataset
+    source_resolver = SequentialSourceResolver(
+        dataset,
+        default_source=str(data_config.get("source", "tracknet")),
+    )
+    metrics = StratifiedBallMetrics(manifest.metrics)
+    timings: list[float] = []
+    processed_frames = 0
+    processed_batches = 0
+    max_batches = manifest.performance.max_batches_per_split
+
+    iterator = iter(dataloader)
+    try:
+        first_batch = next(iterator)
+    except StopIteration as error:
+        raise RuntimeError(f"Evaluation split {split!r} is empty.") from error
+
+    with torch.inference_mode():
+        for _ in range(manifest.performance.warmup_batches):
+            _predict_batch(adapter, first_batch)
+        _reset_peak_memory(adapter.device)
+
+        for batch_index, batch in enumerate(_prepend(first_batch, iterator)):
+            if max_batches is not None and batch_index >= max_batches:
+                break
+            _synchronize(adapter.device)
+            start = time.perf_counter()
+            pred_heatmaps = _predict_batch(adapter, batch)
+            _synchronize(adapter.device)
+            timings.append(time.perf_counter() - start)
+
+            target_coords = _tensor(batch, "coords").to(
+                adapter.device,
+                non_blocking=True,
+            )
+            target_visibility = _tensor(batch, "visibility").to(
+                adapter.device,
+                non_blocking=True,
+            )
+            original_size = _tensor(batch, "original_size").to(
+                adapter.device,
+                non_blocking=True,
+            )
+            sources = source_resolver.next(pred_heatmaps.shape[0])
+            metrics.update(
+                pred_heatmaps,
+                target_coords,
+                target_visibility,
+                original_size,
+                sources=sources,
+            )
+            processed_frames += int(
+                pred_heatmaps.shape[0] * pred_heatmaps.shape[1]
+            )
+            processed_batches += 1
+
+    total_seconds = sum(timings)
+    performance = {
+        "batches": processed_batches,
+        "frames": processed_frames,
+        "total_inference_seconds": total_seconds,
+        "latency_ms_per_batch": (
+            None
+            if not timings
+            else 1000.0 * total_seconds / len(timings)
+        ),
+        "throughput_frames_per_second": (
+            None if total_seconds <= 0 else processed_frames / total_seconds
+        ),
+        "peak_vram_mb": _peak_vram_mb(adapter.device),
+        "warmup_batches": manifest.performance.warmup_batches,
+    }
+    return {
+        "split": split,
+        "metrics": metrics.compute(),
+        "performance": performance,
+        "dataset_provenance": build_split_provenance(
+            data_config=data_config,
+            split=split,
+            dataset=dataset,
+        ),
+    }
+
+
+def _predict_batch(
+    adapter: BallPredictionAdapter,
+    batch: dict[str, Any],
+) -> Tensor:
+    images = _tensor(batch, "images")
+    target_heatmaps = _tensor(batch, "heatmaps")
+    return adapter.predict_heatmaps(
+        images,
+        target_size_hw=(
+            int(target_heatmaps.shape[-2]),
+            int(target_heatmaps.shape[-1]),
+        ),
+    )
+
+
+def _tensor(batch: dict[str, Any], key: str) -> Tensor:
+    value = batch.get(key)
+    if not isinstance(value, Tensor):
+        raise TypeError(f"Evaluation batch field {key!r} must be a Tensor.")
+    return value
+
+
+def _prepend(
+    first: dict[str, Any],
+    iterator: Any,
+) -> Any:
+    yield first
+    yield from iterator
+
+
+def _synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _reset_peak_memory(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.reset_peak_memory_stats(device)
+
+
+def _peak_vram_mb(device: torch.device) -> float | None:
+    if device.type != "cuda":
+        return None
+    return float(
+        torch.cuda.max_memory_allocated(device) / (1024.0 * 1024.0)
+    )
+
+
+def _git_revision() -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _git_dirty() -> bool:
+    return bool(
+        subprocess.run(
+            ["git", "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+
+
+__all__ = [
+    "DefaultJobEvaluator",
+    "JobEvaluator",
+    "build_evaluation_dataloader",
+    "evaluate_dataloader",
+]

--- a/src/tasks/ball_detection/evaluation/metrics.py
+++ b/src/tasks/ball_detection/evaluation/metrics.py
@@ -1,0 +1,156 @@
+"""Aggregate and source-stratified ball-detection metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor
+
+from src.tasks.ball_detection.evaluation.contracts import MetricsSpec
+from src.tasks.ball_detection.training.metrics import BallDetectionMetrics
+from src.utils.data.heatmaps import heatmaps_to_peaks
+
+
+@dataclass
+class _FrameCounts:
+    total: int = 0
+    negative: int = 0
+    negative_false_positive: int = 0
+
+    def to_dict(self) -> dict[str, int | float | None]:
+        negative_fpr = (
+            None
+            if self.negative == 0
+            else self.negative_false_positive / self.negative
+        )
+        return {
+            "frames": self.total,
+            "negative_frames": self.negative,
+            "negative_false_positive_frames": self.negative_false_positive,
+            "negative_frame_fpr": negative_fpr,
+        }
+
+
+class StratifiedBallMetrics:
+    """Compute identical metrics overall and for every dataset source."""
+
+    def __init__(self, spec: MetricsSpec) -> None:
+        self.spec = spec
+        self._overall = self._new_tracker()
+        self._by_source: dict[str, BallDetectionMetrics] = {}
+        self._overall_counts = _FrameCounts()
+        self._source_counts: dict[str, _FrameCounts] = {}
+        self._device: torch.device | None = None
+
+    def update(
+        self,
+        pred_heatmaps: Tensor,
+        target_coords: Tensor,
+        target_visibility: Tensor,
+        original_size: Tensor,
+        *,
+        sources: list[str],
+    ) -> None:
+        """Update aggregate and per-source state for one sequential batch."""
+        batch_size = pred_heatmaps.shape[0]
+        if len(sources) != batch_size:
+            raise ValueError(
+                f"Expected {batch_size} source labels, got {len(sources)}."
+            )
+        self._ensure_device(pred_heatmaps.device)
+        self._overall.update(
+            pred_heatmaps,
+            target_coords,
+            target_visibility,
+            original_size,
+        )
+        self._update_counts(
+            self._overall_counts,
+            pred_heatmaps,
+            target_visibility,
+        )
+
+        for source in sorted(set(sources)):
+            indices = torch.tensor(
+                [index for index, value in enumerate(sources) if value == source],
+                device=pred_heatmaps.device,
+                dtype=torch.long,
+            )
+            if source not in self._by_source:
+                self._by_source[source] = self._new_tracker()
+            tracker = self._by_source[source]
+            tracker.to(pred_heatmaps.device)
+            tracker.update(
+                pred_heatmaps.index_select(0, indices),
+                target_coords.index_select(0, indices),
+                target_visibility.index_select(0, indices),
+                original_size.index_select(0, indices),
+            )
+            counts = self._source_counts.setdefault(source, _FrameCounts())
+            self._update_counts(
+                counts,
+                pred_heatmaps.index_select(0, indices),
+                target_visibility.index_select(0, indices),
+            )
+
+    def compute(self) -> dict[str, object]:
+        """Return JSON-compatible aggregate and source metrics."""
+        aggregate = _metric_values(self._overall)
+        aggregate.update(self._overall_counts.to_dict())
+        by_source: dict[str, dict[str, int | float | None]] = {}
+        for source, tracker in sorted(self._by_source.items()):
+            source_values = _metric_values(tracker)
+            source_values.update(self._source_counts[source].to_dict())
+            by_source[source] = source_values
+        return {"aggregate": aggregate, "by_source": by_source}
+
+    def _new_tracker(self) -> BallDetectionMetrics:
+        return BallDetectionMetrics(
+            peak_threshold=self.spec.peak_threshold,
+            ball_distance_threshold=self.spec.ball_distance_threshold,
+            nms_kernel=self.spec.nms_kernel,
+            max_predictions_per_frame=self.spec.max_predictions_per_frame,
+        )
+
+    def _ensure_device(self, device: torch.device) -> None:
+        if self._device is None:
+            self._overall.to(device)
+            self._device = device
+        elif self._device != device:
+            raise RuntimeError(
+                f"Metric device changed during evaluation: {self._device} -> {device}."
+            )
+
+    def _update_counts(
+        self,
+        counts: _FrameCounts,
+        pred_heatmaps: Tensor,
+        target_visibility: Tensor,
+    ) -> None:
+        _, _, pred_valid = heatmaps_to_peaks(
+            pred_heatmaps,
+            threshold=self.spec.peak_threshold,
+            nms_kernel=self.spec.nms_kernel,
+            max_peaks=self.spec.max_predictions_per_frame,
+        )
+        target_present = (target_visibility > 0.5).any(dim=-1)
+        negative = ~target_present
+        pred_present = pred_valid.any(dim=-1)
+        counts.total += int(target_present.numel())
+        counts.negative += int(negative.sum().item())
+        counts.negative_false_positive += int(
+            (negative & pred_present).sum().item()
+        )
+
+
+def _metric_values(
+    tracker: BallDetectionMetrics,
+) -> dict[str, int | float | None]:
+    return {
+        name: float(value.detach().cpu().item())
+        for name, value in tracker.compute().items()
+    }
+
+
+__all__ = ["StratifiedBallMetrics"]

--- a/src/tasks/ball_detection/evaluation/reporting.py
+++ b/src/tasks/ball_detection/evaluation/reporting.py
@@ -1,0 +1,144 @@
+"""Machine-readable and Markdown comparison report generation."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from src.utils.io import save_json
+
+_CSV_FIELDS = [
+    "category",
+    "model_id",
+    "model_name",
+    "dataset_id",
+    "split",
+    "precision",
+    "recall",
+    "f1",
+    "mean_distance_px",
+    "negative_frame_fpr",
+    "throughput_frames_per_second",
+    "latency_ms_per_batch",
+    "peak_vram_mb",
+]
+
+
+def write_comparison_reports(
+    results: list[dict[str, Any]],
+    *,
+    output_dir: Path,
+) -> None:
+    """Write summary JSON, flat CSV, and category-separated Markdown."""
+    successful = [result for result in results if result.get("status") == "success"]
+    failed = [result for result in results if result.get("status") == "failed"]
+    rows = [_flatten_result(result) for result in successful]
+    save_json(
+        {
+            "schema": "ball_detection_evaluation_summary_v1",
+            "successful_jobs": len(successful),
+            "failed_jobs": len(failed),
+            "results": results,
+        },
+        output_dir / "summary.json",
+    )
+    _write_csv(rows, output_dir / "comparison.csv")
+    (output_dir / "comparison.md").write_text(
+        _render_markdown(rows, failed),
+        encoding="utf-8",
+    )
+
+
+def _flatten_result(result: dict[str, Any]) -> dict[str, Any]:
+    aggregate = result["result"]["metrics"]["aggregate"]
+    performance = result["result"]["performance"]
+    return {
+        "category": result["category"],
+        "model_id": result["model_id"],
+        "model_name": result["model_name"],
+        "dataset_id": result["dataset_id"],
+        "split": result["split"],
+        "precision": aggregate["precision"],
+        "recall": aggregate["recall"],
+        "f1": aggregate["f1"],
+        "mean_distance_px": aggregate["mean_distance_px"],
+        "negative_frame_fpr": aggregate["negative_frame_fpr"],
+        "throughput_frames_per_second": performance[
+            "throughput_frames_per_second"
+        ],
+        "latency_ms_per_batch": performance["latency_ms_per_batch"],
+        "peak_vram_mb": performance["peak_vram_mb"],
+    }
+
+
+def _write_csv(rows: list[dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=_CSV_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _render_markdown(
+    rows: list[dict[str, Any]],
+    failed: list[dict[str, Any]],
+) -> str:
+    lines = ["# Ball detector evaluation", ""]
+    titles = {
+        "architecture-controlled": "Architecture-controlled",
+        "full-strategy": "Full strategy",
+    }
+    for category, title in titles.items():
+        lines.extend([f"## {title}", ""])
+        category_rows = [row for row in rows if row["category"] == category]
+        if not category_rows:
+            lines.extend(["No completed evaluations.", ""])
+            continue
+        lines.extend(
+            [
+                "| Model | Dataset | Split | Precision | Recall | F1 | Distance px | Negative FPR | FPS | Peak VRAM MB |",
+                "|---|---|---|---:|---:|---:|---:|---:|---:|---:|",
+            ]
+        )
+        for row in category_rows:
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        str(row["model_id"]),
+                        str(row["dataset_id"]),
+                        str(row["split"]),
+                        _format(row["precision"]),
+                        _format(row["recall"]),
+                        _format(row["f1"]),
+                        _format(row["mean_distance_px"]),
+                        _format(row["negative_frame_fpr"]),
+                        _format(row["throughput_frames_per_second"]),
+                        _format(row["peak_vram_mb"]),
+                    ]
+                )
+                + " |"
+            )
+        lines.append("")
+
+    if failed:
+        lines.extend(["## Failed jobs", ""])
+        for result in failed:
+            lines.append(
+                f"- `{result['job_id']}`: "
+                f"{result['error']['type']}: {result['error']['message']}"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _format(value: object) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    return str(value)
+
+
+__all__ = ["write_comparison_reports"]

--- a/src/tasks/ball_detection/evaluation/runner.py
+++ b/src/tasks/ball_detection/evaluation/runner.py
@@ -1,0 +1,258 @@
+"""Resumable orchestration for manifest-defined evaluation jobs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import traceback
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from omegaconf import OmegaConf
+
+from src.tasks.ball_detection.evaluation.adapters import (
+    resolve_evaluation_device,
+)
+from src.tasks.ball_detection.evaluation.configuration import load_data_config
+from src.tasks.ball_detection.evaluation.contracts import (
+    DatasetSpec,
+    EvaluationManifest,
+    ModelSpec,
+)
+from src.tasks.ball_detection.evaluation.dataset_provenance import sha256_file
+from src.tasks.ball_detection.evaluation.evaluator import (
+    DefaultJobEvaluator,
+    JobEvaluator,
+)
+from src.tasks.ball_detection.evaluation.reporting import (
+    write_comparison_reports,
+)
+from src.utils.io import ensure_dir, load_json, save_json
+from src.utils.paths import resolve_project_path
+
+_EVALUATOR_SCHEMA = "ball_detection_evaluator_v1"
+
+
+class EvaluationPipeline:
+    """Execute, resume, and report all jobs in one evaluation manifest."""
+
+    def __init__(
+        self,
+        manifest: EvaluationManifest,
+        *,
+        evaluator: JobEvaluator | None = None,
+        output_dir: str | Path | None = None,
+        resume: bool | None = None,
+        fail_fast: bool | None = None,
+    ) -> None:
+        self.manifest = manifest
+        self.output_dir = ensure_dir(output_dir or manifest.output_dir)
+        self.results_dir = ensure_dir(self.output_dir / "results")
+        self.resume = manifest.resume if resume is None else resume
+        self.fail_fast = manifest.fail_fast if fail_fast is None else fail_fast
+        self.evaluator = evaluator or DefaultJobEvaluator(
+            device=resolve_evaluation_device(manifest.device)
+        )
+        self._checkpoint_hashes: dict[Path, str] = {}
+        self._dataset_fingerprints: dict[tuple[str, str], dict[str, Any]] = {}
+
+    def run(self) -> dict[str, int]:
+        """Run unfinished jobs, reuse successful ones, and refresh reports."""
+        save_json(_manifest_payload(self.manifest), self.output_dir / "manifest.json")
+        results: list[dict[str, Any]] = []
+        executed = 0
+        reused = 0
+        failed = 0
+
+        for model in self.manifest.models:
+            if not model.enabled:
+                continue
+            for dataset_id in model.datasets:
+                dataset = self.manifest.datasets[dataset_id]
+                for split in dataset.splits:
+                    job_id = f"{model.id}--{dataset.id}--{split}"
+                    result_path = self.results_dir / f"{job_id}.json"
+                    fingerprint = self._job_fingerprint(
+                        model=model,
+                        dataset=dataset,
+                        split=split,
+                    )
+                    previous = _load_reusable_result(
+                        result_path,
+                        fingerprint=fingerprint,
+                        resume=self.resume,
+                    )
+                    if previous is not None:
+                        results.append(previous)
+                        reused += 1
+                        continue
+
+                    executed += 1
+                    base_result = {
+                        "schema": "ball_detection_evaluation_result_v1",
+                        "job_id": job_id,
+                        "fingerprint": fingerprint,
+                        "category": model.category,
+                        "model_id": model.id,
+                        "model_name": model.expected_model_name,
+                        "dataset_id": dataset.id,
+                        "split": split,
+                    }
+                    try:
+                        payload = self.evaluator.evaluate(
+                            model=model,
+                            dataset=dataset,
+                            split=split,
+                            manifest=self.manifest,
+                        )
+                        result = {
+                            **base_result,
+                            "status": "success",
+                            "result": payload,
+                        }
+                    except Exception as error:
+                        failed += 1
+                        result = {
+                            **base_result,
+                            "status": "failed",
+                            "error": {
+                                "type": type(error).__name__,
+                                "message": str(error),
+                                "traceback": traceback.format_exc(),
+                            },
+                        }
+                        save_json(result, result_path)
+                        results.append(result)
+                        if self.fail_fast:
+                            write_comparison_reports(
+                                results,
+                                output_dir=self.output_dir,
+                            )
+                            raise
+                        continue
+
+                    save_json(result, result_path)
+                    results.append(result)
+
+        write_comparison_reports(results, output_dir=self.output_dir)
+        return {
+            "jobs": len(results),
+            "executed": executed,
+            "reused": reused,
+            "failed": failed,
+        }
+
+    def _job_fingerprint(
+        self,
+        *,
+        model: ModelSpec,
+        dataset: DatasetSpec,
+        split: str,
+    ) -> str:
+        checkpoint = model.checkpoint
+        if checkpoint.is_file():
+            if checkpoint not in self._checkpoint_hashes:
+                self._checkpoint_hashes[checkpoint] = sha256_file(checkpoint)
+            checkpoint_hash = self._checkpoint_hashes[checkpoint]
+        else:
+            checkpoint_hash = "missing"
+        payload = {
+            "evaluator_schema": _EVALUATOR_SCHEMA,
+            "manifest_schema": self.manifest.schema,
+            "device": self.manifest.device,
+            "model": {
+                **asdict(model),
+                "checkpoint": str(checkpoint),
+            },
+            "checkpoint_sha256": checkpoint_hash,
+            "dataset": self._dataset_fingerprint(dataset, split),
+            "split": split,
+            "metrics": asdict(self.manifest.metrics),
+            "performance": asdict(self.manifest.performance),
+        }
+        serialized = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+    def _dataset_fingerprint(
+        self,
+        dataset: DatasetSpec,
+        split: str,
+    ) -> dict[str, Any]:
+        key = (dataset.id, split)
+        if key in self._dataset_fingerprints:
+            return self._dataset_fingerprints[key]
+
+        data_config = load_data_config(
+            dataset.config,
+            overrides=dataset.overrides,
+        )
+        resolved_config = OmegaConf.to_container(data_config, resolve=True)
+        source = str(data_config.get("source", "tracknet"))
+        data_dir = resolve_project_path(str(data_config.get("data_dir", "")))
+        if source == "web":
+            split_artifact = data_dir / "manifest.json"
+        else:
+            split_config = data_config.get("split", {}) or {}
+            split_artifact = resolve_project_path(
+                str(split_config.get(f"{split}_file", ""))
+            )
+        fingerprint = {
+            "spec": asdict(dataset),
+            "resolved_config": resolved_config,
+            "split_artifact": _file_identity(split_artifact),
+        }
+        self._dataset_fingerprints[key] = fingerprint
+        return fingerprint
+
+
+def _load_reusable_result(
+    path: Path,
+    *,
+    fingerprint: str,
+    resume: bool,
+) -> dict[str, Any] | None:
+    if not resume or not path.is_file():
+        return None
+    result = load_json(path)
+    if not isinstance(result, dict):
+        return None
+    if result.get("status") != "success":
+        return None
+    if result.get("fingerprint") != fingerprint:
+        return None
+    return result
+
+
+def _file_identity(path: Path) -> dict[str, str | None]:
+    return {
+        "path": str(path),
+        "sha256": sha256_file(path) if path.is_file() else None,
+    }
+
+
+def _manifest_payload(manifest: EvaluationManifest) -> dict[str, Any]:
+    return {
+        "schema": manifest.schema,
+        "output_dir": str(manifest.output_dir),
+        "device": manifest.device,
+        "resume": manifest.resume,
+        "fail_fast": manifest.fail_fast,
+        "metrics": asdict(manifest.metrics),
+        "performance": asdict(manifest.performance),
+        "datasets": {
+            key: asdict(value) for key, value in manifest.datasets.items()
+        },
+        "models": [
+            {**asdict(model), "checkpoint": str(model.checkpoint)}
+            for model in manifest.models
+        ],
+    }
+
+
+__all__ = ["EvaluationPipeline"]

--- a/src/tasks/ball_detection/scripts/evaluate_manifest.py
+++ b/src/tasks/ball_detection/scripts/evaluate_manifest.py
@@ -1,0 +1,66 @@
+"""Evaluate multiple ball-detector checkpoints and generate comparison reports.
+
+Usage:
+    python -m src.tasks.ball_detection.scripts.evaluate_manifest
+    python -m src.tasks.ball_detection.scripts.evaluate_manifest manifest_path=path/to/manifest.yaml
+
+Notes:
+    - Hydra loads CLI settings from `src/tasks/ball_detection/configs/evaluate_manifest.yaml`.
+    - The manifest defines checkpoints, fixed val/test datasets, comparison categories, and resume behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar, cast
+
+import hydra
+from omegaconf import DictConfig
+
+from src.tasks.ball_detection.evaluation import (
+    EvaluationPipeline,
+    load_evaluation_manifest,
+)
+
+FMain = TypeVar("FMain", bound=Callable[..., Any])
+
+
+def hydra_main(*args: Any, **kwargs: Any) -> Callable[[FMain], FMain]:
+    """Typed wrapper for ``hydra.main``."""
+    return cast(Callable[[FMain], FMain], hydra.main(*args, **kwargs))
+
+
+@hydra_main(
+    config_path="../configs",
+    config_name="evaluate_manifest",
+    version_base="1.3",
+)
+def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
+    """Run all evaluation jobs in the configured manifest."""
+    manifest = load_evaluation_manifest(str(cfg.manifest_path))
+    pipeline = EvaluationPipeline(
+        manifest,
+        output_dir=(
+            None if cfg.get("output_dir") is None else Path(str(cfg.output_dir))
+        ),
+        resume=(
+            None if cfg.get("resume") is None else bool(cfg.get("resume"))
+        ),
+        fail_fast=(
+            None
+            if cfg.get("fail_fast") is None
+            else bool(cfg.get("fail_fast"))
+        ),
+    )
+    summary = pipeline.run()
+    print(
+        "Evaluation complete: "
+        f"jobs={summary['jobs']} executed={summary['executed']} "
+        f"reused={summary['reused']} failed={summary['failed']}"
+    )
+    return 1 if summary["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(cast(Callable[[], int], main)())

--- a/tests/tasks/test_ball_evaluation_pipeline.py
+++ b/tests/tasks/test_ball_evaluation_pipeline.py
@@ -1,0 +1,385 @@
+"""Contracts for manifest-driven ball-detector evaluation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+from torch import nn
+from torch.utils.data import DataLoader, Dataset, TensorDataset
+
+from src.tasks.ball_detection.evaluation.adapters import LightningBallPredictionAdapter
+from src.tasks.ball_detection.evaluation.configuration import (
+    build_evaluation_config,
+    read_checkpoint_config,
+    validate_checkpoint_model_name,
+)
+from src.tasks.ball_detection.evaluation.contracts import (
+    DatasetSpec,
+    EvaluationManifest,
+    MetricsSpec,
+    ModelSpec,
+    PerformanceSpec,
+    load_evaluation_manifest,
+)
+from src.tasks.ball_detection.evaluation.evaluator import (
+    build_evaluation_dataloader,
+    evaluate_dataloader,
+)
+from src.tasks.ball_detection.evaluation.metrics import StratifiedBallMetrics
+from src.tasks.ball_detection.evaluation.runner import EvaluationPipeline
+
+
+def _write_manifest(
+    path: Path,
+    *,
+    checkpoint: Path,
+    splits: str = "[val, test]",
+    data_config: str = "rgb_sequence",
+) -> None:
+    path.write_text(
+        f"""
+schema: ball_detection_evaluation_manifest_v1
+output_dir: {path.parent / "output"}
+device: cpu
+resume: true
+fail_fast: false
+metrics:
+  peak_threshold: 0.5
+  ball_distance_threshold: 2.0
+  nms_kernel: 3
+  max_predictions_per_frame: 2
+performance:
+  warmup_batches: 0
+  max_batches_per_split: 1
+datasets:
+  tracknet:
+    config: {data_config}
+    splits: {splits}
+    overrides:
+      num_workers: 0
+models:
+  - id: baseline
+    category: architecture-controlled
+    checkpoint: {checkpoint}
+    expected_model_name: conv_next_unet
+    datasets: [tracknet]
+""",
+        encoding="utf-8",
+    )
+
+
+def _success_payload() -> dict[str, Any]:
+    return {
+        "metrics": {
+            "aggregate": {
+                "precision": 0.8,
+                "recall": 0.75,
+                "f1": 0.774,
+                "mean_distance_px": 1.25,
+                "negative_frame_fpr": 0.1,
+            },
+            "by_source": {
+                "tracknet": {
+                    "precision": 0.8,
+                    "recall": 0.75,
+                    "f1": 0.774,
+                    "mean_distance_px": 1.25,
+                    "negative_frame_fpr": 0.1,
+                }
+            },
+        },
+        "performance": {
+            "throughput_frames_per_second": 100.0,
+            "latency_ms_per_batch": 10.0,
+            "peak_vram_mb": None,
+        },
+        "provenance": {"git_revision": "test"},
+    }
+
+
+class _RecordingEvaluator:
+    def __init__(self, *, fail_once_split: str | None = None) -> None:
+        self.calls: list[str] = []
+        self.fail_once_split = fail_once_split
+        self.failed = False
+
+    def evaluate(
+        self,
+        *,
+        model: ModelSpec,
+        dataset: DatasetSpec,
+        split: str,
+        manifest: EvaluationManifest,
+    ) -> dict[str, Any]:
+        del model, dataset, manifest
+        self.calls.append(split)
+        if split == self.fail_once_split and not self.failed:
+            self.failed = True
+            raise RuntimeError("synthetic failure")
+        return _success_payload()
+
+
+def test_manifest_forbids_train_split(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "model.ckpt"
+    checkpoint.write_bytes(b"checkpoint")
+    manifest_path = tmp_path / "manifest.yaml"
+    _write_manifest(manifest_path, checkpoint=checkpoint, splits="[train]")
+    with pytest.raises(ValueError, match="forbidden splits"):
+        load_evaluation_manifest(manifest_path)
+
+
+def test_pipeline_reuses_success_and_reruns_only_failure(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "model.ckpt"
+    checkpoint.write_bytes(b"checkpoint")
+    val_split = tmp_path / "val.txt"
+    test_split = tmp_path / "test.txt"
+    val_split.write_text("game-val\n", encoding="utf-8")
+    test_split.write_text("game-test\n", encoding="utf-8")
+    data_config = tmp_path / "evaluation_data.yaml"
+    data_config.write_text(
+        "\n".join(
+            [
+                "source: tracknet",
+                f"data_dir: {tmp_path}",
+                "batch_size: 1",
+                "split:",
+                f"  val_file: {val_split}",
+                f"  test_file: {test_split}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    manifest_path = tmp_path / "manifest.yaml"
+    _write_manifest(
+        manifest_path,
+        checkpoint=checkpoint,
+        data_config=str(data_config),
+    )
+    manifest = load_evaluation_manifest(manifest_path)
+    evaluator = _RecordingEvaluator(fail_once_split="val")
+
+    first = EvaluationPipeline(manifest, evaluator=evaluator).run()
+    assert first == {"jobs": 2, "executed": 2, "reused": 0, "failed": 1}
+    assert evaluator.calls == ["val", "test"]
+
+    second = EvaluationPipeline(manifest, evaluator=evaluator).run()
+    assert second == {"jobs": 2, "executed": 1, "reused": 1, "failed": 0}
+    assert evaluator.calls == ["val", "test", "val"]
+    comparison = (manifest.output_dir / "comparison.md").read_text(
+        encoding="utf-8"
+    )
+    assert "## Architecture-controlled" in comparison
+    assert "## Full strategy" in comparison
+
+    data_config.write_text(
+        data_config.read_text(encoding="utf-8") + "\npin_memory: false\n",
+        encoding="utf-8",
+    )
+    third = EvaluationPipeline(manifest, evaluator=evaluator).run()
+    assert third == {"jobs": 2, "executed": 2, "reused": 0, "failed": 0}
+    assert evaluator.calls == ["val", "test", "val", "val", "test"]
+
+
+def test_stratified_metrics_include_negative_fpr_and_sources() -> None:
+    accumulator = StratifiedBallMetrics(
+        MetricsSpec(
+            peak_threshold=0.5,
+            ball_distance_threshold=2.0,
+            nms_kernel=3,
+            max_predictions_per_frame=2,
+        )
+    )
+    pred_heatmaps = torch.zeros(2, 1, 8, 8)
+    pred_heatmaps[0, 0, 3, 3] = 1.0
+    pred_heatmaps[1, 0, 5, 5] = 1.0
+    coords = torch.zeros(2, 1, 1, 2)
+    coords[0, 0, 0] = torch.tensor([3.0, 3.0])
+    visibility = torch.zeros(2, 1, 1)
+    visibility[0, 0, 0] = 1.0
+    original_size = torch.tensor([[8.0, 8.0], [8.0, 8.0]])
+
+    accumulator.update(
+        pred_heatmaps,
+        coords,
+        visibility,
+        original_size,
+        sources=["source-a", "source-b"],
+    )
+    result = accumulator.compute()
+    aggregate = result["aggregate"]
+    by_source = result["by_source"]
+    assert isinstance(aggregate, dict)
+    assert isinstance(by_source, dict)
+    assert aggregate["negative_frame_fpr"] == 1.0
+    assert by_source["source-b"]["negative_frame_fpr"] == 1.0
+    assert set(by_source) == {"source-a", "source-b"}
+
+
+def test_checkpoint_model_name_mismatch_fails_early(tmp_path: Path) -> None:
+    checkpoint_path = tmp_path / "checkpoint.ckpt"
+    torch.save(
+        {
+            "hyper_parameters": {
+                "config": {"model": {"name": "conv_next_unet"}}
+            }
+        },
+        checkpoint_path,
+    )
+    checkpoint_config = read_checkpoint_config(checkpoint_path)
+    with pytest.raises(ValueError, match="Checkpoint/model config mismatch"):
+        validate_checkpoint_model_name(
+            checkpoint_config,
+            expected_model_name="dinov3_rope",
+        )
+
+
+def test_evaluation_config_keeps_checkpoint_model_and_replaces_dataset() -> None:
+    checkpoint_config = {
+        "model": {
+            "name": "conv_next_unet",
+            "num_frames": 8,
+            "input_mode": "mdd",
+            "input_layout": "bcthw",
+        },
+        "training": {"matmul_precision": "high"},
+    }
+    config = build_evaluation_config(
+        checkpoint_config=OmegaConf.create(checkpoint_config),
+        dataset_spec=DatasetSpec(
+            id="web",
+            config="web_frames",
+            splits=("test",),
+            overrides={
+                "num_workers": 0,
+                "sampling": {"mode": "temporal"},
+            },
+        ),
+        metrics_spec=MetricsSpec(),
+    )
+    assert config.model.name == "conv_next_unet"
+    assert config.model.num_frames == 8
+    assert config.data.source == "web"
+    assert config.data.num_workers == 0
+    assert config.data.sampling.mode == "temporal"
+    assert config.data.sampling.temporal.frame_step == 1
+    assert config.data.augmentation.normalize_imagenet.enabled is True
+
+
+def test_prediction_adapter_rejects_wrong_output_shape() -> None:
+    class WrongShapeModel(nn.Module):
+        def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+            return inputs[:, :1, 0]
+
+    class FakeModule(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.model = WrongShapeModel()
+            self.config = {
+                "model": {
+                    "input_mode": "rgb",
+                    "input_layout": "bcthw",
+                }
+            }
+
+    adapter = LightningBallPredictionAdapter(FakeModule(), device=torch.device("cpu"))
+    with pytest.raises(ValueError, match="output shape mismatch"):
+        adapter.predict_heatmaps(
+            torch.zeros(1, 2, 3, 8, 8),
+            target_size_hw=(8, 8),
+        )
+
+
+def test_validation_loader_does_not_initialize_train_dataset() -> None:
+    class RecordingDataModule:
+        def __init__(self) -> None:
+            self.stage: str | None = None
+            self.dataset = TensorDataset(torch.zeros(2, 1))
+
+        def setup(self, stage: str | None = None) -> None:
+            self.stage = stage
+
+        def val_dataloader(self) -> DataLoader[Any]:
+            return DataLoader(self.dataset, batch_size=1, shuffle=False)
+
+    datamodule = RecordingDataModule()
+    dataloader = build_evaluation_dataloader(datamodule, "val")
+    assert datamodule.stage == "validate"
+    assert isinstance(dataloader.sampler, torch.utils.data.SequentialSampler)
+
+
+def test_evaluate_dataloader_records_metrics_performance_and_split(
+    tmp_path: Path,
+) -> None:
+    class DictDataset(Dataset[dict[str, torch.Tensor]]):
+        def __len__(self) -> int:
+            return 1
+
+        def __getitem__(self, _index: int) -> dict[str, torch.Tensor]:
+            return {
+                "images": torch.zeros(1, 3, 8, 8),
+                "heatmaps": torch.zeros(1, 8, 8),
+                "coords": torch.tensor([[[3.0, 3.0]]]),
+                "visibility": torch.ones(1, 1),
+                "original_size": torch.tensor([8.0, 8.0]),
+                "heatmap_size": torch.tensor([8.0, 8.0]),
+            }
+
+    class FakeAdapter:
+        device = torch.device("cpu")
+
+        def predict_heatmaps(
+            self,
+            images: torch.Tensor,
+            *,
+            target_size_hw: tuple[int, int],
+        ) -> torch.Tensor:
+            heatmaps = torch.zeros(
+                images.shape[0],
+                images.shape[1],
+                *target_size_hw,
+            )
+            heatmaps[:, :, 3, 3] = 1.0
+            return heatmaps
+
+    split_file = tmp_path / "test.txt"
+    split_file.write_text("game1\n", encoding="utf-8")
+    dataloader = DataLoader(DictDataset(), batch_size=1, shuffle=False)
+    manifest = EvaluationManifest(
+        schema="ball_detection_evaluation_manifest_v1",
+        output_dir=tmp_path / "output",
+        device="cpu",
+        resume=True,
+        fail_fast=False,
+        metrics=MetricsSpec(
+            peak_threshold=0.5,
+            ball_distance_threshold=2.0,
+            nms_kernel=3,
+            max_predictions_per_frame=2,
+        ),
+        performance=PerformanceSpec(
+            warmup_batches=1,
+            max_batches_per_split=None,
+        ),
+        datasets={},
+        models=(),
+    )
+    result = evaluate_dataloader(
+        adapter=FakeAdapter(),
+        dataloader=dataloader,
+        data_config={
+            "source": "tracknet",
+            "data_dir": str(tmp_path),
+            "split": {"test_file": str(split_file)},
+        },
+        split="test",
+        manifest=manifest,
+    )
+
+    assert result["metrics"]["aggregate"]["f1"] == 1.0
+    assert result["metrics"]["by_source"]["tracknet"]["f1"] == 1.0
+    assert result["performance"]["frames"] == 1
+    assert result["dataset_provenance"]["split"] == "test"


### PR DESCRIPTION
## 概要

複数のball detector checkpointを同一条件で順次評価し、共通指標・性能・provenance・比較レポートを生成するmanifest駆動パイプラインを追加します。
Architecture-controlled比較とfull-strategy比較を分離し、成功済みjobを再利用して失敗・変更jobのみ再実行できます。

## 変更内容

- checkpoint、dataset、split、比較カテゴリを列挙する型付き評価manifestを追加
- Lightning ball detector共通prediction adapterとmodel/config/output shape検証を実装
- TrackNet val/test、Web testの固定split評価とtrain data非アクセスを実装
- aggregate/source別のprecision・recall・F1・mean distance・明示的負例frame FPRを集計
- latency、throughput、peak VRAMを計測
- command、git revision、checkpoint SHA-256、解決済みconfig、dataset schema、split hashを保存
- job単位JSON、summary JSON、比較CSV、カテゴリ別Markdownを生成
- checkpoint・model条件・device・data config・split artifactを含むfingerprintで安全にresume
- 既存ConvNeXt baselineと将来のDINOv3 runを列挙した標準manifest、Hydra CLI、READMEを追加

## 検証

- `.venv/bin/python -m pytest tests/tasks/test_ball_evaluation_pipeline.py -q`（8 passed）
- stacked branchで評価/DataModule対象テスト（10 passed）
- `tests/tasks -q`（68 passed, 153 warnings）
- 変更Pythonファイルのpre-commit（ruff / mypy / task script reviewer passed）
- 既存ConvNeXt checkpointをTrackNet valで1 batch実評価（8 frames、F1 0.875、約9.88 FPS、provenance生成を確認）
- Web v2 storeはtiny store統合テストでvalidation-only setupとsample contractを確認

## 関連Issue

- Closes #553
- References #549
- References #551
- References #554

## 補足

- stacked PRです。先に #557 をマージし、その後このPRのbaseを `main` に変更してください。
- ローカルの実Web storeは旧 `web_ball_frames_v1` だったため、実checkpointによるWeb testはschema validationで停止しました。現行入力層の契約は `web_ball_frames_v2` であり、旧schemaへの暗黙fallbackは追加していません。
