### PR TITLE
test: scaffold tests/ mirror with utils + tasks/base coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,21 @@ ignore_missing_imports = true
 module = ["third_party.*"]
 ignore_errors = true
 
+# Tests are still type-checked (bodies are validated), but pytest's own
+# fixture / parametrize decorators are seen as untyped under the
+# `--follow-imports=skip` pre-commit invocation, so the strict
+# "annotate every def / no untyped decorators" rules cannot be satisfied for
+# test functions. Relax those ceremony-only rules for the tests package while
+# keeping real type errors active. `warn_unreachable` is also disabled because
+# asserting on state mutated by a helper call trips mypy's narrowing.
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_decorators = false
+warn_unused_ignores = false
+warn_unreachable = false
+
 [tool.coverage.run]
 source = ["src"]
 omit = [
@@ -240,10 +255,13 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = [
     "--verbose",
-    "--cov=src",
-    "--cov-report=term-missing",
-    "--cov-report=html:htmlcov",
-    "--cov-report=xml",
+    # importlib import mode lets the tests/ tree mirror src/ without __init__.py
+    # files and tolerates duplicate test basenames across mirrored packages
+    # (e.g. utils/data/test_augmentation.py vs tasks/base/data/test_augmentation.py).
+    "--import-mode=importlib",
+    # Run the suite in parallel across CPU cores (pytest-xdist).
+    "-n",
+    "auto",
     "--strict-markers",
     "--disable-warnings",
     # Enable doctest for docstring Examples (turn on when examples are stable)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+"""Global pytest fixtures shared across the whole test suite.
+
+Keep this file dependency-light and domain-agnostic: seeding, tmp helpers and
+generic dummy-tensor factories live here. Task-specific fixtures belong in a
+``conftest.py`` directly under that task's test directory (for example
+``tests/unit/tasks/base/conftest.py``).
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+import torch
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_seed() -> None:
+    """Seed Python / NumPy / Torch before every test for reproducibility.
+
+    Autouse so individual tests never have to remember to seed; tests that need
+    a specific seed can still re-seed locally.
+    """
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
+
+
+@pytest.fixture
+def rng() -> np.random.Generator:
+    """A seeded NumPy ``Generator`` for tests that want explicit randomness."""
+    return np.random.default_rng(1234)
+
+
+@pytest.fixture
+def torch_generator() -> torch.Generator:
+    """A seeded CPU ``torch.Generator`` for reproducible stochastic ops."""
+    generator = torch.Generator()
+    generator.manual_seed(1234)
+    return generator
+
+
+@pytest.fixture
+def make_image() -> Callable[..., torch.Tensor]:
+    """Factory producing dummy CHW (or BCHW) float image tensors in ``[0, 1]``."""
+
+    def _make_image(
+        *,
+        channels: int = 3,
+        height: int = 8,
+        width: int = 8,
+        batch: int | None = None,
+    ) -> torch.Tensor:
+        shape: tuple[int, ...] = (channels, height, width)
+        if batch is not None:
+            shape = (batch, *shape)
+        return torch.rand(*shape)
+
+    return _make_image

--- a/tests/integration/tasks/base/test_lightning_train_smoke.py
+++ b/tests/integration/tasks/base/test_lightning_train_smoke.py
@@ -1,0 +1,78 @@
+"""1-step training smoke test for BaseLightningModule.
+
+Runs a real ``Trainer.fit`` for a single optimization step on a tiny in-memory
+dataset to verify that ``configure_optimizers`` (optimizer + scheduler with the
+step/epoch interval logic) wires into the Lightning loop without error. CPU-only,
+no checkpoints, minimal data.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytorch_lightning as pl
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from src.tasks.base.training.lightning_module import BaseLightningModule
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+class _SmokeModule(BaseLightningModule):
+    def __init__(self, config=None) -> None:
+        super().__init__(config)
+        self.net = nn.Linear(4, 1)
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        pred = self.net(x).squeeze(-1)
+        loss = nn.functional.mse_loss(pred, y)
+        self.log("train/loss", loss)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        x, y = batch
+        pred = self.net(x).squeeze(-1)
+        loss = nn.functional.mse_loss(pred, y)
+        self.log("val/loss", loss)
+        return loss
+
+
+def _loader(n: int = 8, batch: int = 4) -> DataLoader:
+    x = torch.randn(n, 4)
+    y = torch.randn(n)
+    return DataLoader(TensorDataset(x, y), batch_size=batch)
+
+
+def _trainer(tmp_path) -> pl.Trainer:
+    return pl.Trainer(
+        max_steps=1,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        num_sanity_val_steps=0,
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        default_root_dir=str(tmp_path),
+    )
+
+
+def test_one_step_with_step_scheduler(tmp_path) -> None:
+    module = _SmokeModule({"training": {"max_epochs": 1, "steps_per_epoch": 2}})
+    trainer = _trainer(tmp_path)
+    trainer.fit(module, _loader(), _loader())
+    assert trainer.global_step == 1
+
+
+def test_one_step_with_epoch_warmup_scheduler(tmp_path) -> None:
+    module = _SmokeModule({"training": {"max_epochs": 4, "warmup_epochs": 2}})
+    trainer = _trainer(tmp_path)
+    trainer.fit(module, _loader(), _loader())
+    assert trainer.global_step == 1
+    # optimizer actually got constructed and is an AdamW
+    opt = trainer.optimizers[0]
+    assert isinstance(opt, torch.optim.AdamW)

--- a/tests/integration/tasks/base/test_qualitative_saving_smoke.py
+++ b/tests/integration/tasks/base/test_qualitative_saving_smoke.py
@@ -1,0 +1,135 @@
+"""Smoke tests for qualitative artifact saving (real PNG/GIF rendering).
+
+These exercise the real rendering/encoding path (Pillow GIF, matplotlib
+animation, TensorBoard summary emission) on tiny dummy frames. CPU-only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from src.tasks.base.training.qualitative_saving import (
+    save_qualitative_animation,
+    save_qualitative_clip,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+def _frame(fill: int = 50) -> np.ndarray:
+    return np.full((6, 8, 3), fill, dtype=np.uint8)
+
+
+class _RecordingWriter:
+    """Minimal TensorBoard SummaryWriter stand-in recording add_* calls."""
+
+    def __init__(self) -> None:
+        self.images: list[tuple[str, tuple[int, ...]]] = []
+        self.video_summaries = 0
+
+    def add_image(self, tag: str, img, step: int) -> None:
+        self.images.append((tag, tuple(np.asarray(img).shape)))
+
+    def _get_file_writer(self):
+        writer = self
+
+        class _FW:
+            def add_summary(self, summary, step):
+                writer.video_summaries += 1
+
+        return _FW()
+
+
+def test_single_frame_saves_png_and_logs_image(tmp_path: Path) -> None:
+    writer = _RecordingWriter()
+    out = save_qualitative_clip(
+        frames_rgb=[_frame()],
+        artifact_dir=tmp_path,
+        name="single",
+        tb_writer=writer,
+        tag="qual/single",
+        global_step=3,
+    )
+    assert out.suffix == ".png"
+    assert out.exists()
+    with Image.open(out) as im:
+        assert im.size == (8, 6)
+    # add_image receives (C, H, W)
+    assert writer.images and writer.images[0][1] == (3, 6, 8)
+
+
+def test_multi_frame_saves_gif_and_logs_video(tmp_path: Path) -> None:
+    writer = _RecordingWriter()
+    out = save_qualitative_clip(
+        frames_rgb=[_frame(10), _frame(200), _frame(120)],
+        artifact_dir=tmp_path,
+        name="clip",
+        tb_writer=writer,
+        tag="qual/clip",
+        global_step=1,
+        fps=8.0,
+    )
+    assert out.suffix == ".gif"
+    with Image.open(out) as im:
+        assert getattr(im, "n_frames", 1) == 3
+    assert writer.video_summaries == 1
+
+
+def test_clip_works_without_writer(tmp_path: Path) -> None:
+    out = save_qualitative_clip(
+        frames_rgb=[_frame(), _frame(80)],
+        artifact_dir=tmp_path,
+        name="nowriter",
+        tb_writer=None,
+        tag="qual/x",
+        global_step=0,
+    )
+    assert out.exists()
+
+
+def test_float_frames_clipped_to_uint8(tmp_path: Path) -> None:
+    # out-of-range floats must be clipped without raising
+    frame: np.ndarray = np.full((4, 4, 3), 300.0, dtype=np.float32)
+    out = save_qualitative_clip(
+        frames_rgb=[frame],
+        artifact_dir=tmp_path,
+        name="floaty",
+        tb_writer=None,
+        tag="t",
+        global_step=0,
+    )
+    assert out.exists()
+
+
+def test_save_animation_smoke(tmp_path: Path) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.animation import FuncAnimation
+
+    fig, ax = plt.subplots()
+    (line,) = ax.plot([], [])
+
+    def _update(frame: int):
+        line.set_data(range(frame + 1), range(frame + 1))
+        return (line,)
+
+    anim = FuncAnimation(fig, _update, frames=3, blit=True)
+    writer = _RecordingWriter()
+    out = save_qualitative_animation(
+        animation=anim,
+        artifact_dir=tmp_path,
+        name="anim",
+        tb_writer=writer,
+        tag="qual/anim",
+        global_step=0,
+        fps=5.0,
+    )
+    assert out.suffix == ".gif"
+    assert out.exists()
+    assert writer.video_summaries == 1

--- a/tests/unit/tasks/base/conftest.py
+++ b/tests/unit/tasks/base/conftest.py
@@ -1,0 +1,134 @@
+"""Base-specific fixtures: dummy scenes, tiny configs, minimal subclasses.
+
+These fixtures support unit tests for ``src.tasks.base`` abstractions. They are
+intentionally lightweight (no real models, no real datasets) so the tests stay
+fast and CPU-only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from src.tasks.base.data.scene_dataset import (
+    Scene,
+    SceneDatasetBase,
+    SceneDatasetConfig,
+)
+
+
+def write_scene_dir(
+    scene_dir: Path,
+    *,
+    num_frames: int = 8,
+    num_cameras: int = 1,
+    arrays: dict[str, np.ndarray] | None = None,
+    meta: dict[str, Any] | None = None,
+) -> Path:
+    """Write a minimal on-disk scene directory (meta.json, scalars.json, npy).
+
+    Returns the scene directory path.
+    """
+    scene_dir.mkdir(parents=True, exist_ok=True)
+    meta_payload: dict[str, Any] = {"num_frames": num_frames}
+    if meta:
+        meta_payload.update(meta)
+    (scene_dir / "meta.json").write_text(json.dumps(meta_payload), encoding="utf-8")
+    (scene_dir / "scalars.json").write_text(
+        json.dumps({"num_cameras": num_cameras}), encoding="utf-8"
+    )
+    arr = arrays if arrays is not None else {"position": np.zeros((num_frames, 3), np.float32)}
+    for key, value in arr.items():
+        np.save(scene_dir / f"{key}.npy", value)
+    return scene_dir
+
+
+@pytest.fixture
+def scene_writer():
+    """Expose ``write_scene_dir`` as a fixture (importlib mode hides the module)."""
+    return write_scene_dir
+
+
+class _ConcreteSceneDataset(SceneDatasetBase[dict]):
+    """Minimal concrete dataset whose sample is just scene metadata."""
+
+    def build_sample(self, scene: Scene) -> dict:
+        return {"path": str(scene.path), "num_frames": scene.num_frames}
+
+
+@pytest.fixture
+def make_scene_dataset(tmp_path: Path):
+    """Factory building a concrete ``SceneDatasetBase`` over on-disk scenes.
+
+    With ``n_scenes > 0`` it writes that many scene directories plus a
+    ``train.txt`` split and returns an initialized dataset. With ``n_scenes == 0``
+    nothing is written; the caller is expected to supply a ``config`` and to have
+    laid out the scenes/split themselves (used for filtering/error tests).
+    """
+
+    def _factory(
+        *,
+        n_scenes: int = 3,
+        num_frames: int = 8,
+        num_cameras: int = 1,
+        config: SceneDatasetConfig | None = None,
+        rng: np.random.Generator | None = None,
+        root: Path | None = None,
+    ) -> SceneDatasetBase:
+        root = root or (tmp_path / f"ds_{n_scenes}_{num_frames}_{num_cameras}")
+        cfg = config
+        if n_scenes > 0:
+            scenes_dir = root / "scenes"
+            names = []
+            for i in range(n_scenes):
+                name = f"scene_{i:04d}"
+                write_scene_dir(
+                    scenes_dir / name,
+                    num_frames=num_frames,
+                    num_cameras=num_cameras,
+                )
+                names.append(name)
+            split_file = root / "train.txt"
+            split_file.write_text("\n".join(names) + "\n", encoding="utf-8")
+            cfg = config or SceneDatasetConfig(
+                scene_dir=root,
+                split_file=split_file,
+                seq_len_range=(1, num_frames),
+                num_views_range=(1, num_cameras),
+            )
+        if cfg is None:
+            raise ValueError("config is required when n_scenes == 0")
+        return _ConcreteSceneDataset(config=cfg, rng=rng or np.random.default_rng(0))
+
+    return _factory
+
+
+@pytest.fixture
+def make_scene():
+    """Factory building an in-memory ``Scene`` (no disk IO)."""
+
+    def _factory(
+        *,
+        num_frames: int = 8,
+        num_cameras: int = 2,
+        data: dict[str, Any] | None = None,
+        meta: dict[str, Any] | None = None,
+        path: Path | None = None,
+    ) -> Scene:
+        payload = data if data is not None else {
+            "cam_0_ball_uv": np.zeros((num_frames, 2), np.float32),
+            "position": np.zeros((num_frames, 3), np.float32),
+        }
+        return Scene(
+            path=path or Path("/tmp/scene_x"),
+            data=payload,
+            meta=meta or {},
+            num_frames=num_frames,
+            num_cameras=num_cameras,
+        )
+
+    return _factory

--- a/tests/unit/tasks/base/data/test_chunk_manager.py
+++ b/tests/unit/tasks/base/data/test_chunk_manager.py
@@ -1,0 +1,134 @@
+"""Unit tests for the background chunk manager.
+
+These exercise the deterministic, single-threaded pieces (id allocation,
+split-file writing, used-marking, session-dir cleanup) and one short
+end-to-end background-generation cycle with a fast synchronous generator. The
+generator writes scene dirs immediately so ``wait_for_ready_chunk`` returns
+quickly; timeouts keep the suite from hanging if something regresses.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from src.tasks.base.data.chunk_manager import (
+    ChunkInfo,
+    ChunkManager,
+    ChunkState,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _fast_generator_factory(scene_count: int = 2):
+    """Generator that writes ``scene_count`` empty scene dirs synchronously."""
+
+    def _generate(chunk_dir: Path, *, num_scenes: int, stop_event: threading.Event) -> None:
+        scenes = chunk_dir / "scenes"
+        scenes.mkdir(parents=True, exist_ok=True)
+        for i in range(scene_count):
+            (scenes / f"scene_{i:03d}").mkdir()
+
+    return lambda: _generate
+
+
+def _make_manager(tmp_path: Path, **kw) -> ChunkManager:
+    return ChunkManager(
+        chunks_dir=tmp_path / "chunks",
+        chunk_generator_factory=_fast_generator_factory(kw.pop("scene_count", 2)),
+        scenes_per_chunk=kw.pop("scenes_per_chunk", 2),
+        epochs_per_chunk=kw.pop("epochs_per_chunk", 1),
+        prefetch_chunks=kw.pop("prefetch_chunks", 0),
+    )
+
+
+def test_init_creates_session_dir(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    assert mgr.session_dir.exists()
+    assert mgr.session_dir.parent == mgr.chunks_dir
+    assert mgr.session_dir.name.startswith("session_")
+
+
+def test_allocate_chunk_id_is_monotonic(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    ids = [mgr._allocate_chunk_id() for _ in range(4)]
+    assert ids == [0, 1, 2, 3]
+    assert mgr._next_chunk_id == 4
+
+
+def test_write_train_split_lists_scene_dirs(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    chunk_dir = tmp_path / "c0"
+    scenes = chunk_dir / "scenes"
+    scenes.mkdir(parents=True)
+    (scenes / "scene_001").mkdir()
+    (scenes / "scene_000").mkdir()
+    (scenes / "not_a_dir.txt").write_text("x")  # files are ignored
+
+    mgr._write_train_split(chunk_dir)
+    lines = (chunk_dir / "train.txt").read_text().splitlines()
+    assert lines == ["scene_000", "scene_001"]  # sorted, dirs only
+
+
+def test_write_train_split_raises_when_empty(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    chunk_dir = tmp_path / "empty"
+    (chunk_dir / "scenes").mkdir(parents=True)
+    with pytest.raises(RuntimeError, match="No scenes were generated"):
+        mgr._write_train_split(chunk_dir)
+
+
+def test_mark_used_on_unknown_id_is_noop(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    # Should not raise even though id 99 was never registered.
+    mgr.mark_used(99)
+
+
+def test_delete_chunk_removes_dir_and_entry(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    chunk_dir = mgr.session_dir / "scene_0"
+    chunk_dir.mkdir(parents=True)
+    mgr._chunks[0] = ChunkInfo(chunk_id=0, path=chunk_dir)
+
+    mgr._delete_chunk(0)
+    assert 0 not in mgr._chunks
+    assert not chunk_dir.exists()
+
+
+def test_wait_for_ready_chunk_times_out_when_none(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    # No worker started, so no ready chunk -> returns None within the timeout.
+    assert mgr.wait_for_ready_chunk(timeout=0.2) is None
+
+
+def test_chunk_info_repr() -> None:
+    info = ChunkInfo(chunk_id=3, path=Path("/x"))
+    assert "id=3" in repr(info)
+    assert info.state is ChunkState.PREPARING
+
+
+def test_background_generation_cycle(tmp_path: Path) -> None:
+    """One start->ready->mark_used->stop cycle with a fast generator."""
+    mgr = _make_manager(tmp_path, prefetch_chunks=0, scene_count=2)
+    mgr.start()
+    try:
+        chunk = mgr.wait_for_ready_chunk(timeout=10.0)
+        assert chunk is not None
+        assert chunk.state is ChunkState.READY
+        assert (chunk.path / "train.txt").exists()
+        assert (chunk.path / "scenes").is_dir()
+        mgr.mark_used(chunk.chunk_id)
+    finally:
+        mgr.stop()
+    # After stop, the session dir is cleaned up.
+    assert not mgr.session_dir.exists()
+
+
+def test_stop_cleans_session_dir(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    assert mgr.session_dir.exists()
+    mgr.stop()
+    assert not mgr.session_dir.exists()

--- a/tests/unit/tasks/base/data/test_chunked_datamodule.py
+++ b/tests/unit/tasks/base/data/test_chunked_datamodule.py
@@ -1,0 +1,162 @@
+"""Unit tests for BaseChunkedDataModule chunk-rotation lifecycle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from torch.utils.data import Dataset
+
+from src.tasks.base.data.chunked_datamodule import BaseChunkedDataModule
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeChunk:
+    def __init__(self, chunk_id: int) -> None:
+        self.chunk_id = chunk_id
+        self.path = Path(f"/chunks/scene_{chunk_id}")
+
+
+class _FakeChunkManager:
+    """Records start/stop/mark_used and serves chunks in sequence."""
+
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+        self.used: list[int] = []
+        self._next = 0
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def mark_used(self, chunk_id: int) -> None:
+        self.used.append(chunk_id)
+
+    def wait_for_ready_chunk(self):
+        chunk = _FakeChunk(self._next)
+        self._next += 1
+        return chunk
+
+
+class _DummyDataset(Dataset):
+    def __init__(self, scene_dir) -> None:
+        self.scene_dir = scene_dir
+
+    def __len__(self) -> int:
+        return 1
+
+    def __getitem__(self, idx):
+        return idx
+
+
+class _DM(BaseChunkedDataModule):
+    def _build_collate_fn(self):
+        return None
+
+    def _build_dataset(self, scene_dir, split_file, augment):
+        return _DummyDataset(scene_dir)
+
+    def _dataset_name(self) -> str:
+        return "dummy"
+
+    def _build_chunk_manager(self):
+        return _FakeChunkManager()
+
+    def _default_chunks_dir(self) -> str:
+        return "outputs/chunks"
+
+
+def test_chunk_config_parsing() -> None:
+    dm = _DM(
+        {
+            "data": {
+                "chunk": {
+                    "scenes_per_chunk": 500,
+                    "epochs_per_chunk": 2,
+                    "prefetch_chunks": 3,
+                    "chunks_dir": "/tmp/chunks",
+                    "generation_workers": 4,
+                },
+                "generator_device": "cuda",
+            }
+        }
+    )
+    assert dm.scenes_per_chunk == 500
+    assert dm.epochs_per_chunk == 2
+    assert dm.prefetch_chunks == 3
+    assert dm.chunks_dir == Path("/tmp/chunks")
+    assert dm.generation_workers == 4
+    assert dm.generator_device == "cuda"
+
+
+def test_chunk_config_defaults() -> None:
+    dm = _DM({})
+    assert dm.scenes_per_chunk == 1000
+    assert dm.epochs_per_chunk == 3
+    assert dm.prefetch_chunks == 1
+    assert dm.chunks_dir == Path("outputs/chunks")
+    assert dm.generator_device == "cpu"
+
+
+def test_epoch_end_rotates_after_epochs_per_chunk(tmp_path: Path) -> None:
+    root = tmp_path / "scenes"
+    root.mkdir()
+    for s in ("train", "val", "test"):
+        (root / f"{s}.txt").write_text("scene_0000\n", encoding="utf-8")
+
+    dm = _DM({"data": {"scene_dir": str(root), "chunk": {"epochs_per_chunk": 2}}})
+    dm.setup("fit")
+    assert dm.chunk_manager.started is True  # type: ignore[union-attr]
+
+    # epoch 1: counter 1 < 2 -> no rotation
+    dm.on_train_epoch_end()
+    assert dm._current_chunk_id is None
+    assert dm._epochs_on_current_chunk == 1
+
+    # epoch 2: counter 2 >= 2 -> rotate (first chunk loaded, none marked used)
+    dm.on_train_epoch_end()
+    assert dm._current_chunk_id == 0
+    assert dm._epochs_on_current_chunk == 0
+    assert dm.chunk_manager.used == []  # type: ignore[union-attr]
+
+    # next two epochs -> rotate again, marking the old chunk used
+    dm.on_train_epoch_end()
+    dm.on_train_epoch_end()
+    assert dm._current_chunk_id == 1
+    assert dm.chunk_manager.used == [0]  # type: ignore[union-attr]
+
+
+def test_teardown_stops_manager(tmp_path: Path) -> None:
+    root = tmp_path / "scenes"
+    root.mkdir()
+    for s in ("train", "val", "test"):
+        (root / f"{s}.txt").write_text("scene_0000\n", encoding="utf-8")
+    dm = _DM({"data": {"scene_dir": str(root)}})
+    dm.setup("fit")
+    manager = dm.chunk_manager
+    dm.teardown("fit")
+    assert manager.stopped is True  # type: ignore[union-attr]
+    assert dm.chunk_manager is None
+
+
+def test_load_next_chunk_raises_when_none(tmp_path: Path) -> None:
+    class _NoneManager(_FakeChunkManager):
+        def wait_for_ready_chunk(self):
+            return None
+
+    class _DMNone(_DM):
+        def _build_chunk_manager(self):
+            return _NoneManager()
+
+    root = tmp_path / "scenes"
+    root.mkdir()
+    for s in ("train", "val", "test"):
+        (root / f"{s}.txt").write_text("scene_0000\n", encoding="utf-8")
+    dm = _DMNone({"data": {"scene_dir": str(root)}})
+    dm.setup("fit")
+    with pytest.raises(RuntimeError, match="no ready chunk"):
+        dm._load_next_chunk()

--- a/tests/unit/tasks/base/data/test_datamodule.py
+++ b/tests/unit/tasks/base/data/test_datamodule.py
@@ -1,0 +1,116 @@
+"""Unit tests for SceneDirectoryDataModule setup/validation logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from torch.utils.data import Dataset
+
+from src.tasks.base.data.datamodule import SceneDirectoryDataModule
+
+pytestmark = pytest.mark.unit
+
+
+class _DummyDataset(Dataset):
+    def __init__(self, name: str, n: int = 4) -> None:
+        self.name = name
+        self.n = n
+
+    def __len__(self) -> int:
+        return self.n
+
+    def __getitem__(self, idx: int):
+        return idx
+
+
+class _DM(SceneDirectoryDataModule):
+    def _build_collate_fn(self):
+        return None
+
+    def _build_dataset(self, scene_dir, split_file, augment):
+        return _DummyDataset(f"{split_file}:{augment}")
+
+    def _dataset_name(self) -> str:
+        return "dummy"
+
+
+def _make_scene_root(tmp_path: Path, *, splits: tuple[str, ...]) -> Path:
+    root = tmp_path / "scene_dir"
+    root.mkdir()
+    for s in splits:
+        (root / f"{s}.txt").write_text("scene_0000\n", encoding="utf-8")
+    return root
+
+
+def test_config_parsing_defaults() -> None:
+    dm = _DM({})
+    assert dm.batch_size == _DM.default_batch_size
+    assert dm.num_workers == 4
+    assert dm.pin_memory is True
+    assert dm.scene_dir == Path(_DM.default_scene_dir)
+
+
+def test_config_parsing_overrides() -> None:
+    dm = _DM({"data": {"batch_size": 8, "num_workers": 2, "pin_memory": False, "scene_dir": "/x"}})
+    assert dm.batch_size == 8
+    assert dm.num_workers == 2
+    assert dm.pin_memory is False
+    assert dm.scene_dir == Path("/x")
+
+
+def test_setup_missing_scene_dir_raises(tmp_path: Path) -> None:
+    dm = _DM({"data": {"scene_dir": str(tmp_path / "absent")}})
+    with pytest.raises(RuntimeError, match="Scene directory not found"):
+        dm.setup("fit")
+
+
+def test_setup_missing_train_split_raises(tmp_path: Path) -> None:
+    root = _make_scene_root(tmp_path, splits=("val",))  # no train.txt
+    dm = _DM({"data": {"scene_dir": str(root)}})
+    with pytest.raises(RuntimeError, match="Missing required split file"):
+        dm.setup("fit")
+
+
+def test_setup_fit_builds_train_and_val(tmp_path: Path) -> None:
+    root = _make_scene_root(tmp_path, splits=("train", "val"))
+    dm = _DM({"data": {"scene_dir": str(root)}})
+    dm.setup("fit")
+    assert dm.train_dataset is not None
+    assert dm.val_dataset is not None
+    assert dm.train_dataset is not dm.val_dataset
+
+
+def test_setup_fit_val_falls_back_to_train(tmp_path: Path) -> None:
+    root = _make_scene_root(tmp_path, splits=("train",))  # no val.txt
+    dm = _DM({"data": {"scene_dir": str(root)}})
+    dm.setup("fit")
+    assert dm.val_dataset is dm.train_dataset
+
+
+def test_setup_test_missing_split_raises(tmp_path: Path) -> None:
+    root = _make_scene_root(tmp_path, splits=("train",))  # no test.txt
+    dm = _DM({"data": {"scene_dir": str(root)}})
+    with pytest.raises(RuntimeError, match="Missing required split file"):
+        dm.setup("test")
+
+
+def test_dataloaders_require_setup(tmp_path: Path) -> None:
+    dm = _DM({"data": {"scene_dir": str(tmp_path)}})
+    with pytest.raises(RuntimeError, match="Call setup"):
+        dm.train_dataloader()
+    with pytest.raises(RuntimeError, match="Call setup"):
+        dm.val_dataloader()
+    with pytest.raises(RuntimeError, match="Call setup"):
+        dm.test_dataloader()
+
+
+def test_train_loader_shuffles_and_drops_last(tmp_path: Path) -> None:
+    root = _make_scene_root(tmp_path, splits=("train", "val"))
+    dm = _DM({"data": {"scene_dir": str(root), "batch_size": 2, "num_workers": 0, "pin_memory": False}})
+    dm.setup("fit")
+    train_loader = dm.train_dataloader()
+    val_loader = dm.val_dataloader()
+    assert train_loader.drop_last is True
+    assert val_loader.drop_last is False
+    assert train_loader.batch_size == 2

--- a/tests/unit/tasks/base/data/test_dataset_writer.py
+++ b/tests/unit/tasks/base/data/test_dataset_writer.py
@@ -1,0 +1,111 @@
+"""Unit tests for the base dataset writer (split + meta generation)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.tasks.base.data.dataset_writer import BaseDatasetWriter
+
+pytestmark = pytest.mark.unit
+
+
+class _Meta:
+    def __init__(self, d: dict) -> None:
+        self._d = d
+
+    def to_dict(self) -> dict:
+        return self._d
+
+
+class _Writer(BaseDatasetWriter):
+    def save_scene(self, scene_data) -> Path:  # pragma: no cover - not exercised here
+        raise NotImplementedError
+
+
+def _writer_with_records(tmp_path: Path, n: int) -> _Writer:
+    w = _Writer(tmp_path / "out")
+    for i in range(n):
+        w.scene_records.append({"file": f"scene_{i:04d}", "num_cameras": (i % 3) + 1})
+    return w
+
+
+def test_init_creates_dirs(tmp_path: Path) -> None:
+    w = _Writer(tmp_path / "out")
+    assert w.output_dir.exists()
+    assert w.scenes_dir.exists()
+    assert w.scenes_dir.name == "scenes"
+
+
+def test_save_split_info_partition_sizes(tmp_path: Path) -> None:
+    w = _writer_with_records(tmp_path, 10)
+    w.save_split_info(train_ratio=0.6, val_ratio=0.2, test_ratio=0.2, seed=0)
+
+    train = (w.output_dir / "train.txt").read_text().splitlines()
+    val = (w.output_dir / "val.txt").read_text().splitlines()
+    test = (w.output_dir / "test.txt").read_text().splitlines()
+    assert len(train) == 6
+    assert len(val) == 2
+    assert len(test) == 2
+    # all 10 unique scenes accounted for, no overlap
+    assert set(train) | set(val) | set(test) == {f"scene_{i:04d}" for i in range(10)}
+    assert not (set(train) & set(val))
+    assert not (set(val) & set(test))
+
+
+def test_save_split_info_is_deterministic(tmp_path: Path) -> None:
+    w1 = _writer_with_records(tmp_path / "a", 8)
+    w2 = _writer_with_records(tmp_path / "b", 8)
+    w1.save_split_info(seed=123)
+    w2.save_split_info(seed=123)
+    assert (w1.output_dir / "train.txt").read_text() == (w2.output_dir / "train.txt").read_text()
+
+
+def test_save_split_info_writes_split_info_json(tmp_path: Path) -> None:
+    w = _writer_with_records(tmp_path, 5)
+    w.save_split_info(train_ratio=0.8, val_ratio=0.1, test_ratio=0.1, seed=7)
+    info = json.loads((w.output_dir / "split_info.json").read_text())
+    assert info["seed"] == 7
+    assert info["train_ratio"] == 0.8
+    assert sum(info["n_scenes"].values()) == 5
+
+
+def test_save_meta_json_stats(tmp_path: Path) -> None:
+    w = _writer_with_records(tmp_path, 3)  # num_cameras: 1, 2, 3
+    w.save_meta_json(config={"k": "v"})
+    meta = json.loads((w.output_dir / "meta.json").read_text())
+    assert meta["stats"]["total_scenes"] == 3
+    assert meta["stats"]["total_cameras"] == 6
+    assert meta["stats"]["avg_cameras_per_scene"] == pytest.approx(2.0)
+    assert meta["config"] == {"k": "v"}
+    assert len(meta["scenes"]) == 3
+
+
+def test_save_meta_json_empty_records(tmp_path: Path) -> None:
+    w = _Writer(tmp_path / "out")
+    w.save_meta_json()
+    meta = json.loads((w.output_dir / "meta.json").read_text())
+    assert meta["stats"]["total_scenes"] == 0
+    assert meta["stats"]["avg_cameras_per_scene"] == 0
+
+
+def test_write_scene_files_roundtrip(tmp_path: Path) -> None:
+    w = _Writer(tmp_path / "out")
+    scene_path = w.scenes_dir / "scene_0000"
+    scene_path.mkdir()
+    arrays: dict[str, np.ndarray] = {
+        "position": np.arange(6).reshape(3, 2).astype(np.float32)
+    }
+    w._write_scene_files(
+        scene_path,
+        scene_meta=_Meta({"num_frames": 3}),
+        scalars={"num_cameras": 2},
+        arrays=arrays,
+    )
+    assert json.loads((scene_path / "meta.json").read_text()) == {"num_frames": 3}
+    assert json.loads((scene_path / "scalars.json").read_text()) == {"num_cameras": 2}
+    loaded = np.load(scene_path / "position.npy")
+    assert np.array_equal(loaded, arrays["position"])

--- a/tests/unit/tasks/base/data/test_scene_dataset.py
+++ b/tests/unit/tasks/base/data/test_scene_dataset.py
@@ -1,0 +1,347 @@
+"""Unit tests for the base scene dataset and its dataclasses/helpers."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.tasks.base.data.scene_dataset import (
+    CameraSelection,
+    Scene,
+    SceneDatasetBase,
+    SceneDatasetConfig,
+    TemporalWindow,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_window_slice() -> None:
+    w = TemporalWindow(start=2, end=5, seq_len=3, full_len=10)
+    assert w.sl == slice(2, 5)
+    arr = np.arange(10)
+    assert arr[w.sl].tolist() == [2, 3, 4]
+
+
+def test_camera_selection_primary() -> None:
+    assert CameraSelection(indices=(2, 0, 1)).primary == 2
+
+
+def test_camera_selection_empty_primary_raises() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        _ = CameraSelection(indices=()).primary
+
+
+# ---------------------------------------------------------------------------
+# Scene accessors
+# ---------------------------------------------------------------------------
+
+
+def test_scene_has_and_require_key(make_scene) -> None:
+    scene = make_scene(data={"position": np.zeros((4, 3))})
+    assert scene.has_key("position")
+    assert not scene.has_key("missing")
+    scene.require_key("position")  # no raise
+    with pytest.raises(KeyError, match="Missing key 'missing'"):
+        scene.require_key("missing")
+
+
+def test_scene_metadata_properties() -> None:
+    scene = Scene(
+        path=Path("/x"),
+        data={},
+        meta={"scene_id": 42, "rally_length": "7", "shots": [{"t": 1}, "bad", {"t": 2}]},
+        num_frames=10,
+        num_cameras=1,
+    )
+    assert scene.scene_id == "42"
+    assert scene.rally_length == 7
+    assert scene.shots == [{"t": 1}, {"t": 2}]  # non-dicts filtered out
+
+
+def test_scene_metadata_missing_or_invalid() -> None:
+    scene = Scene(path=Path("/x"), data={}, meta={"rally_length": "nope"}, num_frames=3, num_cameras=1)
+    assert scene.scene_id is None
+    assert scene.rally_length is None  # invalid int -> None
+    assert scene.shots == []
+
+
+def test_effective_num_frames_takes_min_positive(make_scene) -> None:
+    scene = make_scene(num_frames=10)
+    assert scene.effective_num_frames(6, 8) == 6
+    assert scene.effective_num_frames(20) == 10  # candidates larger -> num_frames
+    assert scene.effective_num_frames(0, -3) == 10  # non-positive candidates ignored
+
+
+def test_get_camera_array_copies_and_windows() -> None:
+    data: dict[str, np.ndarray] = {
+        "cam_1_ball_uv": np.arange(8 * 2).reshape(8, 2).astype(np.float32)
+    }
+    scene = Scene(path=Path("/x"), data=data, meta={}, num_frames=8, num_cameras=2)
+    full = scene.get_camera_array(1, "ball_uv")
+    assert full.shape == (8, 2)
+    # mutating the returned array must not touch the payload (copy semantics)
+    full[0, 0] = -999
+    assert scene.data["cam_1_ball_uv"][0, 0] == 0
+
+    w = TemporalWindow(start=1, end=4, seq_len=3, full_len=8)
+    windowed = scene.get_camera_array(1, "ball_uv", window=w)
+    assert windowed.shape == (3, 2)
+
+
+def test_get_camera_array_out_of_range() -> None:
+    scene = Scene(path=Path("/x"), data={"cam_0_x": np.zeros((4, 2))}, meta={}, num_frames=4, num_cameras=1)
+    with pytest.raises(ValueError, match="out of range"):
+        scene.get_camera_array(1, "x")
+
+
+def test_get_array_scalar_window_raises() -> None:
+    scene = Scene(path=Path("/x"), data={"scalar": np.asarray(3.0)}, meta={}, num_frames=1, num_cameras=1)
+    w = TemporalWindow(start=0, end=1, seq_len=1, full_len=1)
+    with pytest.raises(ValueError, match="scalar and cannot be temporally sliced"):
+        scene.get_array("scalar", window=w)
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value, msg",
+    [
+        ((1, 2, 3), "length 2"),
+        ((0, 5), "positive integers"),
+        ((-1, 5), "positive integers"),
+        ((5, 2), "min must be <= max"),
+    ],
+)
+def test_validate_range_errors(value, msg) -> None:
+    with pytest.raises(ValueError, match=msg):
+        SceneDatasetBase._validate_range(value, name="r")
+
+
+def test_validate_range_ok() -> None:
+    SceneDatasetBase._validate_range((1, 1024), name="r")  # no raise
+
+
+def test_parse_int_range_present_and_default() -> None:
+    cfg = {"seq_len_range": [3, 9]}
+    assert SceneDatasetBase._parse_int_range(cfg, "seq_len_range") == (3, 9)
+    assert SceneDatasetBase._parse_int_range({}, "missing", default=(1, 2)) == (1, 2)
+
+
+def test_parse_int_range_missing_no_default_raises() -> None:
+    with pytest.raises(KeyError, match="seq_len_range"):
+        SceneDatasetBase._parse_int_range({}, "seq_len_range")
+
+
+def test_parse_camera_mode_lowercases_strings() -> None:
+    assert SceneDatasetBase._parse_camera_mode({"camera_mode": "RANDOM"}) == "random"
+    assert SceneDatasetBase._parse_camera_mode({"camera_mode": 2}) == 2
+    assert SceneDatasetBase._parse_camera_mode({}) == "random"
+
+
+def test_resolve_data_cfg_handles_none_and_dict() -> None:
+    assert SceneDatasetBase._resolve_data_cfg(None) == {}
+    assert SceneDatasetBase._resolve_data_cfg({"data": {"a": 1}}) == {"a": 1}
+    assert SceneDatasetBase._resolve_data_cfg({"data": {}}) == {}
+
+
+# ---------------------------------------------------------------------------
+# Window sampling (deterministic with a seeded rng)
+# ---------------------------------------------------------------------------
+
+
+def test_select_window_center_mode(make_scene_dataset, make_scene) -> None:
+    ds = make_scene_dataset(num_frames=10)
+    scene = make_scene(num_frames=10)
+    w = ds.select_window(scene, seq_len_range=(4, 4), crop_mode="center")
+    assert w.seq_len == 4
+    # center crop: max_start=6 -> start=3
+    assert w.start == 3
+    assert w.end == 7
+    assert w.full_len == 10
+
+
+def test_select_window_full_when_seq_ge_full(make_scene_dataset, make_scene) -> None:
+    ds = make_scene_dataset(num_frames=5)
+    scene = make_scene(num_frames=5)
+    w = ds.select_window(scene, seq_len_range=(5, 5), crop_mode="random")
+    assert w.start == 0
+    assert w.end == 5
+
+
+def test_select_window_random_in_bounds(make_scene_dataset, make_scene) -> None:
+    ds = make_scene_dataset(num_frames=12)
+    scene = make_scene(num_frames=12)
+    for _ in range(20):
+        w = ds.select_window(scene, seq_len_range=(2, 6), crop_mode="random")
+        assert 2 <= w.seq_len <= 6
+        assert w.start >= 0
+        assert w.end <= 12
+        assert w.end - w.start == w.seq_len
+
+
+def test_select_window_too_short_raises(make_scene_dataset, make_scene) -> None:
+    ds = make_scene_dataset(num_frames=8)
+    short = make_scene(num_frames=2)
+    with pytest.raises(ValueError, match="too short"):
+        ds.select_window(short, seq_len_range=(5, 5))
+
+
+def test_select_window_bad_crop_mode_raises(make_scene_dataset, make_scene) -> None:
+    ds = make_scene_dataset(num_frames=8)
+    scene = make_scene(num_frames=8)
+    with pytest.raises(ValueError, match="Unsupported crop_mode"):
+        ds.select_window(scene, crop_mode="weird")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Camera selection
+# ---------------------------------------------------------------------------
+
+
+def test_select_cameras_first_mode(make_scene_dataset, make_scene) -> None:
+    ds = make_scene_dataset(num_cameras=4)
+    scene = make_scene(num_cameras=4)
+    sel = ds.select_cameras(scene, num_views_range=(3, 3), camera_mode="first")
+    assert sel.indices == (0, 1, 2)
+
+
+def test_select_cameras_random_unique(make_scene_dataset, make_scene) -> None:
+    ds = make_scene_dataset(num_cameras=5)
+    scene = make_scene(num_cameras=5)
+    for _ in range(15):
+        sel = ds.select_cameras(scene, num_views_range=(2, 4), camera_mode="random")
+        assert 2 <= len(sel.indices) <= 4
+        assert len(set(sel.indices)) == len(sel.indices)  # unique
+        assert all(0 <= i < 5 for i in sel.indices)
+
+
+def test_select_cameras_int_mode_primary_first(make_scene_dataset, make_scene) -> None:
+    ds = make_scene_dataset(num_cameras=5)
+    scene = make_scene(num_cameras=5)
+    sel = ds.select_cameras(scene, num_views_range=(3, 3), camera_mode=2)
+    assert sel.primary == 2
+    assert len(sel.indices) == 3
+    assert len(set(sel.indices)) == 3
+
+
+def test_select_cameras_not_enough_raises(make_scene_dataset, make_scene) -> None:
+    ds = make_scene_dataset(num_cameras=2)
+    scene = make_scene(num_cameras=1)
+    with pytest.raises(ValueError, match="min_views"):
+        ds.select_cameras(scene, num_views_range=(2, 2))
+
+
+def test_select_camera_returns_primary(make_scene_dataset, make_scene) -> None:
+    ds = make_scene_dataset(num_cameras=3)
+    scene = make_scene(num_cameras=3)
+    cam = ds.select_camera(scene)
+    assert isinstance(cam, int)
+    assert 0 <= cam < 3
+
+
+# ---------------------------------------------------------------------------
+# Disk-backed construction, indexing, filtering, __getitem__
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_construction_indexes_scenes(make_scene_dataset) -> None:
+    ds = make_scene_dataset(n_scenes=3, num_frames=8)
+    assert len(ds) == 3
+    assert len(ds.scenes) == 3
+    # headers carry the parsed num_frames / num_cameras
+    header = ds.get_scene_header(ds.scenes[0])
+    assert header.num_frames == 8
+    assert header.num_cameras == 1
+
+
+def test_dataset_getitem_builds_sample(make_scene_dataset) -> None:
+    ds = make_scene_dataset(n_scenes=2, num_frames=6)
+    sample = ds[0]
+    assert sample["num_frames"] == 6
+    assert "path" in sample
+
+
+def test_dataset_filters_short_scenes(make_scene_dataset, scene_writer, tmp_path: Path) -> None:
+    # seq_len_range min=5 filters out 3-frame scenes.
+    root = tmp_path / "mixed"
+    scenes_dir = root / "scenes"
+
+    scene_writer(scenes_dir / "long", num_frames=10)
+    scene_writer(scenes_dir / "short", num_frames=3)
+    (root / "train.txt").write_text("long\nshort\n", encoding="utf-8")
+
+    cfg = SceneDatasetConfig(
+        scene_dir=root,
+        split_file=root / "train.txt",
+        seq_len_range=(5, 10),
+        num_views_range=(1, 1),
+    )
+    ds = make_scene_dataset(config=cfg, root=root, n_scenes=0)
+    assert len(ds) == 1
+    assert ds.scenes[0].name == "long"
+
+
+def test_dataset_missing_split_file_raises(make_scene_dataset, tmp_path: Path) -> None:
+    scene_dir = tmp_path / "nope"
+    scene_dir.mkdir()
+    cfg = SceneDatasetConfig(
+        scene_dir=scene_dir,
+        split_file=scene_dir / "train.txt",
+        seq_len_range=(1, 4),
+    )
+    with pytest.raises(FileNotFoundError, match="Split file not found"):
+        make_scene_dataset(config=cfg, root=scene_dir, n_scenes=0)
+
+
+def test_get_scene_header_unknown_path_raises(make_scene_dataset) -> None:
+    ds = make_scene_dataset(n_scenes=1)
+    with pytest.raises(KeyError, match="Scene header not found"):
+        ds.get_scene_header(Path("/not/a/scene"))
+
+
+def test_decode_meta_variants(make_scene_dataset) -> None:
+    ds = make_scene_dataset(n_scenes=1)
+    assert ds._decode_meta({"a": 1}) == {"a": 1}
+    assert ds._decode_meta('{"a": 2}') == {"a": 2}
+    assert ds._decode_meta(b'{"a": 3}') == {"a": 3}
+    assert ds._decode_meta("not json") == {}
+    assert ds._decode_meta(123) == {}
+
+
+def test_resolve_num_frames_warns_on_overflow(make_scene_dataset) -> None:
+    ds = make_scene_dataset(n_scenes=1)
+    payload = {"position": np.zeros((5, 3))}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        n = ds._resolve_num_frames(path=Path("/x"), meta={"num_frames": 99}, payload=payload)
+    assert n == 5  # clamped to available length
+    assert any("exceeds available length" in str(w.message) for w in caught)
+
+
+def test_resolve_num_frames_uses_fallback_when_invalid(make_scene_dataset) -> None:
+    ds = make_scene_dataset(n_scenes=1)
+    payload = {"position": np.zeros((7, 3))}
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        n = ds._resolve_num_frames(path=Path("/x"), meta={"num_frames": 0}, payload=payload)
+    assert n == 7
+
+
+def test_scene_dataset_config_defaults() -> None:
+    cfg = SceneDatasetConfig(scene_dir=Path("/a"), split_file=Path("/a/train.txt"))
+    assert cfg.seq_len_range == (1, 1024)
+    assert cfg.num_views_range == (1, 1)
+    assert cfg.camera_mode == "random"
+    assert cfg.crop_mode == "random"

--- a/tests/unit/tasks/base/generate_dataset/test_parallel_runner.py
+++ b/tests/unit/tasks/base/generate_dataset/test_parallel_runner.py
@@ -1,0 +1,45 @@
+"""Unit tests for the parallel scene-generation fan-out helper.
+
+Under the ``spawn`` start method, the worker callable must be importable by
+qualified name in a *fresh* interpreter. A function defined in this test module
+is NOT reliably importable there (pytest's ``--import-mode=importlib`` registers
+the test module under a synthetic name with no ``__init__.py`` package on disk).
+We therefore drive the cross-process tests with the builtin :func:`pow`, which
+pickles cleanly and is importable everywhere: ``pow(idx, exponent)``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tasks.base.generate_dataset.parallel_runner import (
+    run_parallel_scene_generation,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_num_workers_below_one_raises() -> None:
+    with pytest.raises(ValueError, match="num_workers >= 1"):
+        list(run_parallel_scene_generation(pow, [0, 1], 2, num_workers=0))
+
+
+def test_results_preserve_input_order() -> None:
+    indices = [1, 2, 3, 4]
+    # pow(idx, 2) == idx ** 2
+    out = list(run_parallel_scene_generation(pow, indices, 2, num_workers=2))
+    assert out == [1, 4, 9, 16]
+
+
+def test_repeated_args_broadcast_to_each_call() -> None:
+    # exponent 3 broadcast to every call: pow(2,3)=8, pow(5,3)=125
+    out = list(run_parallel_scene_generation(pow, [2, 5], 3, num_workers=1))
+    assert out == [8, 125]
+
+
+def test_empty_indices_raises_value_error() -> None:
+    # NOTE (likely bug): for an empty index list, max_workers = min(num_workers, 0)
+    # == 0, and ProcessPoolExecutor rejects max_workers <= 0. So an empty workload
+    # raises instead of yielding nothing. This test documents the current behavior.
+    with pytest.raises(ValueError, match="max_workers must be greater than 0"):
+        list(run_parallel_scene_generation(pow, [], 2, num_workers=4))

--- a/tests/unit/tasks/base/inference/test_predictor.py
+++ b/tests/unit/tasks/base/inference/test_predictor.py
@@ -1,0 +1,77 @@
+"""Unit tests for BasePredictor's static/instance helper methods."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from src.tasks.base.inference.predictor import BasePredictor
+
+pytestmark = pytest.mark.unit
+
+
+class _Predictor(BasePredictor):
+    """Minimal concrete predictor to access non-abstract helpers."""
+
+    @classmethod
+    def load_from_checkpoint(cls, checkpoint_path, device="cpu", **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def predict(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+def test_cannot_instantiate_abstract() -> None:
+    with pytest.raises(TypeError):
+        BasePredictor()  # type: ignore[abstract]
+
+
+def test_ensure_checkpoint_accepts_single_path(tmp_path: Path) -> None:
+    ckpt = tmp_path / "model.ckpt"
+    ckpt.write_text("x")
+    result = _Predictor._ensure_checkpoint(ckpt)
+    assert result == [ckpt]
+    # string form too
+    assert _Predictor._ensure_checkpoint(str(ckpt)) == [ckpt]
+
+
+def test_ensure_checkpoint_accepts_iterable(tmp_path: Path) -> None:
+    a = tmp_path / "a.ckpt"
+    b = tmp_path / "b.ckpt"
+    a.write_text("x")
+    b.write_text("y")
+    assert _Predictor._ensure_checkpoint([a, b]) == [a, b]
+
+
+def test_ensure_checkpoint_missing_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Checkpoint not found"):
+        _Predictor._ensure_checkpoint(tmp_path / "nope.ckpt")
+
+
+def test_ensure_checkpoint_empty_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        _Predictor._ensure_checkpoint([])
+
+
+def test_resolve_device_cpu() -> None:
+    dev = _Predictor._resolve_device("cpu")
+    assert isinstance(dev, torch.device)
+    assert dev.type == "cpu"
+
+
+def test_to_device_preserves_none() -> None:
+    a = torch.zeros(2)
+    moved = _Predictor._to_device(torch.device("cpu"), a, None, torch.ones(3))
+    assert moved[0].device.type == "cpu"
+    assert moved[1] is None
+    assert moved[2].device.type == "cpu"
+
+
+def test_denormalize_coords_scales() -> None:
+    p = _Predictor.__new__(_Predictor)  # bypass __init__ (none defined, but be safe)
+    coords = torch.ones(2, 3)
+    out = p._denormalize_coords(coords, [2.0, 3.0, 4.0])
+    assert out.shape == (2, 3)
+    assert out[0].tolist() == [2.0, 3.0, 4.0]

--- a/tests/unit/tasks/base/training/test_chunk_rotation_callback.py
+++ b/tests/unit/tasks/base/training/test_chunk_rotation_callback.py
@@ -1,0 +1,41 @@
+"""Unit tests for the chunk-rotation callback."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tasks.base.training.chunk_rotation_callback import ChunkRotationCallback
+
+pytestmark = pytest.mark.unit
+
+
+class _DM:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def on_train_epoch_end(self) -> None:
+        self.calls += 1
+
+
+class _Trainer:
+    def __init__(self, datamodule) -> None:
+        self.datamodule = datamodule
+
+
+def test_forwards_to_datamodule_hook() -> None:
+    dm = _DM()
+    ChunkRotationCallback().on_train_epoch_end(_Trainer(dm), pl_module=None)
+    assert dm.calls == 1
+
+
+def test_noop_when_datamodule_none() -> None:
+    # Must not raise.
+    ChunkRotationCallback().on_train_epoch_end(_Trainer(None), pl_module=None)
+
+
+def test_noop_when_hook_absent() -> None:
+    class _Bare:
+        pass
+
+    # Datamodule without on_train_epoch_end -> no error.
+    ChunkRotationCallback().on_train_epoch_end(_Trainer(_Bare()), pl_module=None)

--- a/tests/unit/tasks/base/training/test_gan_loss.py
+++ b/tests/unit/tasks/base/training/test_gan_loss.py
@@ -1,0 +1,68 @@
+"""Unit tests for the least-squares GAN loss helpers."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.tasks.base.training.gan_loss import LSGANLoss
+
+pytestmark = pytest.mark.unit
+
+
+def test_generator_loss_matches_formula() -> None:
+    loss = LSGANLoss()
+    fake = torch.tensor([0.0, 0.5, 1.0])
+    # 0.5 * mean((fake - 1)^2) = 0.5 * mean([1, 0.25, 0]) = 0.5 * 0.4166...
+    expected = 0.5 * ((fake - 1.0) ** 2).mean()
+    assert torch.allclose(loss.generator_loss(fake), expected)
+
+
+def test_generator_loss_zero_when_fake_classified_real() -> None:
+    loss = LSGANLoss()
+    fake = torch.ones(4, 1)  # already at real_label
+    assert loss.generator_loss(fake).item() == pytest.approx(0.0)
+
+
+def test_discriminator_loss_matches_formula() -> None:
+    loss = LSGANLoss()
+    real = torch.tensor([1.0, 0.8])
+    fake = torch.tensor([0.0, 0.3])
+    real_term = ((real - 1.0) ** 2).mean()
+    fake_term = ((fake - 0.0) ** 2).mean()
+    expected = 0.5 * (real_term + fake_term)
+    assert torch.allclose(loss.discriminator_loss(real, fake), expected)
+
+
+def test_discriminator_loss_zero_when_perfectly_separated() -> None:
+    loss = LSGANLoss()
+    real = torch.ones(3, 1)
+    fake = torch.zeros(3, 1)
+    assert loss.discriminator_loss(real, fake).item() == pytest.approx(0.0)
+
+
+def test_custom_labels_respected() -> None:
+    loss = LSGANLoss(real_label=0.9, fake_label=0.1)
+    assert loss.real_label == pytest.approx(0.9)
+    assert loss.fake_label == pytest.approx(0.1)
+    real = torch.full((2, 1), 0.9)
+    fake = torch.full((2, 1), 0.1)
+    assert loss.discriminator_loss(real, fake).item() == pytest.approx(0.0)
+
+
+def test_losses_are_scalar_and_finite() -> None:
+    loss = LSGANLoss()
+    fake = torch.randn(5, 3)
+    real = torch.randn(5, 3)
+    g = loss.generator_loss(fake)
+    d = loss.discriminator_loss(real, fake)
+    assert g.ndim == 0 and d.ndim == 0
+    assert torch.isfinite(g) and torch.isfinite(d)
+
+
+def test_gradients_flow_to_inputs() -> None:
+    loss = LSGANLoss()
+    fake = torch.randn(4, 1, requires_grad=True)
+    loss.generator_loss(fake).backward()
+    assert fake.grad is not None
+    assert torch.isfinite(fake.grad).all()

--- a/tests/unit/tasks/base/training/test_gan_training.py
+++ b/tests/unit/tasks/base/training/test_gan_training.py
@@ -1,0 +1,164 @@
+"""Unit tests for ManualGANTrainingStrategy's pure decision logic.
+
+The optimizer/backward machinery requires a real LightningModule + Trainer and
+is covered by the integration smoke suite. Here we test the deterministic state
+logic: weight clamping, phase activation, step routing, and epoch-end scheduler
+stepping (with fake schedulers).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.tasks.base.training.gan_training import ManualGANTrainingStrategy
+
+pytestmark = pytest.mark.unit
+
+
+def _strategy(scheduler_interval: str = "step") -> ManualGANTrainingStrategy:
+    return ManualGANTrainingStrategy(
+        generator_gradient_clip_val=None,
+        discriminator_gradient_clip_val=None,
+        scheduler_interval=scheduler_interval,
+    )
+
+
+def test_initial_state() -> None:
+    s = _strategy()
+    assert s.phase_active is False
+    assert s.start_epoch is None
+    assert s.current_weight == 0.0
+    assert s.supervised_only_step_count == 0
+    assert s.hybrid_gan_step_count == 0
+
+
+def test_activate_phase_sets_flags() -> None:
+    s = _strategy()
+    s.activate_phase(5)
+    assert s.phase_active is True
+    assert s.start_epoch == 5
+
+
+def test_set_weight_clamps_negative_to_zero() -> None:
+    s = _strategy()
+    s.set_weight(0.3)
+    assert s.current_weight == pytest.approx(0.3)
+    s.set_weight(-1.0)
+    assert s.current_weight == 0.0
+
+
+def test_shared_step_routes_supervised_when_inactive() -> None:
+    """When the GAN phase is inactive, training routes through the supervised step."""
+    s = _strategy()
+    calls: list[str] = []
+
+    class _Module:
+        def _supervised_step(self, batch, stage):
+            calls.append(stage)
+            return ("loss", {"m": 1})
+
+        def _gan_step(self, batch, stage):  # pragma: no cover - should not run
+            calls.append("gan")
+            return ("loss", {})
+
+    # Strategy.shared_step calls the strategy's own _supervised_step/_gan_step,
+    # which delegate into the module. Patch those to observe routing.
+    s._supervised_step = lambda module, batch, stage: ("sup", stage)  # type: ignore
+    s._gan_step = lambda module, batch, stage: ("gan", stage)  # type: ignore
+
+    assert s.shared_step(_Module(), None, "val") == ("sup", "val")
+    assert s.shared_step(_Module(), None, "train") == ("sup", "train")  # inactive
+    s.activate_phase(0)
+    assert s.shared_step(_Module(), None, "train") == ("gan", "train")  # active
+    assert s.shared_step(_Module(), None, "val") == ("sup", "val")  # non-train always sup
+
+
+def test_on_train_epoch_end_steps_schedulers_epoch_interval() -> None:
+    s = _strategy(scheduler_interval="epoch")
+
+    class _Sched:
+        def __init__(self) -> None:
+            self.steps = 0
+
+        def step(self) -> None:
+            self.steps += 1
+
+    gen, disc = _Sched(), _Sched()
+
+    class _Module:
+        def lr_schedulers(self) -> Any:
+            return [gen, disc]
+
+    # Inactive phase -> only generator scheduler steps.
+    s.on_train_epoch_end(_Module())
+    assert gen.steps == 1
+    assert disc.steps == 0
+
+    # Active phase -> both step.
+    s.activate_phase(0)
+    s.on_train_epoch_end(_Module())
+    assert gen.steps == 2
+    assert disc.steps == 1
+
+
+def test_on_train_epoch_end_noop_for_step_interval() -> None:
+    s = _strategy(scheduler_interval="step")
+
+    class _Sched:
+        def __init__(self) -> None:
+            self.steps = 0
+
+        def step(self) -> None:  # pragma: no cover
+            self.steps += 1
+
+    sched = _Sched()
+
+    class _Module:
+        def lr_schedulers(self):
+            return sched
+
+    s.on_train_epoch_end(_Module())
+    assert sched.steps == 0  # step-interval schedulers are not advanced at epoch end
+
+
+def test_manual_optimizers_requires_exactly_two() -> None:
+    s = _strategy()
+
+    class _Module:
+        def optimizers(self):
+            return ["only_one"]
+
+    with pytest.raises(RuntimeError, match="generator and discriminator"):
+        s._manual_optimizers(_Module())
+
+
+def test_manual_schedulers_normalizes_to_list() -> None:
+    s = _strategy()
+
+    class _ModuleNone:
+        def lr_schedulers(self):
+            return None
+
+    class _ModuleSingle:
+        def lr_schedulers(self):
+            return "sched"
+
+    class _ModuleList:
+        def lr_schedulers(self):
+            return ["a", "b"]
+
+    assert s._manual_schedulers(_ModuleNone()) == []
+    assert s._manual_schedulers(_ModuleSingle()) == ["sched"]
+    assert s._manual_schedulers(_ModuleList()) == ["a", "b"]
+
+
+def test_unwrap_optimizer() -> None:
+    s = _strategy()
+
+    class _Wrapped:
+        optimizer = "inner"
+
+    assert s._unwrap_optimizer(_Wrapped()) == "inner"
+    assert s._unwrap_optimizer("plain") == "plain"

--- a/tests/unit/tasks/base/training/test_gan_transition_callback.py
+++ b/tests/unit/tasks/base/training/test_gan_transition_callback.py
@@ -1,0 +1,216 @@
+"""Unit tests for the GAN transition callback's deterministic logic.
+
+Tests cover config parsing, improvement detection, early-stopping-style
+patience, the supervised->GAN switch, warmup weight ramping, and state
+(de)serialization. PyTorch Lightning is not driven end-to-end; lightweight fake
+trainer/module stand-ins exercise the pure decision logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import torch
+
+from src.tasks.base.training.gan_transition_callback import GANTransitionCallback
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeTrainer:
+    def __init__(self, current_epoch: int = 0, metrics: dict[str, Any] | None = None) -> None:
+        self.current_epoch = current_epoch
+        self.callback_metrics = metrics or {}
+
+
+class _FakeModule:
+    """Records calls the callback makes into the LightningModule."""
+
+    def __init__(self) -> None:
+        self.weights: list[float] = []
+        self.activated_at: int | None = None
+
+    def set_gan_weight(self, w: float) -> None:
+        self.weights.append(w)
+
+    def activate_gan_phase(self, epoch: int) -> None:
+        self.activated_at = epoch
+
+
+def _cfg(**gan: Any) -> dict[str, Any]:
+    return {"training": {"gan": gan}}
+
+
+def test_disabled_by_default() -> None:
+    cb = GANTransitionCallback({})
+    assert cb.enabled is False
+    assert cb.has_switched_to_gan is False
+
+
+def test_config_parsing() -> None:
+    cb = GANTransitionCallback(
+        _cfg(
+            enabled=True,
+            target_weight=0.25,
+            warmup_epochs=4,
+            transition={
+                "monitor": "val/acc",
+                "mode": "max",
+                "min_delta": 0.01,
+                "patience": 2,
+                "min_supervised_epochs": 3,
+            },
+        )
+    )
+    assert cb.enabled is True
+    assert cb.monitor == "val/acc"
+    assert cb.mode == "max"
+    assert cb.min_delta == pytest.approx(0.01)
+    assert cb.patience == 2
+    assert cb.min_supervised_epochs == 3
+    assert cb.gan_target_weight == pytest.approx(0.25)
+    assert cb.gan_warmup_epochs == 4
+
+
+def test_invalid_mode_raises() -> None:
+    with pytest.raises(ValueError, match="transition mode"):
+        GANTransitionCallback(_cfg(enabled=True, transition={"mode": "bogus"}))
+
+
+def test_is_improvement_min_mode() -> None:
+    cb = GANTransitionCallback(_cfg(enabled=True, transition={"mode": "min", "min_delta": 0.1}))
+    cb.best_score = 1.0
+    assert cb._is_improvement(0.85) is True  # below best - delta
+    assert cb._is_improvement(0.95) is False  # within delta band
+    assert cb._is_improvement(1.2) is False
+
+
+def test_is_improvement_max_mode() -> None:
+    cb = GANTransitionCallback(_cfg(enabled=True, transition={"mode": "max", "min_delta": 0.1}))
+    cb.best_score = 1.0
+    assert cb._is_improvement(1.2) is True
+    assert cb._is_improvement(1.05) is False
+
+
+def _validation_step(cb: GANTransitionCallback, module: _FakeModule, epoch: int, value: float) -> None:
+    trainer = _FakeTrainer(current_epoch=epoch, metrics={cb.monitor: torch.tensor(value)})
+    cb.on_validation_epoch_end(trainer, module)
+
+
+def test_patience_triggers_switch() -> None:
+    cb = GANTransitionCallback(
+        _cfg(
+            enabled=True,
+            transition={"monitor": "val/loss", "mode": "min", "patience": 2, "min_delta": 0.0},
+        )
+    )
+    module = _FakeModule()
+
+    _validation_step(cb, module, epoch=0, value=1.0)  # sets best
+    assert cb.best_score == pytest.approx(1.0)
+    _validation_step(cb, module, epoch=1, value=1.0)  # no improvement -> bad 1
+    assert cb.bad_epochs == 1
+    assert cb.has_switched_to_gan is False
+    _validation_step(cb, module, epoch=2, value=1.0)  # no improvement -> bad 2 -> switch
+    assert cb.has_switched_to_gan is True
+    assert cb.switch_epoch == 3  # current_epoch + 1
+    assert module.activated_at == 3
+
+
+def test_improvement_resets_bad_epochs() -> None:
+    cb = GANTransitionCallback(
+        _cfg(
+            enabled=True,
+            transition={"monitor": "val/loss", "mode": "min", "patience": 2, "min_delta": 0.0},
+        )
+    )
+    module = _FakeModule()
+    _validation_step(cb, module, 0, 1.0)
+    _validation_step(cb, module, 1, 1.0)  # bad 1
+    assert cb.bad_epochs == 1
+    _validation_step(cb, module, 2, 0.5)  # improvement -> reset
+    assert cb.bad_epochs == 0
+    assert cb.best_score == pytest.approx(0.5)
+
+
+def test_min_supervised_epochs_gates_switch() -> None:
+    cb = GANTransitionCallback(
+        _cfg(
+            enabled=True,
+            transition={
+                "monitor": "val/loss",
+                "mode": "min",
+                "patience": 0,
+                "min_supervised_epochs": 3,
+            },
+        )
+    )
+    module = _FakeModule()
+    # patience<=0 would switch immediately, but min_supervised_epochs gates it.
+    _validation_step(cb, module, epoch=0, value=1.0)  # epoch+1=1 < 3 -> ignored
+    assert cb.has_switched_to_gan is False
+    _validation_step(cb, module, epoch=2, value=1.0)  # epoch+1=3 -> allowed, patience<=0 -> switch
+    assert cb.has_switched_to_gan is True
+
+
+def test_missing_monitor_metric_is_noop() -> None:
+    cb = GANTransitionCallback(
+        _cfg(enabled=True, transition={"monitor": "val/loss", "patience": 0})
+    )
+    module = _FakeModule()
+    trainer = _FakeTrainer(current_epoch=5, metrics={})  # monitor absent
+    cb.on_validation_epoch_end(trainer, module)
+    assert cb.has_switched_to_gan is False
+
+
+def test_on_fit_start_zeroes_weight() -> None:
+    cb = GANTransitionCallback(_cfg(enabled=True))
+    module = _FakeModule()
+    cb.on_fit_start(_FakeTrainer(), module)
+    assert module.weights == [0.0]
+
+
+def test_warmup_weight_ramp() -> None:
+    cb = GANTransitionCallback(
+        _cfg(enabled=True, target_weight=0.2, warmup_epochs=4, transition={"patience": 0})
+    )
+    cb.has_switched_to_gan = True
+    cb.switch_epoch = 2
+    module = _FakeModule()
+
+    # epoch 2 -> since_switch = 1 -> progress 1/4 -> 0.05
+    cb.on_train_epoch_start(_FakeTrainer(current_epoch=2), module)
+    assert module.weights[-1] == pytest.approx(0.2 * 0.25)
+    # epoch 5 -> since_switch = 4 -> progress 1.0 -> full target
+    cb.on_train_epoch_start(_FakeTrainer(current_epoch=5), module)
+    assert module.weights[-1] == pytest.approx(0.2)
+    # beyond warmup stays clamped at target
+    cb.on_train_epoch_start(_FakeTrainer(current_epoch=10), module)
+    assert module.weights[-1] == pytest.approx(0.2)
+
+
+def test_warmup_le_one_sets_target_immediately() -> None:
+    cb = GANTransitionCallback(
+        _cfg(enabled=True, target_weight=0.3, warmup_epochs=1)
+    )
+    cb.has_switched_to_gan = True
+    cb.switch_epoch = 0
+    module = _FakeModule()
+    cb.on_train_epoch_start(_FakeTrainer(current_epoch=0), module)
+    assert module.weights[-1] == pytest.approx(0.3)
+
+
+def test_state_dict_roundtrip() -> None:
+    cb = GANTransitionCallback(_cfg(enabled=True))
+    cb.best_score = 0.42
+    cb.bad_epochs = 2
+    cb.has_switched_to_gan = True
+    cb.switch_epoch = 7
+
+    restored = GANTransitionCallback(_cfg(enabled=True))
+    restored.load_state_dict(cb.state_dict())
+    assert restored.best_score == pytest.approx(0.42)
+    assert restored.bad_epochs == 2
+    assert restored.has_switched_to_gan is True
+    assert restored.switch_epoch == 7

--- a/tests/unit/tasks/base/training/test_lightning_module.py
+++ b/tests/unit/tasks/base/training/test_lightning_module.py
@@ -1,0 +1,180 @@
+"""Unit tests for BaseLightningModule pure helpers.
+
+Covers ``_concat_padded`` (time-axis padding), config-driven step estimation,
+optimizer/scheduler construction, and test-prediction persistence. Heavy
+training (a real ``training_step`` over a model) is deferred to the integration
+smoke suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import CosineAnnealingLR, SequentialLR
+
+from src.tasks.base.training.lightning_module import (
+    BaseLightningModule,
+    _concat_padded,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _TinyModule(BaseLightningModule):
+    """Concrete module with a single trainable parameter for optimizer tests."""
+
+    def __init__(self, config=None) -> None:
+        super().__init__(config)
+        self.lin = nn.Linear(2, 2)
+
+
+# ---------------------------------------------------------------------------
+# _concat_padded
+# ---------------------------------------------------------------------------
+
+
+def test_concat_padded_single_chunk_passthrough() -> None:
+    chunk = np.ones((2, 3))
+    assert _concat_padded([chunk]) is chunk
+
+
+def test_concat_padded_pads_time_axis() -> None:
+    a = np.ones((2, 3, 4))  # T=3
+    b = np.ones((1, 5, 4))  # T=5
+    out = _concat_padded([a, b])
+    assert out.shape == (3, 5, 4)  # batch concat, T padded to 5
+    # padded region of `a` (time steps 3,4) is zero
+    assert (out[0:2, 3:, :] == 0).all()
+    # original content preserved
+    assert (out[0:2, :3, :] == 1).all()
+
+
+def test_concat_padded_low_dim_arrays_concatenated() -> None:
+    a = np.array([1.0, 2.0])  # ndim 1
+    b = np.array([3.0])
+    out = _concat_padded([a, b])
+    assert out.tolist() == [1.0, 2.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# _estimate_total_steps
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_total_steps_from_steps_per_epoch_attr() -> None:
+    m = _TinyModule({"training": {"max_epochs": 4}})
+    m.steps_per_epoch = 50
+    assert m._estimate_total_steps() == 200
+
+
+def test_estimate_total_steps_from_config_steps_per_epoch() -> None:
+    m = _TinyModule({"training": {"max_epochs": 3, "steps_per_epoch": 10}})
+    assert m._estimate_total_steps() == 30
+
+
+def test_estimate_total_steps_from_num_samples() -> None:
+    m = _TinyModule(
+        {
+            "training": {"max_epochs": 2},
+            "data": {"num_samples_per_epoch": 100, "batch_size": 10},
+        }
+    )
+    # steps_per_epoch = 100 // 10 = 10 -> * 2 epochs
+    assert m._estimate_total_steps() == 20
+
+
+def test_estimate_total_steps_default_fallback() -> None:
+    m = _TinyModule({"training": {"max_epochs": 1}})
+    # default num_samples=10000, batch_size=64 -> 156 steps * 1
+    assert m._estimate_total_steps() == (10000 // 64) * 1
+
+
+# ---------------------------------------------------------------------------
+# configure_optimizers
+# ---------------------------------------------------------------------------
+
+
+def test_configure_optimizers_step_interval_no_warmup() -> None:
+    m = _TinyModule({"training": {"max_epochs": 2, "steps_per_epoch": 5}})
+    cfg = m.configure_optimizers()
+    assert isinstance(cfg["optimizer"], AdamW)
+    assert cfg["lr_scheduler"]["interval"] == "step"
+    assert isinstance(cfg["lr_scheduler"]["scheduler"], CosineAnnealingLR)
+
+
+def test_configure_optimizers_epoch_warmup_uses_sequential() -> None:
+    m = _TinyModule({"training": {"max_epochs": 10, "warmup_epochs": 3}})
+    cfg = m.configure_optimizers()
+    assert cfg["lr_scheduler"]["interval"] == "epoch"
+    assert isinstance(cfg["lr_scheduler"]["scheduler"], SequentialLR)
+
+
+def test_configure_optimizers_respects_lr_and_betas() -> None:
+    m = _TinyModule(
+        {
+            "training": {
+                "max_epochs": 1,
+                "learning_rate": 5e-4,
+                "weight_decay": 0.01,
+                "steps_per_epoch": 1,
+                "optimizer": {"betas": [0.8, 0.95]},
+            }
+        }
+    )
+    opt = m.configure_optimizers()["optimizer"]
+    group = opt.param_groups[0]
+    assert group["lr"] == pytest.approx(5e-4)
+    assert group["weight_decay"] == pytest.approx(0.01)
+    assert group["betas"] == (0.8, 0.95)
+
+
+def test_optimizer_betas_none_when_unset() -> None:
+    m = _TinyModule({"training": {"max_epochs": 1}})
+    assert m.optimizer_betas is None
+
+
+# ---------------------------------------------------------------------------
+# test_prediction_payload defaults / collection / saving
+# ---------------------------------------------------------------------------
+
+
+def test_default_payload_empty_and_collect_noop() -> None:
+    m = _TinyModule({})
+    assert m.test_prediction_payload(batch=None, result={}) == {}
+    # collecting an empty payload must not create a buffer
+    m.collect_test_predictions(batch=None, result={})
+    assert not getattr(m, "_test_pred_arrays", None)
+
+
+def test_save_test_predictions_writes_npz(tmp_path: Path, monkeypatch) -> None:
+    class _PredModule(_TinyModule):
+        def test_prediction_payload(self, batch, result):
+            return {"position": result["position"]}
+
+    m = _PredModule({})
+    monkeypatch.setenv("TENNIS_REPRO_DIR", str(tmp_path))
+    m._reset_test_prediction_buffer()
+
+    # two batches of differing time length to exercise padding
+    m.collect_test_predictions(None, {"position": torch.zeros(2, 3, 3)})
+    m.collect_test_predictions(None, {"position": torch.ones(1, 5, 3)})
+
+    npz_path = m.save_test_predictions(metrics={"mae": 0.1})
+    assert npz_path is not None
+    assert npz_path.name == "pred_test.npz"
+    loaded = np.load(npz_path)
+    assert loaded["position"].shape == (3, 5, 3)  # batch 2+1, T padded to 5
+    assert loaded["scene_ids"].shape == (3,)
+    metrics = (npz_path.parent / "metrics.json").read_text()
+    assert "mae" in metrics
+
+
+def test_save_test_predictions_none_when_empty(tmp_path: Path, monkeypatch) -> None:
+    m = _TinyModule({})
+    monkeypatch.setenv("TENNIS_REPRO_DIR", str(tmp_path))
+    assert m.save_test_predictions() is None  # nothing collected

--- a/tests/unit/tasks/base/training/test_losses.py
+++ b/tests/unit/tasks/base/training/test_losses.py
@@ -1,0 +1,81 @@
+"""Unit tests for the shared focal BCE loss."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from src.tasks.base.training.losses import FocalBCEWithLogitsLoss
+
+pytestmark = pytest.mark.unit
+
+
+def test_gamma_zero_equals_mean_bce() -> None:
+    """With gamma=0 the focal modulation vanishes, leaving plain mean BCE."""
+    loss = FocalBCEWithLogitsLoss(gamma=0.0)
+    logits = torch.tensor([[2.0, -1.0], [0.5, -3.0]])
+    targets = torch.tensor([[1.0, 0.0], [1.0, 0.0]])
+
+    got = loss(logits, targets)
+    expected = F.binary_cross_entropy_with_logits(logits, targets, reduction="mean")
+    assert torch.allclose(got, expected, atol=1e-6)
+
+
+def test_focal_downweights_easy_examples() -> None:
+    """A confident-correct prediction contributes less with gamma>0 than gamma=0."""
+    logits = torch.tensor([[6.0]])  # very confident
+    targets = torch.tensor([[1.0]])  # correct
+
+    plain = FocalBCEWithLogitsLoss(gamma=0.0)(logits, targets)
+    focal = FocalBCEWithLogitsLoss(gamma=2.0)(logits, targets)
+    assert focal < plain
+
+
+def test_matches_manual_formula() -> None:
+    """Loss equals mean((1 - p_t)**gamma * BCE)."""
+    gamma = 1.5
+    loss = FocalBCEWithLogitsLoss(gamma=gamma)
+    logits = torch.tensor([0.3, -0.7, 1.2])
+    targets = torch.tensor([1.0, 0.0, 1.0])
+
+    probs = torch.sigmoid(logits)
+    bce = F.binary_cross_entropy_with_logits(logits, targets, reduction="none")
+    p_t = probs * targets + (1 - probs) * (1 - targets)
+    expected = ((1 - p_t) ** gamma * bce).mean()
+
+    assert torch.allclose(loss(logits, targets), expected, atol=1e-6)
+
+
+def test_loss_is_non_negative_scalar() -> None:
+    loss = FocalBCEWithLogitsLoss(gamma=2.0)
+    out = loss(torch.randn(4, 5), torch.randint(0, 2, (4, 5)).float())
+    assert out.ndim == 0
+    assert out.item() >= 0.0
+
+
+def test_negative_gamma_raises() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        FocalBCEWithLogitsLoss(gamma=-0.1)
+
+
+def test_validate_shape_raises_on_mismatch() -> None:
+    loss = FocalBCEWithLogitsLoss(validate_shape=True)
+    with pytest.raises(ValueError, match="same"):
+        loss(torch.randn(2, 3), torch.randn(2, 4))
+
+
+def test_no_validate_shape_allows_broadcastable() -> None:
+    """Without validate_shape, broadcastable shapes do not raise."""
+    loss = FocalBCEWithLogitsLoss(validate_shape=False)
+    out = loss(torch.zeros(2, 1), torch.zeros(2, 1))
+    assert math.isfinite(out.item())
+
+
+def test_perfect_prediction_near_zero_loss() -> None:
+    loss = FocalBCEWithLogitsLoss(gamma=2.0)
+    logits = torch.tensor([[20.0, -20.0]])
+    targets = torch.tensor([[1.0, 0.0]])
+    assert loss(logits, targets).item() < 1e-6

--- a/tests/unit/tasks/base/training/test_qualitative_callback.py
+++ b/tests/unit/tasks/base/training/test_qualitative_callback.py
@@ -1,0 +1,106 @@
+"""Unit tests for QualitativeLoggingCallback selection/gating logic."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from src.tasks.base.training.qualitative_callback import (
+    QualitativeLoggingCallback,
+    _detach_to_cpu,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_init_clamps_minimums() -> None:
+    cb = QualitativeLoggingCallback(every_n_epochs=0, num_samples=0)
+    assert cb.every_n_epochs == 1
+    assert cb.num_samples == 1
+
+
+def test_select_random_subset_bounded() -> None:
+    cb = QualitativeLoggingCallback(num_samples=3, selection_mode="random")
+    selected = cb._select_batch_indices(total=10)
+    assert len(selected) == 3
+    assert selected <= set(range(10))
+
+
+def test_select_random_caps_at_total() -> None:
+    cb = QualitativeLoggingCallback(num_samples=20, selection_mode="random")
+    selected = cb._select_batch_indices(total=5)
+    assert selected == set(range(5))
+
+
+def test_select_zero_total_empty() -> None:
+    cb = QualitativeLoggingCallback(num_samples=4)
+    assert cb._select_batch_indices(total=0) == set()
+
+
+def test_fixed_indices_mode() -> None:
+    cb = QualitativeLoggingCallback(
+        selection_mode="fixed_indices", selected_indices=[0, 2, 4]
+    )
+    assert cb._select_batch_indices(total=6) == {0, 2, 4}
+
+
+def test_fixed_indices_requires_list() -> None:
+    cb = QualitativeLoggingCallback(selection_mode="fixed_indices", selected_indices=None)
+    with pytest.raises(ValueError, match="non-empty selected_indices"):
+        cb._select_batch_indices(total=6)
+
+
+def test_fixed_indices_out_of_range_raises() -> None:
+    cb = QualitativeLoggingCallback(
+        selection_mode="fixed_indices", selected_indices=[0, 7]
+    )
+    with pytest.raises(ValueError, match="out-of-range"):
+        cb._select_batch_indices(total=5)
+
+
+def test_unknown_selection_mode_raises() -> None:
+    cb = QualitativeLoggingCallback(selection_mode="bogus")
+    with pytest.raises(ValueError, match="must be 'random' or"):
+        cb._select_batch_indices(total=5)
+
+
+class _Trainer:
+    def __init__(self, *, enabled_epoch: int = 0, sanity: bool = False) -> None:
+        self.current_epoch = enabled_epoch
+        self.sanity_checking = sanity
+
+
+def test_should_log_respects_enabled_flag() -> None:
+    cb = QualitativeLoggingCallback(enabled=False)
+    assert cb._should_log(_Trainer()) is False
+
+
+def test_should_log_skips_sanity_check() -> None:
+    cb = QualitativeLoggingCallback(enabled=True)
+    assert cb._should_log(_Trainer(sanity=True)) is False
+
+
+def test_should_log_every_n_epochs() -> None:
+    cb = QualitativeLoggingCallback(enabled=True, every_n_epochs=3)
+    assert cb._should_log(_Trainer(enabled_epoch=0)) is True
+    assert cb._should_log(_Trainer(enabled_epoch=3)) is True
+    assert cb._should_log(_Trainer(enabled_epoch=1)) is False
+
+
+def test_detach_to_cpu_recurses_structures() -> None:
+    t = torch.ones(2, requires_grad=True)
+    data = {"a": t, "b": [t, t], "c": ("x", 3)}
+    out = _detach_to_cpu(data)
+    assert out["a"].requires_grad is False
+    assert out["a"].device.type == "cpu"
+    assert isinstance(out["b"], list)
+    assert isinstance(out["c"], tuple)
+    assert out["c"] == ("x", 3)
+
+
+def test_detach_to_cpu_passthrough_non_tensor() -> None:
+    assert _detach_to_cpu(5) == 5
+    assert _detach_to_cpu("hello") == "hello"
+    arr = np.zeros(3)
+    assert _detach_to_cpu(arr) is arr

--- a/tests/unit/tasks/base/visualization/test_frames.py
+++ b/tests/unit/tasks/base/visualization/test_frames.py
@@ -1,0 +1,84 @@
+"""Unit tests for image-source resolution and RGB loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from src.tasks.base.visualization.frames import (
+    load_rgb_frames,
+    read_rgb,
+    resolve_image_paths,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write_img(path: Path, *, fill: tuple[int, int, int] = (10, 20, 30), h: int = 4, w: int = 5) -> None:
+    """Write a solid BGR image (cv2 expects BGR)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    img: np.ndarray = np.zeros((h, w, 3), np.uint8)
+    img[:] = fill  # interpreted as BGR by imwrite
+    cv2.imwrite(str(path), img)
+
+
+def test_resolve_single_file(tmp_path: Path) -> None:
+    p = tmp_path / "frame.png"
+    _write_img(p)
+    assert resolve_image_paths(p) == [p]
+
+
+def test_resolve_directory_sorted_and_filtered(tmp_path: Path) -> None:
+    _write_img(tmp_path / "b.png")
+    _write_img(tmp_path / "a.jpg")
+    (tmp_path / "notes.txt").write_text("ignore me")
+    paths = resolve_image_paths(tmp_path)
+    assert [p.name for p in paths] == ["a.jpg", "b.png"]
+
+
+def test_resolve_glob_pattern(tmp_path: Path) -> None:
+    _write_img(tmp_path / "f0.png")
+    _write_img(tmp_path / "f1.png")
+    _write_img(tmp_path / "other.png")
+    paths = resolve_image_paths(str(tmp_path / "f*.png"))
+    assert [p.name for p in paths] == ["f0.png", "f1.png"]
+
+
+def test_resolve_max_frames_caps(tmp_path: Path) -> None:
+    for i in range(5):
+        _write_img(tmp_path / f"f{i}.png")
+    paths = resolve_image_paths(tmp_path, max_frames=2)
+    assert len(paths) == 2
+
+
+def test_resolve_no_images_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="No images found"):
+        resolve_image_paths(tmp_path / "does_not_exist_*.png")
+
+
+def test_read_rgb_converts_bgr_to_rgb(tmp_path: Path) -> None:
+    p = tmp_path / "c.png"
+    # write a blue image in BGR -> (255, 0, 0) bgr is pure blue
+    _write_img(p, fill=(255, 0, 0))
+    rgb = read_rgb(p)
+    assert rgb.shape == (4, 5, 3)
+    # after BGR->RGB the blue channel (index 2) should be 255
+    assert rgb[0, 0, 2] == 255
+    assert rgb[0, 0, 0] == 0
+
+
+def test_read_rgb_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="Failed to read"):
+        read_rgb(tmp_path / "missing.png")
+
+
+def test_load_rgb_frames_resizes(tmp_path: Path) -> None:
+    _write_img(tmp_path / "a.png", h=8, w=10)
+    _write_img(tmp_path / "b.png", h=8, w=10)
+    frames = load_rgb_frames(tmp_path, resize_hw=(4, 6))
+    assert [name for name, _ in frames] == ["a.png", "b.png"]
+    for _, rgb in frames:
+        assert rgb.shape == (4, 6, 3)

--- a/tests/unit/tasks/base/visualization/test_gif.py
+++ b/tests/unit/tasks/base/visualization/test_gif.py
@@ -1,0 +1,52 @@
+"""Unit tests for the shared animated-GIF writer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from src.tasks.base.visualization.gif import save_gif
+
+pytestmark = pytest.mark.unit
+
+
+def _frame(h: int = 4, w: int = 6, fill: int = 30) -> np.ndarray:
+    return np.full((h, w, 3), fill, dtype=np.uint8)
+
+
+def test_empty_frames_raises() -> None:
+    with pytest.raises(ValueError, match="At least one frame"):
+        save_gif(frames_rgb=[], path=Path("/tmp/x.gif"), fps=10)
+
+
+def test_non_positive_fps_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="fps must be positive"):
+        save_gif(frames_rgb=[_frame()], path=tmp_path / "x.gif", fps=0)
+    with pytest.raises(ValueError, match="fps must be positive"):
+        save_gif(frames_rgb=[_frame()], path=tmp_path / "x.gif", fps=-5)
+
+
+def test_non_gif_suffix_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Only .gif"):
+        save_gif(frames_rgb=[_frame()], path=tmp_path / "x.png", fps=10)
+
+
+def test_writes_multi_frame_gif(tmp_path: Path) -> None:
+    out = tmp_path / "nested" / "anim.gif"
+    frames = [_frame(fill=10), _frame(fill=200), _frame(fill=120)]
+    save_gif(frames_rgb=frames, path=out, fps=12)
+    assert out.exists()
+    with Image.open(out) as im:
+        assert im.format == "GIF"
+        assert im.size == (6, 4)  # (width, height)
+        n = getattr(im, "n_frames", 1)
+        assert n == 3
+
+
+def test_creates_parent_directory(tmp_path: Path) -> None:
+    out = tmp_path / "a" / "b" / "c.gif"
+    save_gif(frames_rgb=[_frame()], path=out, fps=10)
+    assert out.parent.is_dir()

--- a/tests/unit/tasks/base/visualization/test_io.py
+++ b/tests/unit/tasks/base/visualization/test_io.py
@@ -1,0 +1,60 @@
+"""Unit tests for visualization scene-IO camera resolution."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from src.tasks.base.visualization.io import BaseSceneBundle, resolve_cameras
+
+pytestmark = pytest.mark.unit
+
+
+def _all_cams() -> list[int]:
+    return [0, 1, 2]
+
+
+def test_resolve_all_expands_via_callback() -> None:
+    assert resolve_cameras(3, 0, "all", _all_cams) == [0, 1, 2]
+
+
+def test_resolve_explicit_list() -> None:
+    assert resolve_cameras(3, 0, [1, 2], _all_cams) == [1, 2]
+
+
+def test_resolve_none_falls_back_to_single_camera() -> None:
+    assert resolve_cameras(3, 2, None, _all_cams) == [2]
+
+
+def test_resolve_empty_list_falls_back_to_single_camera() -> None:
+    # an empty list is falsy -> falls through to [camera]
+    assert resolve_cameras(3, 1, [], _all_cams) == [1]
+
+
+def test_out_of_range_high_raises() -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        resolve_cameras(3, 0, [3], _all_cams)
+
+
+def test_out_of_range_negative_raises() -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        resolve_cameras(3, 0, [-1], _all_cams)
+
+
+def test_fallback_camera_out_of_range_raises() -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        resolve_cameras(2, 5, None, _all_cams)
+
+
+def test_all_returning_empty_raises() -> None:
+    with pytest.raises(ValueError, match="No cameras selected"):
+        resolve_cameras(3, 0, "all", list)  # list() -> []
+
+
+def test_scene_bundle_dataclass_frozen() -> None:
+    bundle = BaseSceneBundle(cameras=[0, 1], fps=30.0)
+    assert bundle.cameras == [0, 1]
+    assert bundle.fps == 30.0
+    with pytest.raises(FrozenInstanceError):
+        bundle.fps = 60.0  # type: ignore[misc]

--- a/tests/unit/tasks/base/visualization/test_layout.py
+++ b/tests/unit/tasks/base/visualization/test_layout.py
@@ -1,0 +1,95 @@
+"""Unit tests for panel-composition primitives."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import numpy as np
+import pytest
+
+from src.tasks.base.visualization.layout import (
+    PanelStyle,
+    compose_grid,
+    compose_row,
+    label_panel,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _panel(h: int, w: int, fill: int = 100) -> np.ndarray:
+    return np.full((h, w, 3), fill, dtype=np.uint8)
+
+
+def test_panel_style_defaults() -> None:
+    style = PanelStyle()
+    assert style.tile_gap == 12
+    assert style.panel_label_height == 24
+    # frozen dataclass -> immutable
+    with pytest.raises(FrozenInstanceError):
+        style.tile_gap = 5  # type: ignore[misc]
+
+
+def test_compose_row_dimensions_and_gap() -> None:
+    panels = [_panel(10, 20), _panel(10, 20), _panel(10, 20)]
+    out = compose_row(panels=panels, tile_gap=4, background_rgb=(0, 0, 0))
+    # width = 3*20 + 2*4 = 68
+    assert out.shape == (10, 68, 3)
+    # gap columns between panel0 and panel1 stay background (0)
+    assert (out[:, 20:24] == 0).all()
+    # first panel content preserved
+    assert (out[:, 0:20] == 100).all()
+
+
+def test_compose_row_single_panel_no_gap() -> None:
+    out = compose_row(panels=[_panel(5, 7)], tile_gap=10, background_rgb=(0, 0, 0))
+    assert out.shape == (5, 7, 3)
+
+
+def test_compose_row_empty_raises() -> None:
+    with pytest.raises(ValueError, match="At least one panel"):
+        compose_row(panels=[], tile_gap=2, background_rgb=(0, 0, 0))
+
+
+def test_compose_grid_dimensions() -> None:
+    row = [_panel(8, 12), _panel(8, 12)]
+    grid = compose_grid(panels=[row, row], tile_gap=3, background_rgb=(0, 0, 0))
+    # row width = 2*12 + 1*3 = 27 ; height = 2*8 + 1*3 = 19
+    assert grid.shape == (19, 27, 3)
+
+
+def test_compose_grid_empty_raises() -> None:
+    with pytest.raises(ValueError, match="At least one panel"):
+        compose_grid(panels=[], tile_gap=2, background_rgb=(0, 0, 0))
+    with pytest.raises(ValueError, match="At least one panel"):
+        compose_grid(panels=[[]], tile_gap=2, background_rgb=(0, 0, 0))
+
+
+def test_label_panel_prepends_strip() -> None:
+    panel = _panel(10, 30)
+    labelled = label_panel(
+        panel,
+        text="hi",
+        label_height=12,
+        background_rgb=(0, 0, 0),
+        text_color_rgb=(255, 255, 255),
+        text_scale=0.5,
+        text_thickness=1,
+    )
+    assert labelled.shape == (22, 30, 3)
+    # original panel preserved at the bottom
+    assert (labelled[12:] == 100).all()
+
+
+def test_label_panel_zero_height_returns_original() -> None:
+    panel = _panel(4, 4)
+    out = label_panel(
+        panel,
+        text="x",
+        label_height=0,
+        background_rgb=(0, 0, 0),
+        text_color_rgb=(1, 1, 1),
+        text_scale=0.5,
+        text_thickness=1,
+    )
+    assert out is panel

--- a/tests/unit/tasks/base/visualization/test_orchestrator.py
+++ b/tests/unit/tasks/base/visualization/test_orchestrator.py
@@ -1,0 +1,46 @@
+"""Unit tests for visualization orchestration parsing helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tasks.base.visualization.orchestrator import parse_cameras, resolve_device
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("raw", [None, "", "   "])
+def test_parse_cameras_empty_returns_none(raw) -> None:
+    assert parse_cameras(raw) is None
+
+
+def test_parse_cameras_all_keyword() -> None:
+    assert parse_cameras("all") == "all"
+    assert parse_cameras("  all  ") == "all"
+
+
+def test_parse_cameras_comma_string() -> None:
+    assert parse_cameras("0,1,2") == [0, 1, 2]
+    assert parse_cameras(" 3 , 4 ") == [3, 4]
+
+
+def test_parse_cameras_iterable() -> None:
+    assert parse_cameras([0, 2, 5]) == [0, 2, 5]
+    assert parse_cameras((1, 3)) == [1, 3]
+
+
+def test_parse_cameras_invalid_string_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_cameras("a,b")
+
+
+def test_resolve_device_explicit_passthrough() -> None:
+    assert resolve_device("cpu") == "cpu"
+    assert resolve_device("cuda:1") == "cuda:1"
+
+
+def test_resolve_device_auto_returns_valid_device() -> None:
+    import torch
+
+    expected = "cuda" if torch.cuda.is_available() else "cpu"
+    assert resolve_device("auto") == expected

--- a/tests/unit/utils/data/test_augmentation.py
+++ b/tests/unit/utils/data/test_augmentation.py
@@ -1,0 +1,197 @@
+"""Unit tests for :mod:`src.utils.data.augmentation`.
+
+Covers the deterministic / validation-heavy public helpers. The stochastic
+augmentations are exercised through their no-op early-returns, their error
+paths, and (with a seeded generator) their shape/bounds invariants.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from src.utils.data.augmentation import (
+    add_gaussian_noise,
+    add_temporally_correlated_jitter,
+    apply_burst_visibility_dropout,
+    augment_keypoints,
+    denormalize_tensor_images_imagenet,
+    dilate_temporal_mask,
+    inject_false_positive_observations,
+    normalize_frames_imagenet,
+    normalize_tensor_images_imagenet,
+    parse_float_range,
+    parse_int_range,
+    random_visibility_dropout,
+    scale_uv_with_visibility,
+)
+
+
+class TestParseFloatRange:
+    def test_valid_range(self) -> None:
+        assert parse_float_range([0.1, 0.9], "r") == (0.1, 0.9)
+
+    @pytest.mark.parametrize("value", [[1.0], "ab", [3.0, 1.0], 5.0])
+    def test_invalid_raises(self, value: object) -> None:
+        with pytest.raises(ValueError, match="r"):
+            parse_float_range(value, "r")
+
+
+class TestParseIntRange:
+    def test_valid_range(self) -> None:
+        assert parse_int_range([1, 4], "r") == (1, 4)
+
+    @pytest.mark.parametrize("value", [[1], [-1, 2], [3, 1]])
+    def test_invalid_raises(self, value: object) -> None:
+        with pytest.raises(ValueError, match="r"):
+            parse_int_range(value, "r")
+
+
+class TestImageNetNormalization:
+    def test_round_trip(self) -> None:
+        images = torch.rand(2, 3, 4, 4)
+        normalized = normalize_tensor_images_imagenet(images)
+        recovered = denormalize_tensor_images_imagenet(normalized)
+        assert torch.allclose(recovered, images, atol=1e-6)
+
+    def test_known_value(self) -> None:
+        images = torch.full((3, 1, 1), 0.485)
+        images[1] = 0.456
+        images[2] = 0.406
+        out = normalize_tensor_images_imagenet(images)
+        # mean-subtracted channels become ~0 at the ImageNet mean.
+        assert torch.allclose(out.squeeze(), torch.zeros(3), atol=1e-6)
+
+    @pytest.mark.parametrize("shape", [(1, 4, 4), (2, 4, 4), (4,)])
+    def test_bad_channel_shape_raises(self, shape: tuple[int, ...]) -> None:
+        with pytest.raises(ValueError, match="3, H, W"):
+            normalize_tensor_images_imagenet(torch.zeros(shape))
+
+    def test_numpy_frames(self) -> None:
+        frames: list[np.ndarray] = [np.full((2, 2, 3), 0.5, dtype=np.float32)]
+        out = normalize_frames_imagenet(frames)
+        assert out[0].shape == (2, 2, 3)
+        assert out[0].dtype == np.float32
+
+
+class TestScaleUvWithVisibility:
+    def test_identity_scale_keeps_points(self) -> None:
+        uv = torch.tensor([[0.25, 0.75]])
+        vis = torch.tensor([True])
+        out_uv, out_vis = scale_uv_with_visibility(uv, vis, scale=1.0)
+        assert torch.allclose(out_uv, uv)
+        assert bool(out_vis[0])
+
+    def test_scaling_out_of_bounds_drops_visibility(self) -> None:
+        uv = torch.tensor([[0.95, 0.5]])
+        vis = torch.tensor([True])
+        _, out_vis = scale_uv_with_visibility(uv, vis, scale=3.0, center=0.5)
+        assert not bool(out_vis[0])
+
+    def test_non_positive_scale_raises(self) -> None:
+        with pytest.raises(ValueError, match="scale"):
+            scale_uv_with_visibility(torch.zeros(1, 2), torch.zeros(1), scale=0.0)
+
+
+class TestAddGaussianNoise:
+    def test_non_positive_std_is_noop(self) -> None:
+        t = torch.arange(5.0)
+        assert add_gaussian_noise(t, 0.0) is t
+
+    def test_reproducible_with_generator(self, torch_generator: torch.Generator) -> None:
+        t = torch.zeros(100)
+        gen2 = torch.Generator().manual_seed(torch_generator.initial_seed())
+        a = add_gaussian_noise(t, 0.5, generator=torch_generator)
+        b = add_gaussian_noise(t, 0.5, generator=gen2)
+        assert torch.allclose(a, b)
+        assert a.shape == t.shape
+
+
+class TestRandomVisibilityDropout:
+    def test_zero_prob_is_noop(self) -> None:
+        vis = torch.ones(10, dtype=torch.bool)
+        assert random_visibility_dropout(vis, 0.0) is vis
+
+    def test_full_prob_drops_everything(self) -> None:
+        vis = torch.ones(50, dtype=torch.bool)
+        out = random_visibility_dropout(vis, 1.0)
+        assert int(out.sum()) == 0
+
+
+class TestDilateTemporalMask:
+    def test_zero_radius_returns_bool(self) -> None:
+        mask = torch.tensor([0, 1, 0], dtype=torch.float32)
+        out = dilate_temporal_mask(mask, 0)
+        assert out.dtype == torch.bool
+        assert out.tolist() == [False, True, False]
+
+    def test_dilation_spreads_to_neighbors(self) -> None:
+        mask = torch.tensor([False, False, True, False, False])
+        out = dilate_temporal_mask(mask, radius=1)
+        assert out.tolist() == [False, True, True, True, False]
+
+
+class TestAddTemporallyCorrelatedJitter:
+    def test_zero_std_is_noop(self) -> None:
+        uv = torch.rand(3, 2)
+        out = add_temporally_correlated_jitter(uv, jitter_std=0.0, drift_std=0.0)
+        assert out is uv
+
+    def test_invalid_drift_decay_raises(self) -> None:
+        with pytest.raises(ValueError, match="drift_decay"):
+            add_temporally_correlated_jitter(
+                torch.rand(3, 2), jitter_std=0.1, drift_decay=1.0
+            )
+
+    def test_output_is_clamped(self, torch_generator: torch.Generator) -> None:
+        uv = torch.rand(10, 2)
+        out = add_temporally_correlated_jitter(
+            uv, jitter_std=5.0, drift_std=5.0, generator=torch_generator
+        )
+        assert out.min() >= 0.0 and out.max() <= 1.0
+
+
+class TestApplyBurstVisibilityDropout:
+    def test_zero_prob_is_noop(self) -> None:
+        vis = torch.ones(2, 8, dtype=torch.bool)
+        out = apply_burst_visibility_dropout(
+            vis, prob=0.0, min_len=1, max_len=2
+        )
+        assert out is vis
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"prob": 0.5, "min_len": 0, "max_len": 2},
+            {"prob": 0.5, "min_len": 3, "max_len": 1},
+        ],
+    )
+    def test_invalid_lengths_raise(self, kwargs: dict) -> None:
+        with pytest.raises(ValueError):
+            apply_burst_visibility_dropout(torch.ones(1, 4), **kwargs)
+
+
+class TestInjectFalsePositiveObservations:
+    def test_no_prob_is_noop(self) -> None:
+        uv = torch.rand(1, 4, 2)
+        vis = torch.ones(1, 4)
+        out_uv, out_vis = inject_false_positive_observations(uv, vis)
+        assert out_uv is uv and out_vis is vis
+
+    def test_shape_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="visibility shape"):
+            inject_false_positive_observations(
+                torch.rand(1, 4, 2),
+                torch.ones(1, 3),
+                false_positive_prob=0.5,
+            )
+
+
+class TestAugmentKeypoints:
+    def test_returns_same_shapes(self) -> None:
+        kp = torch.rand(6, 2)
+        vis = torch.ones(6, dtype=torch.bool)
+        out_kp, out_vis = augment_keypoints(kp, vis, noise_std=0.1)
+        assert out_kp.shape == kp.shape
+        assert out_vis.shape == vis.shape

--- a/tests/unit/utils/data/test_heatmaps.py
+++ b/tests/unit/utils/data/test_heatmaps.py
@@ -1,0 +1,160 @@
+"""Unit tests for :mod:`src.utils.data.heatmaps`."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.utils.data.heatmaps import (
+    generate_gaussian_heatmap,
+    generate_gaussian_heatmaps,
+    heatmaps_to_argmax,
+    heatmaps_to_peaks,
+    heatmaps_to_pixel_coords,
+    heatmaps_to_soft_argmax,
+)
+
+
+class TestGenerateGaussianHeatmaps:
+    def test_single_center_returns_squeezed_2d(self) -> None:
+        hm = generate_gaussian_heatmaps((16, 16), (0.5, 0.5), sigma_ratio=0.1)
+        assert hm.shape == (16, 16)
+
+    def test_peak_is_at_center(self) -> None:
+        hm = generate_gaussian_heatmaps((33, 33), (0.5, 0.5), sigma_ratio=0.05)
+        peak = hm.argmax()
+        row, col = divmod(int(peak), 33)
+        assert (row, col) == (16, 16)
+        assert hm.max().item() == pytest.approx(1.0, abs=1e-4)
+
+    def test_batched_centers_shape(self) -> None:
+        centers = torch.tensor([[0.2, 0.3], [0.7, 0.8], [0.5, 0.5]])
+        hm = generate_gaussian_heatmaps((8, 12), centers, sigma_ratio=0.1)
+        assert hm.shape == (3, 8, 12)
+
+    def test_out_of_bounds_center_is_zeroed(self) -> None:
+        hm = generate_gaussian_heatmaps((16, 16), (1.5, 0.5), sigma_ratio=0.1)
+        assert torch.count_nonzero(hm) == 0
+
+    def test_visibility_false_zeroes_map(self) -> None:
+        centers = torch.tensor([[0.5, 0.5], [0.5, 0.5]])
+        visibility = torch.tensor([True, False])
+        hm = generate_gaussian_heatmaps(
+            (16, 16), centers, sigma_ratio=0.1, visibility=visibility
+        )
+        assert hm[0].sum() > 0
+        assert torch.count_nonzero(hm[1]) == 0
+
+    def test_non_positive_sigma_raises(self) -> None:
+        with pytest.raises(ValueError, match="sigma_ratio"):
+            generate_gaussian_heatmaps((16, 16), (0.5, 0.5), sigma_ratio=0.0)
+
+    def test_bad_center_shape_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"\(\.\.\., 2\)"):
+            generate_gaussian_heatmaps((16, 16), torch.zeros(3, 3), sigma_ratio=0.1)
+
+    @pytest.mark.parametrize("size", [(0, 8), (8, -1), (8,)])
+    def test_invalid_size_raises(self, size: tuple[int, ...]) -> None:
+        with pytest.raises(ValueError):
+            generate_gaussian_heatmaps(size, (0.5, 0.5), sigma_ratio=0.1)
+
+
+class TestGenerateGaussianHeatmap:
+    def test_visible_flag_false_zeroes(self) -> None:
+        hm = generate_gaussian_heatmap((16, 16), (0.5, 0.5), 0.1, visible=False)
+        assert torch.count_nonzero(hm) == 0
+
+    def test_visible_true_has_peak(self) -> None:
+        # Odd size so the normalized center 0.5 lands exactly on a grid point.
+        hm = generate_gaussian_heatmap((17, 17), (0.5, 0.5), 0.1, visible=True)
+        assert hm.max().item() == pytest.approx(1.0, abs=1e-4)
+
+
+class TestHeatmapsToArgmax:
+    def test_recovers_normalized_peak(self) -> None:
+        hm = torch.zeros(9, 9)
+        hm[0, 8] = 1.0  # bottom-left in (row=y, col=x) -> x=1.0, y=0.0
+        coords, values = heatmaps_to_argmax(hm)
+        assert torch.allclose(coords, torch.tensor([1.0, 0.0]))
+        assert values.item() == 1.0
+
+    def test_batched_leading_dims(self) -> None:
+        hm = torch.rand(2, 3, 5, 7)
+        coords, values = heatmaps_to_argmax(hm)
+        assert coords.shape == (2, 3, 2)
+        assert values.shape == (2, 3)
+
+    def test_low_ndim_raises(self) -> None:
+        with pytest.raises(ValueError):
+            heatmaps_to_argmax(torch.zeros(5))
+
+
+class TestHeatmapsToPixelCoords:
+    def test_scales_to_pixel_grid(self) -> None:
+        hm = torch.zeros(10, 20)
+        hm[9, 19] = 1.0
+        coords = heatmaps_to_pixel_coords(hm)
+        assert torch.allclose(coords, torch.tensor([19.0, 9.0]))
+
+    def test_custom_target_size(self) -> None:
+        hm = torch.zeros(10, 10)
+        hm[9, 9] = 1.0
+        coords = heatmaps_to_pixel_coords(hm, height=100, width=200)
+        assert torch.allclose(coords, torch.tensor([199.0, 99.0]))
+
+
+class TestHeatmapsToSoftArgmax:
+    def test_sharp_peak_approximates_argmax(self) -> None:
+        hm = torch.full((11, 11), -10.0)
+        hm[5, 5] = 10.0
+        coords = heatmaps_to_soft_argmax(hm, temperature=0.5)
+        assert torch.allclose(coords, torch.tensor([0.5, 0.5]), atol=1e-3)
+
+    def test_is_differentiable(self) -> None:
+        hm = torch.randn(8, 8, requires_grad=True)
+        coords = heatmaps_to_soft_argmax(hm)
+        coords.sum().backward()
+        assert hm.grad is not None
+        assert torch.isfinite(hm.grad).all()
+
+    def test_non_positive_temperature_raises(self) -> None:
+        with pytest.raises(ValueError, match="temperature"):
+            heatmaps_to_soft_argmax(torch.zeros(4, 4), temperature=0.0)
+
+    def test_low_ndim_raises(self) -> None:
+        with pytest.raises(ValueError):
+            heatmaps_to_soft_argmax(torch.zeros(4))
+
+
+class TestHeatmapsToPeaks:
+    def test_extracts_single_peak(self) -> None:
+        hm = torch.zeros(17, 17)
+        hm[8, 8] = 1.0
+        coords, values, valid = heatmaps_to_peaks(
+            hm, threshold=0.5, nms_kernel=3, max_peaks=4
+        )
+        assert coords.shape == (4, 2)
+        assert valid[0].item() is True
+        assert values[0].item() == pytest.approx(1.0)
+        assert torch.allclose(coords[0], torch.tensor([0.5, 0.5]), atol=1e-6)
+        # Only one peak exceeds threshold.
+        assert int(valid.sum()) == 1
+
+    def test_threshold_filters_low_peaks(self) -> None:
+        hm = torch.full((9, 9), 0.1)
+        _, _, valid = heatmaps_to_peaks(
+            hm, threshold=0.5, nms_kernel=3, max_peaks=4
+        )
+        assert int(valid.sum()) == 0
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"threshold": -1.0, "nms_kernel": 3, "max_peaks": 1},
+            {"threshold": 0.0, "nms_kernel": 2, "max_peaks": 1},
+            {"threshold": 0.0, "nms_kernel": 3, "max_peaks": 0},
+        ],
+    )
+    def test_invalid_args_raise(self, kwargs: dict) -> None:
+        with pytest.raises(ValueError):
+            heatmaps_to_peaks(torch.zeros(8, 8), **kwargs)

--- a/tests/unit/utils/data/test_splits.py
+++ b/tests/unit/utils/data/test_splits.py
@@ -1,0 +1,74 @@
+"""Unit tests for :mod:`src.utils.data.splits`."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from src.utils.data.splits import GroupSplitConfig, make_group_split_map
+
+
+def _uniform_groups(n: int) -> dict[str, int]:
+    return {f"g{i}": 1 for i in range(n)}
+
+
+class TestMakeGroupSplitMap:
+    def test_empty_groups_returns_empty(self) -> None:
+        config = GroupSplitConfig(val_ratio=0.2, test_ratio=0.2, seed=0)
+        assert make_group_split_map({}, config) == {}
+
+    @pytest.mark.parametrize(
+        "val,test",
+        [(-0.1, 0.2), (0.2, -0.1), (0.5, 0.5), (0.7, 0.4)],
+    )
+    def test_invalid_ratios_raise(self, val: float, test: float) -> None:
+        config = GroupSplitConfig(val_ratio=val, test_ratio=test, seed=0)
+        with pytest.raises(ValueError, match="ratios"):
+            make_group_split_map(_uniform_groups(10), config)
+
+    def test_fewer_than_three_groups_all_train(self) -> None:
+        config = GroupSplitConfig(val_ratio=0.3, test_ratio=0.3, seed=0)
+        result = make_group_split_map(_uniform_groups(2), config)
+        assert set(result.values()) == {"train"}
+
+    def test_every_group_is_assigned_once(self) -> None:
+        config = GroupSplitConfig(val_ratio=0.2, test_ratio=0.2, seed=7)
+        groups = _uniform_groups(10)
+        result = make_group_split_map(groups, config)
+        assert set(result) == set(groups)
+        assert set(result.values()) <= {"train", "val", "test"}
+
+    def test_split_group_counts(self) -> None:
+        config = GroupSplitConfig(val_ratio=0.2, test_ratio=0.2, seed=7)
+        result = make_group_split_map(_uniform_groups(10), config)
+        counts = Counter(result.values())
+        assert counts["test"] == 2
+        assert counts["val"] == 2
+        assert counts["train"] == 6
+
+    def test_deterministic_for_same_seed(self) -> None:
+        config = GroupSplitConfig(val_ratio=0.2, test_ratio=0.2, seed=42)
+        groups = _uniform_groups(12)
+        first = make_group_split_map(groups, config)
+        second = make_group_split_map(groups, config)
+        assert first == second
+
+    def test_seed_changes_assignment(self) -> None:
+        groups = _uniform_groups(12)
+        a = make_group_split_map(
+            groups, GroupSplitConfig(val_ratio=0.25, test_ratio=0.25, seed=1)
+        )
+        b = make_group_split_map(
+            groups, GroupSplitConfig(val_ratio=0.25, test_ratio=0.25, seed=999)
+        )
+        # Same number of holdout groups, but membership differs across seeds.
+        assert a != b
+
+
+class TestGroupSplitConfig:
+    def test_is_frozen(self) -> None:
+        config = GroupSplitConfig(val_ratio=0.1, test_ratio=0.1, seed=0)
+        with pytest.raises(FrozenInstanceError):
+            config.seed = 5  # type: ignore[misc]

--- a/tests/unit/utils/geometry/test_angles.py
+++ b/tests/unit/utils/geometry/test_angles.py
@@ -1,0 +1,106 @@
+"""Unit tests for :mod:`src.utils.geometry.angles`."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from src.utils.geometry.angles import (
+    angular_error,
+    normalize_vector,
+    signed_angle_around_axis,
+    wrapped_angle_diff,
+)
+
+
+class TestNormalizeVector:
+    def test_unit_norm_result(self) -> None:
+        v = torch.tensor([3.0, 4.0])
+        out = normalize_vector(v)
+        assert out.norm().item() == pytest.approx(1.0, abs=1e-6)
+        assert torch.allclose(out, torch.tensor([0.6, 0.8]), atol=1e-6)
+
+    def test_preserves_direction_batched(self) -> None:
+        v = torch.tensor([[2.0, 0.0, 0.0], [0.0, 0.0, 5.0]])
+        out = normalize_vector(v)
+        expected = torch.tensor([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        assert torch.allclose(out, expected, atol=1e-6)
+
+    def test_zero_vector_is_safe(self) -> None:
+        v = torch.zeros(3)
+        out = normalize_vector(v)
+        # eps clamp avoids division by zero; result stays finite and near-zero.
+        assert torch.isfinite(out).all()
+        assert out.norm().item() < 1e-3
+
+
+class TestWrappedAngleDiff:
+    def test_zero_difference(self) -> None:
+        a = torch.tensor([0.0, 1.0, -2.0])
+        assert torch.allclose(wrapped_angle_diff(a, a), torch.zeros(3), atol=1e-6)
+
+    def test_result_wrapped_into_pi_range(self) -> None:
+        pred = torch.tensor([0.1])
+        target = torch.tensor([2 * math.pi - 0.1])
+        diff = wrapped_angle_diff(pred, target)
+        assert diff.item() == pytest.approx(0.2, abs=1e-5)
+        assert -math.pi <= diff.item() <= math.pi
+
+    def test_sign_is_preserved(self) -> None:
+        diff = wrapped_angle_diff(torch.tensor([1.0]), torch.tensor([0.0]))
+        assert diff.item() == pytest.approx(1.0, abs=1e-6)
+
+
+class TestAngularError:
+    def test_orthogonal_cos_sin_pairs(self) -> None:
+        pred = torch.tensor([1.0, 0.0])  # angle 0
+        target = torch.tensor([0.0, 1.0])  # angle pi/2
+        assert angular_error(pred, target).item() == pytest.approx(
+            math.pi / 2, abs=1e-6
+        )
+
+    def test_error_is_non_negative_and_wrapped(self) -> None:
+        pred = torch.tensor([math.cos(0.1), math.sin(0.1)])
+        target = torch.tensor([math.cos(-0.1), math.sin(-0.1)])
+        err = angular_error(pred, target)
+        assert err.item() == pytest.approx(0.2, abs=1e-5)
+        assert err.item() >= 0.0
+
+    def test_batched_shape(self) -> None:
+        pred = torch.randn(4, 5, 2)
+        target = torch.randn(4, 5, 2)
+        assert angular_error(pred, target).shape == (4, 5)
+
+
+class TestSignedAngleAroundAxis:
+    def test_quarter_turn_around_z(self) -> None:
+        v1 = torch.tensor([1.0, 0.0, 0.0])
+        v2 = torch.tensor([0.0, 1.0, 0.0])
+        axis = torch.tensor([0.0, 0.0, 1.0])
+        assert signed_angle_around_axis(v1, v2, axis).item() == pytest.approx(
+            math.pi / 2, abs=1e-6
+        )
+
+    def test_sign_flips_with_direction(self) -> None:
+        v1 = torch.tensor([1.0, 0.0, 0.0])
+        v2 = torch.tensor([0.0, -1.0, 0.0])
+        axis = torch.tensor([0.0, 0.0, 1.0])
+        assert signed_angle_around_axis(v1, v2, axis).item() == pytest.approx(
+            -math.pi / 2, abs=1e-6
+        )
+
+    def test_component_along_axis_is_ignored(self) -> None:
+        # Adding an axis-parallel component to either vector must not change
+        # the signed angle measured in the perpendicular plane.
+        v1 = torch.tensor([1.0, 0.0, 0.0])
+        v2 = torch.tensor([0.0, 1.0, 0.0])
+        axis = torch.tensor([0.0, 0.0, 1.0])
+        base = signed_angle_around_axis(v1, v2, axis)
+        shifted = signed_angle_around_axis(
+            v1 + torch.tensor([0.0, 0.0, 3.0]),
+            v2 - torch.tensor([0.0, 0.0, 2.0]),
+            axis,
+        )
+        assert shifted.item() == pytest.approx(base.item(), abs=1e-6)

--- a/tests/unit/utils/geometry/test_court_pose.py
+++ b/tests/unit/utils/geometry/test_court_pose.py
@@ -1,0 +1,62 @@
+"""Unit tests for :mod:`src.utils.geometry.court_pose`."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from src.utils.geometry.court_pose import (
+    canonical_pose_to_world_pose,
+    court_position_to_world_translation,
+    world_pose_to_canonical_pose,
+)
+from src.utils.schema.court import (
+    COURT_COORD_SCALE_X,
+    COURT_COORD_SCALE_Y,
+    COURT_COORD_SCALE_Z,
+)
+
+
+class TestCourtPositionToWorldTranslation:
+    def test_scales_each_axis(self) -> None:
+        position = torch.tensor([1.0, 1.0, 1.0])
+        out = court_position_to_world_translation(position)
+        expected = torch.tensor(
+            [COURT_COORD_SCALE_X, COURT_COORD_SCALE_Y, COURT_COORD_SCALE_Z]
+        )
+        assert torch.allclose(out, expected, atol=1e-5)
+
+    def test_zero_position_maps_to_origin(self) -> None:
+        out = court_position_to_world_translation(torch.zeros(3))
+        assert torch.allclose(out, torch.zeros(3))
+
+
+def _rotation(theta: float) -> torch.Tensor:
+    return torch.tensor([math.cos(theta), math.sin(theta)])
+
+
+class TestCanonicalWorldRoundTrip:
+    def test_identity_placement_is_noop(self) -> None:
+        canonical = torch.randn(5, 3)
+        position = torch.zeros(3)
+        rotation = _rotation(0.0)  # (cos 0, sin 0) = (1, 0)
+        world = canonical_pose_to_world_pose(canonical, position, rotation)
+        assert torch.allclose(world, canonical, atol=1e-5)
+
+    def test_round_trip_recovers_canonical(self) -> None:
+        canonical = torch.randn(8, 3)
+        position = torch.tensor([0.3, -0.5, 0.2])
+        rotation = _rotation(0.7)
+        world = canonical_pose_to_world_pose(canonical, position, rotation)
+        recovered = world_pose_to_canonical_pose(world, position, rotation)
+        assert torch.allclose(recovered, canonical, atol=1e-4)
+
+    def test_z_axis_is_pure_translation(self) -> None:
+        canonical = torch.randn(4, 3)
+        position = torch.tensor([0.1, 0.2, 1.0])
+        rotation = _rotation(1.1)
+        world = canonical_pose_to_world_pose(canonical, position, rotation)
+        # Yaw only rotates in the XY plane; Z just shifts by the scaled offset.
+        expected_z = canonical[..., 2] + position[2] * COURT_COORD_SCALE_Z
+        assert torch.allclose(world[..., 2], expected_z, atol=1e-5)

--- a/tests/unit/utils/geometry/test_keypoints.py
+++ b/tests/unit/utils/geometry/test_keypoints.py
@@ -1,0 +1,66 @@
+"""Unit tests for :mod:`src.utils.geometry.keypoints`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.utils.geometry.keypoints import (
+    clamp_pixel_coordinate,
+    denormalize_keypoints,
+    normalize_keypoints,
+)
+
+
+class TestClampPixelCoordinate:
+    def test_value_inside_range_is_unchanged(self) -> None:
+        assert clamp_pixel_coordinate(5.0, 10) == 5.0
+
+    def test_negative_value_clamped_to_zero(self) -> None:
+        assert clamp_pixel_coordinate(-3.0, 10) == 0.0
+
+    def test_value_above_max_clamped_to_axis_size_minus_one(self) -> None:
+        assert clamp_pixel_coordinate(100.0, 10) == 9.0
+
+    def test_zero_axis_size_clamps_to_zero(self) -> None:
+        # max(axis_size - 1, 0) keeps the upper bound non-negative.
+        assert clamp_pixel_coordinate(5.0, 0) == 0.0
+
+    def test_returns_float(self) -> None:
+        assert isinstance(clamp_pixel_coordinate(3, 10), float)
+
+
+class TestNormalizeKeypoints:
+    def test_scales_by_width_and_height(self) -> None:
+        kp = np.array([[100.0, 50.0], [200.0, 100.0]], dtype=np.float32)
+        out = normalize_keypoints(kp, width=200, height=100)
+        expected = np.array([[0.5, 0.5], [1.0, 1.0]], dtype=np.float32)
+        np.testing.assert_allclose(out, expected)
+
+    def test_does_not_mutate_input(self) -> None:
+        kp = np.array([[100.0, 50.0]], dtype=np.float32)
+        original = kp.copy()
+        normalize_keypoints(kp, width=200, height=100)
+        np.testing.assert_array_equal(kp, original)
+
+    def test_supports_leading_dims(self) -> None:
+        kp: np.ndarray = np.zeros((4, 7, 2), dtype=np.float32)
+        assert normalize_keypoints(kp, 10, 10).shape == (4, 7, 2)
+
+
+class TestDenormalizeKeypoints:
+    def test_scales_back_to_pixels(self) -> None:
+        kp = np.array([[0.5, 0.5]], dtype=np.float32)
+        out = denormalize_keypoints(kp, width=200, height=100)
+        np.testing.assert_allclose(out, np.array([[100.0, 50.0]], dtype=np.float32))
+
+    def test_round_trip_recovers_original(self) -> None:
+        kp = np.array([[123.0, 45.0], [12.0, 99.0]], dtype=np.float32)
+        normalized = normalize_keypoints(kp, 256, 128)
+        recovered = denormalize_keypoints(normalized, 256, 128)
+        np.testing.assert_allclose(recovered, kp, rtol=1e-5)
+
+    def test_does_not_mutate_input(self) -> None:
+        kp = np.array([[0.5, 0.5]], dtype=np.float32)
+        original = kp.copy()
+        denormalize_keypoints(kp, 200, 100)
+        np.testing.assert_array_equal(kp, original)

--- a/tests/unit/utils/geometry/test_matrices.py
+++ b/tests/unit/utils/geometry/test_matrices.py
@@ -1,0 +1,98 @@
+"""Unit tests for :mod:`src.utils.geometry.matrices`."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from src.utils.geometry.matrices import (
+    apply_plcs_transform,
+    apply_plcs_transform_batch,
+    axis_angle_to_rotation_matrix,
+    rotation_matrix_y,
+    rotation_matrix_z,
+)
+
+
+def _is_rotation(mat: np.ndarray) -> bool:
+    identity = np.eye(3, dtype=mat.dtype)
+    orthonormal = np.allclose(mat @ mat.T, identity, atol=1e-5)
+    proper = math.isclose(float(np.linalg.det(mat)), 1.0, abs_tol=1e-5)
+    return orthonormal and proper
+
+
+class TestRotationMatrixY:
+    def test_zero_yaw_is_identity(self) -> None:
+        np.testing.assert_allclose(rotation_matrix_y(0.0), np.eye(3), atol=1e-7)
+
+    def test_is_a_proper_rotation(self) -> None:
+        assert _is_rotation(rotation_matrix_y(0.9))
+
+    def test_rotates_x_into_minus_z_for_quarter_turn(self) -> None:
+        # vertices @ R.T convention: a quarter Y-turn maps +x to -z.
+        rot = rotation_matrix_y(math.pi / 2)
+        point = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        rotated = point @ rot.T
+        np.testing.assert_allclose(rotated, [0.0, 0.0, -1.0], atol=1e-6)
+
+    def test_returns_float32(self) -> None:
+        assert rotation_matrix_y(0.3).dtype == np.float32
+
+
+class TestRotationMatrixZ:
+    def test_batched_shape(self) -> None:
+        yaw: np.ndarray = np.zeros((4, 5), dtype=np.float32)
+        assert rotation_matrix_z(yaw).shape == (4, 5, 3, 3)
+
+    def test_zero_yaw_is_identity(self) -> None:
+        rot = rotation_matrix_z(np.zeros(2, dtype=np.float32))
+        np.testing.assert_allclose(rot, np.broadcast_to(np.eye(3), (2, 3, 3)), atol=1e-7)
+
+    def test_each_matrix_is_a_proper_rotation(self) -> None:
+        yaw = np.array([0.1, 1.2, -0.7], dtype=np.float32)
+        for mat in rotation_matrix_z(yaw):
+            assert _is_rotation(mat)
+
+
+class TestAxisAngleToRotationMatrix:
+    def test_zero_rotation_is_identity(self) -> None:
+        out = axis_angle_to_rotation_matrix(np.zeros(3, dtype=np.float32))
+        np.testing.assert_allclose(out, np.eye(3), atol=1e-6)
+
+    def test_matches_rotation_matrix_z_for_z_axis(self) -> None:
+        theta = 0.73
+        aa = np.array([0.0, 0.0, theta], dtype=np.float32)
+        from_axis_angle = axis_angle_to_rotation_matrix(aa)
+        from_z = rotation_matrix_z(np.array(theta, dtype=np.float32))
+        np.testing.assert_allclose(from_axis_angle, from_z, atol=1e-6)
+
+    def test_batched_proper_rotations(self) -> None:
+        aa = np.array([[0.0, 0.0, 0.5], [0.3, -0.2, 0.1]], dtype=np.float32)
+        out = axis_angle_to_rotation_matrix(aa)
+        assert out.shape == (2, 3, 3)
+        for mat in out:
+            assert _is_rotation(mat)
+
+
+class TestApplyPlcsTransform:
+    def test_identity_transform_is_noop(self) -> None:
+        verts = np.random.rand(5, 3).astype(np.float32)
+        out = apply_plcs_transform(verts, np.zeros(3, dtype=np.float32), 0.0)
+        np.testing.assert_allclose(out, verts, atol=1e-6)
+
+    def test_translation_only(self) -> None:
+        verts: np.ndarray = np.zeros((3, 3), dtype=np.float32)
+        pos = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        out = apply_plcs_transform(verts, pos, 0.0)
+        np.testing.assert_allclose(out, np.broadcast_to(pos, (3, 3)), atol=1e-6)
+
+    def test_batch_matches_per_frame(self) -> None:
+        rng = np.random.default_rng(0)
+        verts = rng.random((4, 6, 3)).astype(np.float32)
+        positions = rng.random((4, 3)).astype(np.float32)
+        yaws = rng.random(4).astype(np.float32)
+        batched = apply_plcs_transform_batch(verts, positions, yaws)
+        for t in range(4):
+            per_frame = apply_plcs_transform(verts[t], positions[t], float(yaws[t]))
+            np.testing.assert_allclose(batched[t], per_frame, atol=1e-5)

--- a/tests/unit/utils/projection/test_camera_projector.py
+++ b/tests/unit/utils/projection/test_camera_projector.py
@@ -1,0 +1,122 @@
+"""Unit tests for :mod:`src.utils.projection.camera_projector`."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from src.utils.projection.camera_projector import (
+    Camera,
+    CameraConfig,
+    CameraProjector,
+    CameraView,
+    make_look_at_camera,
+    project_points,
+)
+
+
+class TestMakeLookAtCamera:
+    def test_rotation_is_orthonormal(self) -> None:
+        cam = make_look_at_camera(center=(2.0, -3.0, 4.0), look_at=(0.0, 0.0, 0.0))
+        rtr = cam.R @ cam.R.t()
+        assert torch.allclose(rtr, torch.eye(3), atol=1e-5)
+
+    def test_principal_point_is_image_center(self) -> None:
+        cam = make_look_at_camera(center=(0.0, 0.0, 5.0), image_size=(1280, 720))
+        assert cam.cx == pytest.approx(640.0)
+        assert cam.cy == pytest.approx(360.0)
+        assert cam.w == 1280 and cam.h == 720
+
+    def test_focal_length_from_hfov(self) -> None:
+        cam = make_look_at_camera(
+            center=(0.0, 0.0, 5.0), image_size=(1000, 500), hfov_deg=90.0
+        )
+        expected_f = 0.5 * 1000 / math.tan(math.radians(45.0))
+        assert cam.f == pytest.approx(expected_f, rel=1e-5)
+
+
+class TestProjectPoints:
+    def test_empty_input(self) -> None:
+        cam = make_look_at_camera(center=(0.0, 0.0, 5.0))
+        uv, mask = project_points(cam, torch.zeros(0, 3))
+        assert uv.shape == (0, 2)
+        assert mask.shape == (0,)
+
+    def test_look_at_target_maps_to_principal_point(self) -> None:
+        cam = make_look_at_camera(center=(0.0, 0.0, 5.0), look_at=(0.0, 0.0, 0.0))
+        uv, mask = project_points(cam, torch.tensor([[0.0, 0.0, 0.0]]))
+        assert bool(mask[0])
+        assert uv[0, 0].item() == pytest.approx(cam.cx, abs=1e-3)
+        assert uv[0, 1].item() == pytest.approx(cam.cy, abs=1e-3)
+
+    def test_point_behind_camera_is_masked(self) -> None:
+        cam = make_look_at_camera(center=(0.0, 0.0, 5.0), look_at=(0.0, 0.0, 0.0))
+        # Camera looks down -z; a point above it (further +z) is behind.
+        _, mask = project_points(cam, torch.tensor([[0.0, 0.0, 10.0]]))
+        assert not bool(mask[0])
+
+
+class TestCameraProjector:
+    def test_project_points_to_uv_normalized_and_visible(self) -> None:
+        projector = CameraProjector()
+        cam = make_look_at_camera(center=(0.0, 0.0, 5.0), look_at=(0.0, 0.0, 0.0))
+        uv, visible = projector.project_points_to_uv(
+            torch.tensor([[0.0, 0.0, 0.0]]), cam
+        )
+        assert uv.shape == (1, 2)
+        assert torch.allclose(uv[0], torch.tensor([0.5, 0.5]), atol=1e-3)
+        assert bool(visible[0])
+
+    def test_project_points_to_uv_empty(self) -> None:
+        projector = CameraProjector()
+        cam = make_look_at_camera(center=(0.0, 0.0, 5.0))
+        uv, visible = projector.project_points_to_uv(torch.zeros(0, 3), cam)
+        assert uv.shape == (0, 2)
+        assert visible.shape == (0,)
+
+    def test_project_points_preserves_leading_dims(self) -> None:
+        projector = CameraProjector()
+        cam = make_look_at_camera(center=(0.0, 0.0, 5.0))
+        pts = torch.rand(4, 7, 3)
+        uv, visible = projector.project_points_to_uv(pts, cam)
+        assert uv.shape == (4, 7, 2)
+        assert visible.shape == (4, 7)
+
+    def test_project_court_keypoints_shape(self) -> None:
+        projector = CameraProjector()
+        cam = make_look_at_camera(center=(0.0, -15.0, 5.0), look_at=(0.0, 0.0, 0.0))
+        uv, visible = projector.project_court_keypoints(cam)
+        assert uv.shape == (20, 2)
+        assert visible.shape == (20,)
+        assert visible.dtype == torch.bool
+
+    def test_generate_camera_view_serializes_params(self) -> None:
+        projector = CameraProjector()
+        cam = make_look_at_camera(center=(0.0, -15.0, 5.0), look_at=(0.0, 0.0, 0.0))
+        view = projector.generate_camera_view(torch.rand(3, 3), cam)
+        assert isinstance(view, CameraView)
+        assert set(view.camera_params) == {"C", "R", "f", "cx", "cy", "w", "h"}
+        assert view.points_uv is not None and view.points_uv.shape == (3, 2)
+
+    def test_fixed_cameras_deterministic_without_noise(self) -> None:
+        config = CameraConfig(
+            fixed_position_noise_radius=0.0,
+            fixed_look_at_xy_radius=0.0,
+        )
+        projector = CameraProjector(config=config)
+        cams_a = projector.fixed_cameras()
+        cams_b = projector.fixed_cameras()
+        assert len(cams_a) == 6
+        for a, b in zip(cams_a, cams_b, strict=True):
+            assert torch.allclose(a.C, b.C)
+            assert torch.allclose(a.R, b.R)
+
+
+class TestCameraDataclass:
+    def test_is_constructible(self) -> None:
+        cam = Camera(
+            C=torch.zeros(3), R=torch.eye(3), f=1.0, cx=0.5, cy=0.5, w=2, h=2
+        )
+        assert cam.f == 1.0

--- a/tests/unit/utils/test_seeding.py
+++ b/tests/unit/utils/test_seeding.py
@@ -1,0 +1,60 @@
+"""Unit tests for :mod:`src.utils.seeding`."""
+
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import torch
+
+from src.utils.seeding import make_sample_rng, seed_everything
+
+
+class TestSeedEverything:
+    def test_python_random_is_reproducible(self) -> None:
+        seed_everything(123)
+        a = [random.random() for _ in range(5)]
+        seed_everything(123)
+        b = [random.random() for _ in range(5)]
+        assert a == b
+
+    def test_numpy_is_reproducible(self) -> None:
+        seed_everything(7)
+        a = np.random.rand(5)
+        seed_everything(7)
+        b = np.random.rand(5)
+        np.testing.assert_array_equal(a, b)
+
+    def test_torch_is_reproducible(self) -> None:
+        seed_everything(99)
+        a = torch.randn(5)
+        seed_everything(99)
+        b = torch.randn(5)
+        assert torch.equal(a, b)
+
+    def test_different_seeds_differ(self) -> None:
+        seed_everything(1)
+        a = torch.randn(10)
+        seed_everything(2)
+        b = torch.randn(10)
+        assert not torch.equal(a, b)
+
+
+class TestMakeSampleRng:
+    def test_returns_random_instance(self) -> None:
+        torch.manual_seed(0)
+        assert isinstance(make_sample_rng(0), random.Random)
+
+    def test_same_sample_idx_is_deterministic(self) -> None:
+        torch.manual_seed(0)
+        a = make_sample_rng(5).random()
+        torch.manual_seed(0)
+        b = make_sample_rng(5).random()
+        assert a == b
+
+    def test_different_sample_idx_decorrelated(self) -> None:
+        torch.manual_seed(0)
+        a = make_sample_rng(1).random()
+        torch.manual_seed(0)
+        b = make_sample_rng(2).random()
+        assert a != b

--- a/tests/unit/utils/test_tensor_utils.py
+++ b/tests/unit/utils/test_tensor_utils.py
@@ -1,0 +1,114 @@
+"""Unit tests for :mod:`src.utils.tensor_utils`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from src.utils.tensor_utils import (
+    clone_tensor_dict,
+    masked_mean,
+    normalize_padding_mask,
+    to_numpy,
+)
+
+
+class TestCloneTensorDict:
+    def test_tensors_are_cloned(self) -> None:
+        original = {"x": torch.ones(3), "name": "ball"}
+        cloned = clone_tensor_dict(original)
+        cloned["x"][0] = 99.0
+        assert original["x"][0] == 1.0  # original untouched
+        assert cloned["x"] is not original["x"]
+
+    def test_non_tensors_passed_by_reference(self) -> None:
+        payload = [1, 2, 3]
+        original = {"meta": payload}
+        cloned = clone_tensor_dict(original)
+        assert cloned["meta"] is payload
+
+    def test_returns_plain_dict(self) -> None:
+        assert isinstance(clone_tensor_dict({"x": torch.zeros(1)}), dict)
+
+
+class TestToNumpy:
+    def test_detaches_and_converts(self) -> None:
+        t = torch.ones(2, 2, requires_grad=True) * 2
+        arr = to_numpy(t)
+        assert isinstance(arr, np.ndarray)
+        np.testing.assert_array_equal(arr, np.full((2, 2), 2.0))
+
+    def test_bfloat16_upcast(self) -> None:
+        t = torch.ones(3, dtype=torch.bfloat16)
+        arr = to_numpy(t)
+        assert arr.dtype == np.float32
+
+    def test_dtype_override(self) -> None:
+        arr = to_numpy(torch.ones(3), dtype=np.int64)
+        assert arr.dtype == np.int64
+
+    def test_array_like_passthrough(self) -> None:
+        np.testing.assert_array_equal(to_numpy([1, 2, 3]), np.array([1, 2, 3]))
+
+
+class TestMaskedMean:
+    def test_none_mask_is_plain_mean(self) -> None:
+        values = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        assert masked_mean(values).item() == pytest.approx(2.5)
+
+    def test_basic_masked_mean(self) -> None:
+        values = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        mask = torch.tensor([1.0, 0.0, 1.0, 0.0])
+        assert masked_mean(values, mask).item() == pytest.approx(2.0)
+
+    def test_binarize_treats_mask_as_boolean(self) -> None:
+        values = torch.tensor([10.0, 20.0])
+        mask = torch.tensor([0.5, 0.0])
+        assert masked_mean(values, mask, binarize=True).item() == pytest.approx(10.0)
+
+    def test_broadcast_lower_rank_mask(self) -> None:
+        values = torch.tensor([[1.0, 1.0, 1.0], [3.0, 3.0, 3.0]])
+        mask = torch.tensor([1.0, 0.0])  # keep only the first row
+        assert masked_mean(values, mask, broadcast=True).item() == pytest.approx(1.0)
+
+    def test_denom_min_prevents_div_by_zero(self) -> None:
+        values = torch.tensor([5.0, 5.0])
+        mask = torch.zeros(2)
+        out = masked_mean(values, mask, denom_min=1.0)
+        assert out.item() == pytest.approx(0.0)
+        assert torch.isfinite(out)
+
+
+class TestNormalizePaddingMask:
+    def test_none_returns_none(self) -> None:
+        assert normalize_padding_mask(None) is None
+
+    def test_1d_and_2d_passthrough(self) -> None:
+        mask = torch.tensor([[1, 0], [0, 1]])
+        out = normalize_padding_mask(mask)
+        assert out.dtype == torch.bool
+        assert out.tolist() == [[True, False], [False, True]]
+
+    def test_3d_reduces_over_n(self) -> None:
+        # (B=1, N=2, T=3) -> any over N
+        mask = torch.tensor([[[1, 0, 0], [0, 0, 1]]])
+        out = normalize_padding_mask(mask)
+        assert out.shape == (1, 3)
+        assert out.tolist() == [[True, False, True]]
+
+    def test_4d_reduces_over_n_and_j(self) -> None:
+        mask = torch.zeros(2, 3, 4, 5)
+        mask[0, 0, 1, 0] = 1
+        out = normalize_padding_mask(mask)
+        assert out.shape == (2, 4)
+        assert bool(out[0, 1])
+
+    def test_flatten(self) -> None:
+        mask = torch.tensor([[1, 0], [1, 1]])
+        out = normalize_padding_mask(mask, flatten=True)
+        assert out.shape == (4,)
+
+    def test_invalid_rank_raises(self) -> None:
+        with pytest.raises(ValueError):
+            normalize_padding_mask(torch.zeros(2, 3, 4, 5, 6))

--- a/tests/unit/utils/video/test_batching.py
+++ b/tests/unit/utils/video/test_batching.py
@@ -1,0 +1,39 @@
+"""Unit tests for :mod:`src.utils.video.batching`."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.utils.video.batching import iter_temporal_batches
+from src.utils.video.types import TemporalWindow
+
+
+def _window(start: int, *, seq_len: int = 2, c: int = 3, h: int = 4, w: int = 4):
+    frames = tuple(torch.rand(c, h, w) for _ in range(seq_len))
+    return TemporalWindow(
+        start_index=start,
+        frame_indices=tuple(range(start, start + seq_len)),
+        frames=frames,
+    )
+
+
+class TestIterTemporalBatches:
+    def test_stacks_into_bt_chw(self) -> None:
+        windows = [_window(0), _window(2)]
+        batches = list(iter_temporal_batches(windows, batch_size=2))
+        assert len(batches) == 1
+        assert batches[0].tensor.shape == (2, 2, 3, 4, 4)
+        assert batches[0].windows == tuple(windows)
+
+    def test_partial_final_batch(self) -> None:
+        windows = [_window(i) for i in range(3)]
+        batches = list(iter_temporal_batches(windows, batch_size=2))
+        assert [b.tensor.shape[0] for b in batches] == [2, 1]
+
+    def test_empty_input_yields_nothing(self) -> None:
+        assert list(iter_temporal_batches([], batch_size=4)) == []
+
+    def test_non_positive_batch_size_raises(self) -> None:
+        with pytest.raises(ValueError, match="batch_size"):
+            list(iter_temporal_batches([_window(0)], batch_size=0))

--- a/tests/unit/utils/video/test_transforms.py
+++ b/tests/unit/utils/video/test_transforms.py
@@ -1,0 +1,47 @@
+"""Unit tests for :mod:`src.utils.video.transforms`."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from src.utils.data.augmentation import normalize_tensor_images_imagenet
+from src.utils.video.transforms import (
+    BgrToTensorTransform,
+    normalize_tensor_imagenet,
+)
+
+
+class TestBgrToTensorTransform:
+    def test_output_shape_dtype_range(self) -> None:
+        frame_bgr = np.random.randint(0, 256, (8, 8, 3), dtype=np.uint8)
+        transform = BgrToTensorTransform(image_size=(4, 6))
+        out = transform(frame_bgr)
+        assert out.shape == (3, 4, 6)
+        assert out.dtype == torch.float32
+        assert out.min() >= 0.0 and out.max() <= 1.0
+
+    def test_bgr_to_rgb_channel_order(self) -> None:
+        # Pure-blue BGR image (B=255). After BGR->RGB it lands in channel index 2.
+        frame_bgr: np.ndarray = np.zeros((4, 4, 3), dtype=np.uint8)
+        frame_bgr[..., 0] = 255
+        out = BgrToTensorTransform(image_size=(4, 4))(frame_bgr)
+        assert torch.allclose(out[2], torch.ones(4, 4))
+        assert torch.allclose(out[0], torch.zeros(4, 4))
+
+    def test_imagenet_normalization_changes_values(self) -> None:
+        frame_bgr: np.ndarray = np.full((4, 4, 3), 128, dtype=np.uint8)
+        plain = BgrToTensorTransform(image_size=(4, 4))(frame_bgr)
+        normed = BgrToTensorTransform(image_size=(4, 4), normalize_imagenet=True)(
+            frame_bgr
+        )
+        assert not torch.allclose(plain, normed)
+
+
+class TestNormalizeTensorImagenetAlias:
+    def test_matches_canonical_implementation(self) -> None:
+        images = torch.rand(3, 5, 5)
+        assert torch.allclose(
+            normalize_tensor_imagenet(images),
+            normalize_tensor_images_imagenet(images),
+        )

--- a/tests/unit/utils/video/test_windows.py
+++ b/tests/unit/utils/video/test_windows.py
@@ -1,0 +1,84 @@
+"""Unit tests for :mod:`src.utils.video.windows`."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from src.utils.video.types import FramePacket
+from src.utils.video.windows import iter_temporal_windows
+
+
+def _frames(n: int) -> list[FramePacket[int]]:
+    """Frame packets whose payload equals their index, for easy assertions."""
+    return [FramePacket(index=i, frame=i, original_size=(1, 1)) for i in range(n)]
+
+
+def _starts(windows: Iterator) -> list[int]:
+    return [w.start_index for w in windows]
+
+
+class TestIterTemporalWindows:
+    def test_basic_stride_one(self) -> None:
+        windows = list(
+            iter_temporal_windows(_frames(5), sequence_length=3, stride=1)
+        )
+        assert [w.start_index for w in windows] == [0, 1, 2]
+        assert windows[0].frame_indices == (0, 1, 2)
+        assert windows[0].frames == (0, 1, 2)
+
+    def test_stride_two_emits_backfill_tail(self) -> None:
+        # 6 frames, seq=3, stride=2 -> regular starts 0,2 then a tail at 3 so the
+        # last frame (5) is covered.
+        starts = _starts(
+            iter_temporal_windows(_frames(6), sequence_length=3, stride=2)
+        )
+        assert starts == [0, 2, 3]
+
+    def test_drop_policy_skips_tail(self) -> None:
+        starts = _starts(
+            iter_temporal_windows(
+                _frames(6), sequence_length=3, stride=2, tail_policy="drop"
+            )
+        )
+        assert starts == [0, 2]
+
+    def test_no_duplicate_tail_when_aligned(self) -> None:
+        # stride=1 already ends on the last frame -> no extra tail window.
+        starts = _starts(
+            iter_temporal_windows(_frames(5), sequence_length=3, stride=1)
+        )
+        assert starts == [0, 1, 2]
+
+    def test_fewer_frames_than_sequence_backfills(self) -> None:
+        windows = list(
+            iter_temporal_windows(_frames(2), sequence_length=3, stride=1)
+        )
+        assert len(windows) == 1
+        assert windows[0].start_index == 0
+        # Last frame is repeated to pad to sequence_length.
+        assert windows[0].frame_indices == (0, 1, 1)
+
+    def test_fewer_frames_drop_policy_yields_nothing(self) -> None:
+        windows = list(
+            iter_temporal_windows(
+                _frames(2), sequence_length=3, stride=1, tail_policy="drop"
+            )
+        )
+        assert windows == []
+
+    def test_empty_stream_yields_nothing(self) -> None:
+        assert list(iter_temporal_windows([], sequence_length=3, stride=1)) == []
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"sequence_length": 0, "stride": 1},
+            {"sequence_length": 3, "stride": 0},
+            {"sequence_length": 3, "stride": 1, "tail_policy": "nope"},
+        ],
+    )
+    def test_invalid_args_raise(self, kwargs: dict) -> None:
+        with pytest.raises(ValueError):
+            list(iter_temporal_windows(_frames(4), **kwargs))


### PR DESCRIPTION
## Summary

Bootstraps the `tests/` suite per the project's **test-structure** policy, starting from the two highest-ROI areas requested: `src/utils` and `src/tasks/base`. The `tests/` directory was previously empty.

- `unit/` mirrors `src/` one layer down (`src/utils/geometry/angles.py` → `tests/unit/utils/geometry/test_angles.py`).
- Heavy training / rendering paths go to `integration/` as 1-step smoke tests with markers.
- **361 tests pass** (`-n auto`, ~17s). ruff + mypy clean under pre-commit.

## What's covered

**`tests/conftest.py`** — autouse deterministic seeding + shared `rng` / `torch_generator` / `make_image` fixtures.

**`utils/` unit tests (167):** geometry (angles, court_pose, keypoints, matrices), projection/camera_projector, data (heatmaps, splits, augmentation), video (windows, batching, transforms), tensor_utils, seeding. Happy paths, edge/error cases, shape/dtype invariants, determinism, round-trips.

**`tasks/base/` tests (194):** pure logic (losses, gan_loss, gan_transition, chunk_manager, scene_dataset, dataset_writer, datamodules, lightning helpers, predictor, visualization, parallel_runner) as `unit/`; `Trainer.fit` + rendering as `integration/tasks/base/` smoke tests marked `integration` + `slow` (CPU-only, nothing GPU-gated). Selectable via `-m "integration and slow"`.

## Config changes (`pyproject.toml`)

- **addopts:** removed `--cov` / `--cov-report*`; added `-n auto` (parallel); added `--import-mode=importlib` so the mirror tree needs no `__init__.py` and tolerates duplicate test basenames (e.g. `utils/data/test_augmentation.py` vs `tasks/base/data/test_augmentation.py`).
- **mypy:** added a `tests.*` override relaxing `disallow_untyped_defs` / `disallow_untyped_decorators` / `warn_unreachable` / `warn_unused_ignores`. Rationale: the pre-commit runs mypy with `--follow-imports=skip`, under which pytest's own `@fixture` / `@mark.parametrize` decorators are seen as untyped — so those strict rules are unsatisfiable for any fixture or parametrized test. Test bodies are still type-checked (real errors stay active); only the ceremony rules are relaxed.

## Findings while testing `tasks/base` (not addressed here)

1. **Likely bug — `parallel_runner.py:46`:** `run_parallel_scene_generation([])` computes `max_workers=min(num_workers, 0)=0`, and `ProcessPoolExecutor(max_workers=0)` raises `ValueError` instead of yielding nothing. Captured by a test with a NOTE; a `if not scene_indices: return` guard would fix it.
2. **Test-infra note:** under importlib mode + no `__init__.py`, `spawn`-ed subprocesses can't import callables defined in test modules. Any future cross-process test must use an importable top-level callable.

## Test plan

- [x] `pytest tests` → 361 passed
- [x] `ruff check tests/` clean
- [x] `mypy --follow-imports=skip tests/` clean
- [x] pre-commit hooks pass on commit
- [x] `-m "integration and slow"` selects the 7 smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
