### PR TITLE
chore: CLAUDE.md を AGENTS.md の単一ソース化 (@import)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,31 +1,9 @@
-# AGENTS.md
+@AGENTS.md
 
-## Project overview
-
-- This repository develops ML components for tennis analysis.
-- Task-specific modules live under `src/tasks/*` (for example `ball_detection`).
-- Task integration and scene-level analysis live under `src/tennis_scene`.
-- Shared reusable modules live under `src/utils`.
-- Datasets and dataset-related files live under `data`.
-- Generated outputs belong in `outputs/`.
-
-## Python environment
-
-- Use `.venv/bin/python` as the Python runtime for all project commands and scripts.
-- When adding dependencies, use `uv add <package>`.
-- When removing dependencies, use `uv remove <package>`.
-- Do not edit dependency definitions manually when `uv` can manage them.
-
-## Code reuse and shared utilities
-
-- Before writing a helper, check `src/utils` (see `src/utils/README.md` for the
-  full index and an "I need to…" table). Generic, domain-agnostic logic —
-  path/device/seed handling, IO, tensor and geometry math, heatmaps, rendering,
-  schemas, video — lives there, not copied into a task module.
-- Rule of thumb: if a function has no dependency on a specific task's domain
-  types, it belongs in `src/utils` (next to the closest existing module), not in
-  `src/tasks/*` or `src/tennis_scene`.
-- When you find a generic helper duplicated locally, extract it to `src/utils`
-  and replace each copy with an import (delegate or re-export to keep existing
-  import paths working) instead of leaving the WET copies.
-- Add a unit test for new shared utilities in `tests/test_utils_extraction.py`.
+<!--
+Single source of truth: AGENTS.md (the cross-tool standard read by Codex,
+Gemini CLI, Antigravity/agy, Cursor, etc.). Claude Code reads this CLAUDE.md
+and pulls in AGENTS.md through the @path import on the first line, so the
+project guidance is maintained in one place instead of two drifting copies.
+Add Claude-Code-only instructions below this comment if ever needed.
+-->


### PR DESCRIPTION
## 概要

`CLAUDE.md` と `AGENTS.md` がバイト同一の重複で、手動同期が必要でドリフトの温床になっていました。`AGENTS.md` を単一の正(single source of truth)とし、`CLAUDE.md` は `@AGENTS.md` インポート1行に置き換えます。

## なぜこの方法か

- `AGENTS.md` はクロスツール標準(Codex / Gemini CLI / Antigravity(agy) / Cursor 等が読む)。Claude Code だけが `CLAUDE.md` を読む。
- `@AGENTS.md` インポートは Anthropic 推奨パターンで、**symlink と違い Windows でも動く**(Developer Mode 不要)。
- Claude 固有ルールが必要になれば、インポート行の下に追記できる。

## 変更内容

- `CLAUDE.md`: 重複していた本文を削除し、先頭行 `@AGENTS.md` + 意図を説明するコメントに置換(31削除 / 9追加)。
- 読み込まれる実効内容は従来どおり(`AGENTS.md` が取り込まれる)。挙動変更なし、重複解消のみ。

## 備考

- PR #561 のレビュー過程で判明した二重管理問題の (2) に対応するもの。`main` から切ったブランチです。
- スキルの二重管理 (`.agents/skills` ⇄ `.claude/skills`) は別途(symlink 化 or 同期ツール)で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)