### PR TITLE
fix: short-circuit empty workload in run_parallel_scene_generation

### DIFF
--- a/src/tasks/base/generate_dataset/parallel_runner.py
+++ b/src/tasks/base/generate_dataset/parallel_runner.py
@@ -43,6 +43,12 @@ def run_parallel_scene_generation(
             f"Parallel scene generation requires num_workers >= 1 (got {num_workers})"
         )
 
+    # An empty workload short-circuits to an empty iterator: otherwise
+    # ``max_workers`` would be ``min(num_workers, 0) == 0`` and
+    # ``ProcessPoolExecutor`` rejects ``max_workers <= 0``.
+    if not scene_indices:
+        return
+
     max_workers = min(num_workers, len(scene_indices))
 
     # Chunk generation runs from a background thread while the training process

--- a/tests/unit/tasks/base/generate_dataset/test_parallel_runner.py
+++ b/tests/unit/tasks/base/generate_dataset/test_parallel_runner.py
@@ -37,9 +37,7 @@ def test_repeated_args_broadcast_to_each_call() -> None:
     assert out == [8, 125]
 
 
-def test_empty_indices_raises_value_error() -> None:
-    # NOTE (likely bug): for an empty index list, max_workers = min(num_workers, 0)
-    # == 0, and ProcessPoolExecutor rejects max_workers <= 0. So an empty workload
-    # raises instead of yielding nothing. This test documents the current behavior.
-    with pytest.raises(ValueError, match="max_workers must be greater than 0"):
-        list(run_parallel_scene_generation(pow, [], 2, num_workers=4))
+def test_empty_indices_yields_nothing() -> None:
+    # An empty index list short-circuits to an empty iterator rather than
+    # constructing a ProcessPoolExecutor with max_workers=0 (which would raise).
+    assert list(run_parallel_scene_generation(pow, [], 2, num_workers=4)) == []


### PR DESCRIPTION
## Summary

Fixes a bug in `run_parallel_scene_generation` where an **empty** `scene_indices` list crashes instead of yielding nothing.

`max_workers = min(num_workers, len(scene_indices))` becomes `min(num_workers, 0) == 0`, and `ProcessPoolExecutor(max_workers=0)` raises `ValueError("max_workers must be greater than 0")`. An empty workload should simply produce an empty iterator.

## Change

- `parallel_runner.py`: add an early `return` (the function is a generator) when `scene_indices` is empty.
- Update `test_empty_indices_*` to assert the corrected behavior (empty in → empty out) instead of documenting the crash.

This bug was discovered while writing the `tasks/base` test suite (#566).

## Stacking

> ⚠️ **Stacked on #566** (base branch = `test/utils-and-base-structure`).
> The test that exercises this path only exists in #566, and the source fix + test update must land together to keep both branches green. Merge #566 first; GitHub will then retarget this PR to `main`. (Alternatively, squash-merge this into #566.)

## Test plan

- [x] `pytest tests/unit/tasks/base/generate_dataset/test_parallel_runner.py` → 4 passed
- [x] ruff + mypy clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
