### PR TITLE
feat(data): DINOv3 SSL向けYouTube画像収集パイプラインを追加

### DIFF
--- a/src/tasks/ball_detection/configs/prepare_dinov3_ssl_images.yaml
+++ b/src/tasks/ball_detection/configs/prepare_dinov3_ssl_images.yaml
@@ -72,7 +72,7 @@ workflow:
     overwrite: false
 
   gate:
-    backend: openai_compatible
+    backend: vllm
     mock:
       accept_all: false
     contact_sheet:
@@ -95,8 +95,23 @@ workflow:
       prompt: "Classify this contact sheet. Return exactly one label: tennis, non_tennis, or unknown."
     openai_compatible:
       base_url: http://127.0.0.1:8000/v1
-      model: GabrieleConte/Qwen3.5-0.8B-LiteRT
+      model: Qwen/Qwen3.5-0.8B
       timeout_sec: 60
+      max_tokens: 128
       accept_labels:
         - tennis
-      prompt: "Classify this contact sheet. Return exactly one label: tennis, non_tennis, or unknown."
+      extra_body: {}
+      prompt: "Classify this contact sheet. Return JSON only: {\"label\":\"tennis|non_tennis|unknown\",\"confidence\":0.0,\"reason\":\"short visual reason\"}."
+    vllm:
+      # Start vLLM separately, for example:
+      # VLLM_CPU_KVCACHE_SPACE=2 python -m vllm.entrypoints.openai.api_server --model Qwen/Qwen3.5-0.8B --host 127.0.0.1 --port 8000 --max-model-len 2048 --max-num-seqs 1 --max-num-batched-tokens 2048 --enforce-eager --skip-mm-profiling --reasoning-parser qwen3 --limit-mm-per-prompt '{"image":1}' --trust-remote-code
+      base_url: http://127.0.0.1:8000/v1
+      model: Qwen/Qwen3.5-0.8B
+      timeout_sec: 120
+      max_tokens: 512
+      accept_labels:
+        - tennis
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: true
+      prompt: "Classify the image grid for a DINOv3 tennis SSL corpus. Reason briefly if enabled. Final answer must be JSON with label and confidence. label must be tennis or non_tennis or unknown. Use tennis only when a tennis court or players or rackets or net are visible."

--- a/src/tasks/ball_detection/configs/prepare_dinov3_ssl_images.yaml
+++ b/src/tasks/ball_detection/configs/prepare_dinov3_ssl_images.yaml
@@ -80,35 +80,13 @@ workflow:
       columns: 4
       thumb_width: 224
       thumb_height: 126
-    command_backend:
-      # Example for a local wrapper around Qwen3.5-0.8B LiteRT/ONNX INT8.
-      command:
-        - python
-        - -m
-        - tools.qwen35_vlm_gate
-        - --image
-        - "{image_path}"
-        - --prompt
-        - "{prompt}"
-      accept_labels:
-        - tennis
-      prompt: "Classify this contact sheet. Return exactly one label: tennis, non_tennis, or unknown."
-    openai_compatible:
-      base_url: http://127.0.0.1:8000/v1
-      model: Qwen/Qwen3.5-0.8B
-      timeout_sec: 60
-      max_tokens: 128
-      accept_labels:
-        - tennis
-      extra_body: {}
-      prompt: "Classify this contact sheet. Return JSON only: {\"label\":\"tennis|non_tennis|unknown\",\"confidence\":0.0,\"reason\":\"short visual reason\"}."
     vllm:
       # Start vLLM separately, for example:
-      # VLLM_CPU_KVCACHE_SPACE=2 python -m vllm.entrypoints.openai.api_server --model Qwen/Qwen3.5-0.8B --host 127.0.0.1 --port 8000 --max-model-len 2048 --max-num-seqs 1 --max-num-batched-tokens 2048 --enforce-eager --skip-mm-profiling --reasoning-parser qwen3 --limit-mm-per-prompt '{"image":1}' --trust-remote-code
+      # VLLM_CPU_KVCACHE_SPACE=4 python -m vllm.entrypoints.openai.api_server --model Qwen/Qwen3.5-0.8B --host 127.0.0.1 --port 8000 --max-model-len 4096 --max-num-seqs 1 --max-num-batched-tokens 4096 --enforce-eager --skip-mm-profiling --reasoning-parser qwen3 --limit-mm-per-prompt '{"image":1}' --trust-remote-code
       base_url: http://127.0.0.1:8000/v1
       model: Qwen/Qwen3.5-0.8B
       timeout_sec: 120
-      max_tokens: 512
+      max_tokens: 4096
       accept_labels:
         - tennis
       extra_body:

--- a/src/tasks/ball_detection/configs/prepare_dinov3_ssl_images.yaml
+++ b/src/tasks/ball_detection/configs/prepare_dinov3_ssl_images.yaml
@@ -1,0 +1,102 @@
+hydra:
+  run:
+    dir: outputs/ball_detection/prepare_dinov3_ssl_images/${now:%Y-%m-%d_%H-%M-%S}
+  output_subdir: null
+  job:
+    chdir: false
+
+workflow:
+  root: data/tennis/dino_ssl
+
+  sources: []
+
+  discovery:
+    enabled: true
+    queries:
+      - tennis rally highlights short
+      - tennis practice rally short
+      - tennis match point short
+      - tennis court rally 5 minutes
+    max_results_per_query: 25
+    min_duration_sec: 20
+    max_duration_sec: 600
+    allow_unknown_duration: false
+
+  paths:
+    videos_dir: videos
+    source_dir: source
+    h264_dir: h264
+    sampled_dir: sampled
+    images_dir: images
+    manifests_dir: manifests
+
+  processing:
+    max_new_videos: 20
+    reprocess_existing: false
+
+  download:
+    enabled: true
+    format: "bestvideo[vcodec^=avc1][height<=360]+bestaudio/bestvideo[height<=360]+bestaudio/best[height<=360]"
+    merge_output_format: mkv
+    js_runtimes: node
+    remote_components: null
+    download_archive: data/tennis/dino_ssl/manifests/download_archive.txt
+    overwrite: false
+    extra_args:
+      - --match-filter
+      - "duration >= 20 & duration <= 600"
+
+  transcode:
+    enabled: false
+    fallback_on_decode_error: true
+    ffmpeg_binary: ffmpeg
+    encoder: libx264
+    hwaccel: null
+    hwaccel_output_format: null
+    preset: veryfast
+    tune: null
+    rate_control: null
+    cq: null
+    bitrate: null
+    maxrate: null
+    bufsize: null
+    profile: high
+    pix_fmt: yuv420p
+    crf: 24
+    overwrite: false
+
+  frames:
+    frames_per_video: 50
+    output_ext: jpg
+    jpeg_quality: 92
+    overwrite: false
+
+  gate:
+    backend: openai_compatible
+    mock:
+      accept_all: false
+    contact_sheet:
+      max_images: 12
+      columns: 4
+      thumb_width: 224
+      thumb_height: 126
+    command_backend:
+      # Example for a local wrapper around Qwen3.5-0.8B LiteRT/ONNX INT8.
+      command:
+        - python
+        - -m
+        - tools.qwen35_vlm_gate
+        - --image
+        - "{image_path}"
+        - --prompt
+        - "{prompt}"
+      accept_labels:
+        - tennis
+      prompt: "Classify this contact sheet. Return exactly one label: tennis, non_tennis, or unknown."
+    openai_compatible:
+      base_url: http://127.0.0.1:8000/v1
+      model: GabrieleConte/Qwen3.5-0.8B-LiteRT
+      timeout_sec: 60
+      accept_labels:
+        - tennis
+      prompt: "Classify this contact sheet. Return exactly one label: tennis, non_tennis, or unknown."

--- a/src/tasks/ball_detection/scripts/youtube/prepare_dinov3_ssl_images.py
+++ b/src/tasks/ball_detection/scripts/youtube/prepare_dinov3_ssl_images.py
@@ -7,7 +7,7 @@ Usage:
 
 Notes:
     - Hydra loads configuration from `src/tasks/ball_detection/configs/prepare_dinov3_ssl_images.yaml`.
-    - The intended production gate is Qwen3.5-0.8B INT8 via a local VLM command or OpenAI-compatible endpoint.
+    - The intended production gate is Qwen/Qwen3.5-0.8B served by local vLLM.
     - `mock` gate is kept for pipeline dry-runs and tests when the local VLM runtime is unavailable.
 """
 
@@ -109,53 +109,10 @@ class MockTennisGate:
         )
 
 
-class CommandVlmGate:
-    """Run a local command that receives a contact-sheet path and emits a label."""
+class VllmGate:
+    """Call a local vLLM OpenAI-compatible VLM endpoint."""
 
     def __init__(self, cfg: DictConfig) -> None:
-        self.command = [str(value) for value in cfg.command]
-        self.prompt = str(cfg.prompt)
-        self.accept_labels = {str(value).lower() for value in cfg.accept_labels}
-
-    def classify(
-        self,
-        *,
-        source: Mapping[str, Any],
-        sampled_frames: Sequence[Mapping[str, Any]],
-        contact_sheet: Path,
-    ) -> GateDecision:
-        replacements = {
-            "{image_path}": str(contact_sheet),
-            "{prompt}": self.prompt,
-            "{title}": str(source.get("title") or ""),
-            "{url}": str(source.get("url") or source.get("source_url") or ""),
-        }
-        cmd = [_replace_tokens(part, replacements) for part in self.command]
-        import subprocess
-
-        completed = subprocess.run(
-            cmd,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        raw = (completed.stdout or completed.stderr).strip()
-        label = _parse_gate_label(raw)
-        accepted = label in self.accept_labels
-        return GateDecision(
-            accepted=accepted,
-            label=label,
-            confidence=None,
-            reason=f"command gate returned label={label!r}",
-            backend="command",
-            raw_response=raw,
-        )
-
-
-class OpenAICompatibleVlmGate:
-    """Call a local OpenAI-compatible VLM endpoint, such as vLLM."""
-
-    def __init__(self, cfg: DictConfig, *, backend_name: str) -> None:
         self.base_url = str(cfg.base_url).rstrip("/")
         self.model = str(cfg.model)
         self.prompt = str(cfg.prompt)
@@ -166,7 +123,6 @@ class OpenAICompatibleVlmGate:
             JSONDict,
             OmegaConf.to_container(cfg.get("extra_body", {}), resolve=True),
         )
-        self.backend_name = backend_name
 
     def classify(
         self,
@@ -214,7 +170,7 @@ class OpenAICompatibleVlmGate:
             label=label,
             confidence=cast(float | None, parsed["confidence"]),
             reason=str(parsed["reason"]),
-            backend=self.backend_name,
+            backend="vllm",
             raw_response=raw,
             reasoning=None if reasoning is None else str(reasoning),
             raw_payload=cast(JSONDict, payload),
@@ -669,14 +625,8 @@ def _build_gate(cfg: DictConfig) -> FrameGate:
     backend = str(cfg.backend)
     if backend == "mock":
         return MockTennisGate(accept_all=bool(cfg.mock.accept_all))
-    if backend == "command":
-        return CommandVlmGate(cfg.command_backend)
-    if backend == "openai_compatible":
-        return OpenAICompatibleVlmGate(
-            cfg.openai_compatible, backend_name="openai_compatible"
-        )
     if backend == "vllm":
-        return OpenAICompatibleVlmGate(cfg.vllm, backend_name="vllm")
+        return VllmGate(cfg.vllm)
     raise ValueError(f"Unsupported gate.backend={backend!r}.")
 
 
@@ -706,13 +656,6 @@ def _gate_record(
 
 def _read_info_json(path: Path) -> JSONDict:
     return cast(JSONDict, load_json_if_exists(path, {}))
-
-
-def _replace_tokens(text: str, replacements: Mapping[str, str]) -> str:
-    output = text
-    for key, value in replacements.items():
-        output = output.replace(key, value)
-    return output
 
 
 def _parse_gate_label(text: str) -> str:

--- a/src/tasks/ball_detection/scripts/youtube/prepare_dinov3_ssl_images.py
+++ b/src/tasks/ball_detection/scripts/youtube/prepare_dinov3_ssl_images.py
@@ -1,0 +1,729 @@
+"""Build a tennis-scene image corpus for DINOv3 SSL from YouTube videos.
+
+Usage:
+    python -m src.tasks.ball_detection.scripts.youtube.prepare_dinov3_ssl_images
+    python -m src.tasks.ball_detection.scripts.youtube.prepare_dinov3_ssl_images workflow.discovery.max_results_per_query=2
+    python -m src.tasks.ball_detection.scripts.youtube.prepare_dinov3_ssl_images workflow.gate.backend=mock workflow.processing.max_new_videos=1
+
+Notes:
+    - Hydra loads configuration from `src/tasks/ball_detection/configs/prepare_dinov3_ssl_images.yaml`.
+    - The intended production gate is Qwen3.5-0.8B INT8 via a local VLM command or OpenAI-compatible endpoint.
+    - `mock` gate is kept for pipeline dry-runs and tests when the local VLM runtime is unavailable.
+"""
+
+from __future__ import annotations
+
+import base64
+import shutil
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, TypeVar, cast
+
+import cv2
+import hydra
+import requests
+from hydra.utils import to_absolute_path
+from omegaconf import DictConfig, OmegaConf
+
+from src.utils.io import (
+    JSONDict,
+    ensure_dirs,
+    load_json_if_exists,
+    read_jsonl,
+    relative_path,
+    save_json_atomic,
+    utc_now_iso,
+    write_jsonl,
+)
+from src.utils.video import (
+    probe_video_info,
+    read_video_frame,
+    sample_uniform_frame_indices,
+)
+from src.utils.video.youtube import download_youtube_video, transcode_h264_video
+
+F = TypeVar("F", bound=Callable[..., Any])
+TENNIS_TERMS = ("tennis", "atp", "wta", "grand slam", "rally", "court")
+
+
+def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
+    """Typed wrapper for ``hydra.main``."""
+    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Video-level gate decision for sampled frames."""
+
+    accepted: bool
+    label: str
+    confidence: float | None
+    reason: str
+    backend: str
+    raw_response: str | None = None
+
+
+class FrameGate(Protocol):
+    """Protocol for a video/frame-domain classifier."""
+
+    def classify(
+        self,
+        *,
+        source: Mapping[str, Any],
+        sampled_frames: Sequence[Mapping[str, Any]],
+        contact_sheet: Path,
+    ) -> GateDecision:
+        """Classify whether a sampled video belongs to the tennis domain."""
+
+
+class MockTennisGate:
+    """Deterministic gate for tests and dry-runs without a local VLM."""
+
+    def __init__(self, *, accept_all: bool = False) -> None:
+        self.accept_all = accept_all
+
+    def classify(
+        self,
+        *,
+        source: Mapping[str, Any],
+        sampled_frames: Sequence[Mapping[str, Any]],
+        contact_sheet: Path,
+    ) -> GateDecision:
+        text = " ".join(
+            str(source.get(key, ""))
+            for key in ("title", "query", "url", "source_url", "video_id")
+        ).lower()
+        accepted = self.accept_all or any(term in text for term in TENNIS_TERMS)
+        return GateDecision(
+            accepted=accepted,
+            label="tennis" if accepted else "non_tennis",
+            confidence=1.0 if accepted else 0.0,
+            reason="mock gate matched tennis metadata"
+            if accepted
+            else "mock gate rejected metadata",
+            backend="mock",
+        )
+
+
+class CommandVlmGate:
+    """Run a local command that receives a contact-sheet path and emits a label."""
+
+    def __init__(self, cfg: DictConfig) -> None:
+        self.command = [str(value) for value in cfg.command]
+        self.prompt = str(cfg.prompt)
+        self.accept_labels = {str(value).lower() for value in cfg.accept_labels}
+
+    def classify(
+        self,
+        *,
+        source: Mapping[str, Any],
+        sampled_frames: Sequence[Mapping[str, Any]],
+        contact_sheet: Path,
+    ) -> GateDecision:
+        replacements = {
+            "{image_path}": str(contact_sheet),
+            "{prompt}": self.prompt,
+            "{title}": str(source.get("title") or ""),
+            "{url}": str(source.get("url") or source.get("source_url") or ""),
+        }
+        cmd = [_replace_tokens(part, replacements) for part in self.command]
+        import subprocess
+
+        completed = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        raw = (completed.stdout or completed.stderr).strip()
+        label = _parse_gate_label(raw)
+        accepted = label in self.accept_labels
+        return GateDecision(
+            accepted=accepted,
+            label=label,
+            confidence=None,
+            reason=f"command gate returned label={label!r}",
+            backend="command",
+            raw_response=raw,
+        )
+
+
+class OpenAICompatibleVlmGate:
+    """Call a local OpenAI-compatible VLM endpoint, such as vLLM."""
+
+    def __init__(self, cfg: DictConfig) -> None:
+        self.base_url = str(cfg.base_url).rstrip("/")
+        self.model = str(cfg.model)
+        self.prompt = str(cfg.prompt)
+        self.timeout_sec = float(cfg.timeout_sec)
+        self.accept_labels = {str(value).lower() for value in cfg.accept_labels}
+
+    def classify(
+        self,
+        *,
+        source: Mapping[str, Any],
+        sampled_frames: Sequence[Mapping[str, Any]],
+        contact_sheet: Path,
+    ) -> GateDecision:
+        image_data = base64.b64encode(contact_sheet.read_bytes()).decode("ascii")
+        response = requests.post(
+            f"{self.base_url}/chat/completions",
+            json={
+                "model": self.model,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": self.prompt},
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": f"data:image/jpeg;base64,{image_data}",
+                                },
+                            },
+                        ],
+                    }
+                ],
+                "temperature": 0,
+                "max_tokens": 32,
+            },
+            timeout=self.timeout_sec,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        raw = str(payload["choices"][0]["message"]["content"]).strip()
+        label = _parse_gate_label(raw)
+        accepted = label in self.accept_labels
+        return GateDecision(
+            accepted=accepted,
+            label=label,
+            confidence=None,
+            reason=f"openai-compatible gate returned label={label!r}",
+            backend="openai_compatible",
+            raw_response=raw,
+        )
+
+
+@hydra_main(
+    config_path="../../configs",
+    config_name="prepare_dinov3_ssl_images",
+    version_base="1.3",
+)
+def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
+    """Hydra entry point."""
+    run_pipeline(cfg)
+    return 0
+
+
+def run_pipeline(cfg: DictConfig) -> dict[str, int]:
+    """Run the YouTube-to-DINOv3-SSL image pipeline."""
+    workflow = cfg.workflow
+    root = Path(to_absolute_path(str(workflow.root))).resolve()
+    paths = workflow.paths
+    videos_dir = root / str(paths.videos_dir)
+    source_dir = videos_dir / str(paths.source_dir)
+    h264_dir = videos_dir / str(paths.h264_dir)
+    sampled_dir = root / str(paths.sampled_dir)
+    images_dir = root / str(paths.images_dir)
+    manifests_dir = root / str(paths.manifests_dir)
+    ensure_dirs([source_dir, h264_dir, sampled_dir, images_dir, manifests_dir])
+
+    sources = _collect_sources(workflow)
+    existing_video_ids = _existing_video_ids(manifests_dir)
+    gate = _build_gate(workflow.gate)
+
+    source_records: list[JSONDict] = []
+    sample_records: list[JSONDict] = []
+    image_records: list[JSONDict] = []
+    gate_records: list[JSONDict] = []
+    processed_new = 0
+    accepted_videos = 0
+
+    for source in sources:
+        video_id = str(source["video_id"])
+        if video_id in existing_video_ids and not bool(
+            workflow.processing.reprocess_existing
+        ):
+            print(f"[prepare_dinov3_ssl_images] skip existing video_id={video_id}")
+            continue
+        if processed_new >= int(workflow.processing.max_new_videos):
+            break
+
+        print(f"[prepare_dinov3_ssl_images] source={video_id}")
+        processed_new += 1
+        source_records.append(dict(source))
+        source_video = _resolve_source_video(source, source_dir, workflow.download)
+        sample_video = _transcode_source_video(
+            source_video, video_id, h264_dir, workflow.transcode
+        )
+        info = _read_info_json(source_dir / f"{video_id}.info.json")
+        source_with_info = {**source, "title": info.get("title") or source.get("title")}
+
+        try:
+            sampled_frames = _sample_video_frames(
+                source=source_with_info,
+                video_path=sample_video,
+                output_dir=sampled_dir / video_id,
+                root=root,
+                cfg=workflow.frames,
+            )
+        except RuntimeError:
+            if bool(workflow.transcode.enabled) or not bool(
+                workflow.transcode.fallback_on_decode_error
+            ):
+                raise
+            print("  source decode failed; falling back to H.264 transcode")
+            sample_video = _force_transcode_source_video(
+                source_video, video_id, h264_dir, workflow.transcode
+            )
+            sampled_frames = _sample_video_frames(
+                source=source_with_info,
+                video_path=sample_video,
+                output_dir=sampled_dir / video_id,
+                root=root,
+                cfg=workflow.frames,
+            )
+        sample_records.extend(sampled_frames)
+        contact_sheet = _write_contact_sheet(
+            sampled_frames=sampled_frames,
+            output_path=sampled_dir / video_id / "contact_sheet.jpg",
+            root=root,
+            cfg=workflow.gate.contact_sheet,
+        )
+        decision = gate.classify(
+            source=source_with_info,
+            sampled_frames=sampled_frames,
+            contact_sheet=contact_sheet,
+        )
+        gate_record = _gate_record(
+            video_id, source_with_info, decision, root, contact_sheet
+        )
+        gate_records.append(gate_record)
+        print(
+            f"  gate: {decision.label} accepted={decision.accepted} reason={decision.reason}"
+        )
+        if not decision.accepted:
+            continue
+
+        accepted_videos += 1
+        image_records.extend(
+            _promote_sampled_frames(
+                sampled_frames=sampled_frames,
+                images_dir=images_dir,
+                root=root,
+                decision=decision,
+                overwrite=bool(workflow.frames.overwrite),
+            )
+        )
+
+    write_jsonl(manifests_dir / "sources.jsonl", source_records)
+    write_jsonl(manifests_dir / "sampled_frames.jsonl", sample_records)
+    write_jsonl(manifests_dir / "gate_decisions.jsonl", gate_records)
+    write_jsonl(manifests_dir / "images.jsonl", image_records)
+    summary = {
+        "schema_name": "dinov3_ssl_youtube_images_summary_v1",
+        "source_count": len(source_records),
+        "sampled_frame_count": len(sample_records),
+        "accepted_video_count": accepted_videos,
+        "image_count": len(image_records),
+        "images_dir": relative_path(images_dir, root),
+        "written_at": utc_now_iso(),
+    }
+    save_json_atomic(summary, manifests_dir / "summary.json")
+    return {
+        "source_count": len(source_records),
+        "sampled_frame_count": len(sample_records),
+        "accepted_video_count": accepted_videos,
+        "image_count": len(image_records),
+    }
+
+
+def _collect_sources(workflow: DictConfig) -> list[JSONDict]:
+    manual_sources = _manual_sources(workflow.get("sources", []))
+    discovered_sources = _discover_sources(workflow.discovery)
+    deduped: dict[str, JSONDict] = {}
+    for source in [*manual_sources, *discovered_sources]:
+        video_id = str(source["video_id"])
+        if video_id not in deduped:
+            deduped[video_id] = source
+    return list(deduped.values())
+
+
+def _manual_sources(raw_sources: Iterable[Any]) -> list[JSONDict]:
+    sources: list[JSONDict] = []
+    for raw_source in raw_sources:
+        source = cast(JSONDict, OmegaConf.to_container(raw_source, resolve=True))
+        url = str(source.get("url") or "")
+        video_id = str(source.get("video_id") or source.get("source_id") or "")
+        if not video_id:
+            video_id = _video_id_from_url(url)
+        if not video_id:
+            raise ValueError(
+                f"Manual source must define video_id/source_id or url: {source}"
+            )
+        sources.append({**source, "video_id": video_id, "url": url})
+    return sources
+
+
+def _discover_sources(cfg: DictConfig) -> list[JSONDict]:
+    if not bool(cfg.enabled):
+        return []
+    import yt_dlp  # type: ignore[import-untyped]
+
+    sources: list[JSONDict] = []
+    ydl_opts = {
+        "extract_flat": True,
+        "quiet": True,
+        "ignoreerrors": True,
+        "skip_download": True,
+    }
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        for query in cfg.queries:
+            result = ydl.extract_info(
+                f"ytsearch{int(cfg.max_results_per_query)}:{query}",
+                download=False,
+            )
+            entries = [] if result is None else result.get("entries", [])
+            for entry in entries:
+                if not entry:
+                    continue
+                video_id = str(entry.get("id") or "")
+                if not video_id:
+                    continue
+                duration_sec = _duration_seconds(entry.get("duration"))
+                if not _duration_allowed(duration_sec, cfg):
+                    print(
+                        "  skip discovery result by duration: "
+                        f"video_id={video_id} duration_sec={duration_sec}"
+                    )
+                    continue
+                url = str(
+                    entry.get("url") or f"https://www.youtube.com/watch?v={video_id}"
+                )
+                if not url.startswith("http"):
+                    url = f"https://www.youtube.com/watch?v={video_id}"
+                sources.append(
+                    {
+                        "video_id": video_id,
+                        "url": url,
+                        "title": entry.get("title"),
+                        "duration_sec": duration_sec,
+                        "query": str(query),
+                        "source": "ytsearch",
+                    }
+                )
+    return sources
+
+
+def _existing_video_ids(manifests_dir: Path) -> set[str]:
+    video_ids: set[str] = set()
+    for manifest_name in (
+        "images.jsonl",
+        "gate_decisions.jsonl",
+        "sampled_frames.jsonl",
+    ):
+        for record in read_jsonl(manifests_dir / manifest_name):
+            if record.get("video_id") is not None:
+                video_ids.add(str(record["video_id"]))
+    return video_ids
+
+
+def _resolve_source_video(
+    source: Mapping[str, Any], source_dir: Path, cfg: DictConfig
+) -> Path:
+    local_video = source.get("local_video")
+    if local_video:
+        return Path(to_absolute_path(str(local_video))).resolve()
+    archive = None
+    if cfg.get("download_archive") is not None:
+        archive = Path(to_absolute_path(str(cfg.download_archive))).resolve()
+    return download_youtube_video(
+        url=str(source["url"]),
+        video_id=str(source["video_id"]),
+        output_dir=source_dir,
+        format_selector=str(cfg.format),
+        merge_output_format=str(cfg.merge_output_format),
+        enabled=bool(cfg.enabled),
+        overwrite=bool(cfg.overwrite),
+        js_runtimes=None if cfg.get("js_runtimes") is None else str(cfg.js_runtimes),
+        remote_components=(
+            None if cfg.get("remote_components") is None else str(cfg.remote_components)
+        ),
+        download_archive=archive,
+        extra_args=[str(value) for value in cfg.get("extra_args", [])],
+    )
+
+
+def _transcode_source_video(
+    source_video: Path,
+    video_id: str,
+    h264_dir: Path,
+    cfg: DictConfig,
+) -> Path:
+    if not bool(cfg.enabled):
+        print(f"  transcode disabled; sampling source video directly: {source_video}")
+        return source_video
+    return transcode_h264_video(
+        source_video=source_video,
+        output_path=h264_dir / f"{video_id}.mp4",
+        enabled=bool(cfg.enabled),
+        overwrite=bool(cfg.overwrite),
+        ffmpeg_binary=str(cfg.ffmpeg_binary),
+        encoder=str(cfg.encoder),
+        hwaccel=None if cfg.get("hwaccel") is None else str(cfg.hwaccel),
+        hwaccel_output_format=(
+            None
+            if cfg.get("hwaccel_output_format") is None
+            else str(cfg.hwaccel_output_format)
+        ),
+        preset=str(cfg.preset),
+        tune=None if cfg.get("tune") is None else str(cfg.tune),
+        rate_control=None if cfg.get("rate_control") is None else str(cfg.rate_control),
+        cq=None if cfg.get("cq") is None else cfg.cq,
+        bitrate=None if cfg.get("bitrate") is None else str(cfg.bitrate),
+        maxrate=None if cfg.get("maxrate") is None else str(cfg.maxrate),
+        bufsize=None if cfg.get("bufsize") is None else str(cfg.bufsize),
+        profile=None if cfg.get("profile") is None else str(cfg.profile),
+        pix_fmt=str(cfg.pix_fmt),
+        crf=cfg.crf,
+    )
+
+
+def _force_transcode_source_video(
+    source_video: Path,
+    video_id: str,
+    h264_dir: Path,
+    cfg: DictConfig,
+) -> Path:
+    return transcode_h264_video(
+        source_video=source_video,
+        output_path=h264_dir / f"{video_id}.mp4",
+        enabled=True,
+        overwrite=bool(cfg.overwrite),
+        ffmpeg_binary=str(cfg.ffmpeg_binary),
+        encoder=str(cfg.encoder),
+        hwaccel=None if cfg.get("hwaccel") is None else str(cfg.hwaccel),
+        hwaccel_output_format=(
+            None
+            if cfg.get("hwaccel_output_format") is None
+            else str(cfg.hwaccel_output_format)
+        ),
+        preset=str(cfg.preset),
+        tune=None if cfg.get("tune") is None else str(cfg.tune),
+        rate_control=None if cfg.get("rate_control") is None else str(cfg.rate_control),
+        cq=None if cfg.get("cq") is None else cfg.cq,
+        bitrate=None if cfg.get("bitrate") is None else str(cfg.bitrate),
+        maxrate=None if cfg.get("maxrate") is None else str(cfg.maxrate),
+        bufsize=None if cfg.get("bufsize") is None else str(cfg.bufsize),
+        profile=None if cfg.get("profile") is None else str(cfg.profile),
+        pix_fmt=str(cfg.pix_fmt),
+        crf=cfg.crf,
+    )
+
+
+def _sample_video_frames(
+    *,
+    source: Mapping[str, Any],
+    video_path: Path,
+    output_dir: Path,
+    root: Path,
+    cfg: DictConfig,
+) -> list[JSONDict]:
+    manifest_path = output_dir / "frames.jsonl"
+    if manifest_path.exists() and not bool(cfg.overwrite):
+        existing_records = read_jsonl(manifest_path)
+        if existing_records:
+            print(f"  sampled frames exist: {len(existing_records)} -> {output_dir}")
+            return existing_records
+
+    ensure_dirs([output_dir])
+    info = probe_video_info(video_path)
+    if info.frame_count <= 0:
+        raise RuntimeError(f"OpenCV reported no frames for {video_path}")
+    frame_indices = sample_uniform_frame_indices(
+        info.frame_count, int(cfg.frames_per_video)
+    )
+    records: list[JSONDict] = []
+    for frame_index in frame_indices:
+        packet = read_video_frame(video_path, frame_index)
+        image_id = f"{source['video_id']}_f{frame_index:08d}"
+        output_path = output_dir / f"{image_id}.{cfg.output_ext}"
+        if not output_path.exists() or bool(cfg.overwrite):
+            params = [cv2.IMWRITE_JPEG_QUALITY, int(cfg.jpeg_quality)]
+            if not cv2.imwrite(str(output_path), packet.frame, params):
+                raise RuntimeError(f"Failed to write sampled frame: {output_path}")
+        records.append(
+            {
+                "image_id": image_id,
+                "image_path": relative_path(output_path, root),
+                "video_id": source["video_id"],
+                "source_url": source.get("url") or source.get("source_url"),
+                "source_title": source.get("title"),
+                "source_frame_index": frame_index,
+                "timestamp_sec": frame_index / info.fps if info.fps > 0 else None,
+                "fps": info.fps,
+                "width": info.width,
+                "height": info.height,
+                "sampled_at": utc_now_iso(),
+            }
+        )
+    write_jsonl(manifest_path, records)
+    print(f"  sampled frames: {len(records)} -> {output_dir}")
+    return records
+
+
+def _write_contact_sheet(
+    *,
+    sampled_frames: Sequence[Mapping[str, Any]],
+    output_path: Path,
+    root: Path,
+    cfg: DictConfig,
+) -> Path:
+    selected = list(sampled_frames)[
+        :: max(1, len(sampled_frames) // int(cfg.max_images))
+    ]
+    selected = selected[: int(cfg.max_images)]
+    thumbs = []
+    for record in selected:
+        image = cv2.imread(str(root / str(record["image_path"])))
+        if image is None:
+            continue
+        thumbs.append(cv2.resize(image, (int(cfg.thumb_width), int(cfg.thumb_height))))
+    if not thumbs:
+        raise RuntimeError("No sampled frames available for contact sheet.")
+    cols = int(cfg.columns)
+    rows = []
+    for start in range(0, len(thumbs), cols):
+        row = thumbs[start : start + cols]
+        if len(row) < cols:
+            row.extend([row[-1].copy() for _ in range(cols - len(row))])
+        rows.append(cv2.hconcat(row))
+    sheet = cv2.vconcat(rows)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if not cv2.imwrite(str(output_path), sheet, [cv2.IMWRITE_JPEG_QUALITY, 90]):
+        raise RuntimeError(f"Failed to write contact sheet: {output_path}")
+    return output_path
+
+
+def _promote_sampled_frames(
+    *,
+    sampled_frames: Sequence[Mapping[str, Any]],
+    images_dir: Path,
+    root: Path,
+    decision: GateDecision,
+    overwrite: bool,
+) -> list[JSONDict]:
+    records: list[JSONDict] = []
+    for frame in sampled_frames:
+        source_path = root / str(frame["image_path"])
+        destination = images_dir / source_path.name
+        if overwrite or not destination.exists():
+            shutil.copy2(source_path, destination)
+        records.append(
+            {
+                **dict(frame),
+                "image_path": relative_path(destination, root),
+                "gate_label": decision.label,
+                "gate_backend": decision.backend,
+                "accepted_at": utc_now_iso(),
+            }
+        )
+    return records
+
+
+def _build_gate(cfg: DictConfig) -> FrameGate:
+    backend = str(cfg.backend)
+    if backend == "mock":
+        return MockTennisGate(accept_all=bool(cfg.mock.accept_all))
+    if backend == "command":
+        return CommandVlmGate(cfg.command_backend)
+    if backend == "openai_compatible":
+        return OpenAICompatibleVlmGate(cfg.openai_compatible)
+    raise ValueError(f"Unsupported gate.backend={backend!r}.")
+
+
+def _gate_record(
+    video_id: str,
+    source: Mapping[str, Any],
+    decision: GateDecision,
+    root: Path,
+    contact_sheet: Path,
+) -> JSONDict:
+    return {
+        "video_id": video_id,
+        "source_url": source.get("url") or source.get("source_url"),
+        "source_title": source.get("title"),
+        "accepted": decision.accepted,
+        "label": decision.label,
+        "confidence": decision.confidence,
+        "reason": decision.reason,
+        "backend": decision.backend,
+        "raw_response": decision.raw_response,
+        "contact_sheet": relative_path(contact_sheet, root),
+        "processed_at": utc_now_iso(),
+    }
+
+
+def _read_info_json(path: Path) -> JSONDict:
+    return cast(JSONDict, load_json_if_exists(path, {}))
+
+
+def _replace_tokens(text: str, replacements: Mapping[str, str]) -> str:
+    output = text
+    for key, value in replacements.items():
+        output = output.replace(key, value)
+    return output
+
+
+def _parse_gate_label(text: str) -> str:
+    normalized = text.strip().lower()
+    if "non_tennis" in normalized or "not tennis" in normalized:
+        return "non_tennis"
+    if "tennis" in normalized:
+        return "tennis"
+    if "unknown" in normalized or "uncertain" in normalized:
+        return "unknown"
+    return normalized.split()[0] if normalized.split() else "unknown"
+
+
+def _duration_seconds(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    text = str(value)
+    if not text:
+        return None
+    parts = text.split(":")
+    try:
+        if len(parts) == 1:
+            return float(parts[0])
+        seconds = 0.0
+        for part in parts:
+            seconds = seconds * 60.0 + float(part)
+        return seconds
+    except ValueError:
+        return None
+
+
+def _duration_allowed(duration_sec: float | None, cfg: DictConfig) -> bool:
+    if duration_sec is None:
+        return bool(cfg.allow_unknown_duration)
+    min_duration = cfg.get("min_duration_sec")
+    max_duration = cfg.get("max_duration_sec")
+    if min_duration is not None and duration_sec < float(min_duration):
+        return False
+    return not (max_duration is not None and duration_sec > float(max_duration))
+
+
+def _video_id_from_url(url: str) -> str:
+    if "watch?v=" in url:
+        return url.split("watch?v=", 1)[1].split("&", 1)[0]
+    if "youtu.be/" in url:
+        return url.split("youtu.be/", 1)[1].split("?", 1)[0]
+    return ""
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # type: ignore[call-arg]

--- a/src/tasks/ball_detection/scripts/youtube/prepare_dinov3_ssl_images.py
+++ b/src/tasks/ball_detection/scripts/youtube/prepare_dinov3_ssl_images.py
@@ -14,6 +14,7 @@ Notes:
 from __future__ import annotations
 
 import base64
+import json
 import shutil
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
@@ -62,6 +63,8 @@ class GateDecision:
     reason: str
     backend: str
     raw_response: str | None = None
+    reasoning: str | None = None
+    raw_payload: JSONDict | None = None
 
 
 class FrameGate(Protocol):
@@ -152,12 +155,18 @@ class CommandVlmGate:
 class OpenAICompatibleVlmGate:
     """Call a local OpenAI-compatible VLM endpoint, such as vLLM."""
 
-    def __init__(self, cfg: DictConfig) -> None:
+    def __init__(self, cfg: DictConfig, *, backend_name: str) -> None:
         self.base_url = str(cfg.base_url).rstrip("/")
         self.model = str(cfg.model)
         self.prompt = str(cfg.prompt)
         self.timeout_sec = float(cfg.timeout_sec)
+        self.max_tokens = int(cfg.get("max_tokens", 128))
         self.accept_labels = {str(value).lower() for value in cfg.accept_labels}
+        self.extra_body = cast(
+            JSONDict,
+            OmegaConf.to_container(cfg.get("extra_body", {}), resolve=True),
+        )
+        self.backend_name = backend_name
 
     def classify(
         self,
@@ -167,41 +176,48 @@ class OpenAICompatibleVlmGate:
         contact_sheet: Path,
     ) -> GateDecision:
         image_data = base64.b64encode(contact_sheet.read_bytes()).decode("ascii")
+        request_body: JSONDict = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": self.prompt},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/jpeg;base64,{image_data}",
+                            },
+                        },
+                    ],
+                }
+            ],
+            "temperature": 0,
+            "max_tokens": self.max_tokens,
+        }
+        request_body.update(self.extra_body)
         response = requests.post(
             f"{self.base_url}/chat/completions",
-            json={
-                "model": self.model,
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": [
-                            {"type": "text", "text": self.prompt},
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": f"data:image/jpeg;base64,{image_data}",
-                                },
-                            },
-                        ],
-                    }
-                ],
-                "temperature": 0,
-                "max_tokens": 32,
-            },
+            json=request_body,
             timeout=self.timeout_sec,
         )
         response.raise_for_status()
         payload = response.json()
-        raw = str(payload["choices"][0]["message"]["content"]).strip()
-        label = _parse_gate_label(raw)
+        message = payload["choices"][0]["message"]
+        raw = str(message.get("content") or "").strip()
+        reasoning = message.get("reasoning_content") or message.get("reasoning")
+        parsed = _parse_gate_output(raw)
+        label = parsed["label"]
         accepted = label in self.accept_labels
         return GateDecision(
             accepted=accepted,
             label=label,
-            confidence=None,
-            reason=f"openai-compatible gate returned label={label!r}",
-            backend="openai_compatible",
+            confidence=cast(float | None, parsed["confidence"]),
+            reason=str(parsed["reason"]),
+            backend=self.backend_name,
             raw_response=raw,
+            reasoning=None if reasoning is None else str(reasoning),
+            raw_payload=cast(JSONDict, payload),
         )
 
 
@@ -438,20 +454,27 @@ def _resolve_source_video(
     archive = None
     if cfg.get("download_archive") is not None:
         archive = Path(to_absolute_path(str(cfg.download_archive))).resolve()
-    return download_youtube_video(
-        url=str(source["url"]),
-        video_id=str(source["video_id"]),
-        output_dir=source_dir,
-        format_selector=str(cfg.format),
-        merge_output_format=str(cfg.merge_output_format),
-        enabled=bool(cfg.enabled),
-        overwrite=bool(cfg.overwrite),
-        js_runtimes=None if cfg.get("js_runtimes") is None else str(cfg.js_runtimes),
-        remote_components=(
-            None if cfg.get("remote_components") is None else str(cfg.remote_components)
+    return cast(
+        Path,
+        download_youtube_video(
+            url=str(source["url"]),
+            video_id=str(source["video_id"]),
+            output_dir=source_dir,
+            format_selector=str(cfg.format),
+            merge_output_format=str(cfg.merge_output_format),
+            enabled=bool(cfg.enabled),
+            overwrite=bool(cfg.overwrite),
+            js_runtimes=None
+            if cfg.get("js_runtimes") is None
+            else str(cfg.js_runtimes),
+            remote_components=(
+                None
+                if cfg.get("remote_components") is None
+                else str(cfg.remote_components)
+            ),
+            download_archive=archive,
+            extra_args=[str(value) for value in cfg.get("extra_args", [])],
         ),
-        download_archive=archive,
-        extra_args=[str(value) for value in cfg.get("extra_args", [])],
     )
 
 
@@ -464,29 +487,34 @@ def _transcode_source_video(
     if not bool(cfg.enabled):
         print(f"  transcode disabled; sampling source video directly: {source_video}")
         return source_video
-    return transcode_h264_video(
-        source_video=source_video,
-        output_path=h264_dir / f"{video_id}.mp4",
-        enabled=bool(cfg.enabled),
-        overwrite=bool(cfg.overwrite),
-        ffmpeg_binary=str(cfg.ffmpeg_binary),
-        encoder=str(cfg.encoder),
-        hwaccel=None if cfg.get("hwaccel") is None else str(cfg.hwaccel),
-        hwaccel_output_format=(
-            None
-            if cfg.get("hwaccel_output_format") is None
-            else str(cfg.hwaccel_output_format)
+    return cast(
+        Path,
+        transcode_h264_video(
+            source_video=source_video,
+            output_path=h264_dir / f"{video_id}.mp4",
+            enabled=bool(cfg.enabled),
+            overwrite=bool(cfg.overwrite),
+            ffmpeg_binary=str(cfg.ffmpeg_binary),
+            encoder=str(cfg.encoder),
+            hwaccel=None if cfg.get("hwaccel") is None else str(cfg.hwaccel),
+            hwaccel_output_format=(
+                None
+                if cfg.get("hwaccel_output_format") is None
+                else str(cfg.hwaccel_output_format)
+            ),
+            preset=str(cfg.preset),
+            tune=None if cfg.get("tune") is None else str(cfg.tune),
+            rate_control=None
+            if cfg.get("rate_control") is None
+            else str(cfg.rate_control),
+            cq=None if cfg.get("cq") is None else cfg.cq,
+            bitrate=None if cfg.get("bitrate") is None else str(cfg.bitrate),
+            maxrate=None if cfg.get("maxrate") is None else str(cfg.maxrate),
+            bufsize=None if cfg.get("bufsize") is None else str(cfg.bufsize),
+            profile=None if cfg.get("profile") is None else str(cfg.profile),
+            pix_fmt=str(cfg.pix_fmt),
+            crf=cfg.crf,
         ),
-        preset=str(cfg.preset),
-        tune=None if cfg.get("tune") is None else str(cfg.tune),
-        rate_control=None if cfg.get("rate_control") is None else str(cfg.rate_control),
-        cq=None if cfg.get("cq") is None else cfg.cq,
-        bitrate=None if cfg.get("bitrate") is None else str(cfg.bitrate),
-        maxrate=None if cfg.get("maxrate") is None else str(cfg.maxrate),
-        bufsize=None if cfg.get("bufsize") is None else str(cfg.bufsize),
-        profile=None if cfg.get("profile") is None else str(cfg.profile),
-        pix_fmt=str(cfg.pix_fmt),
-        crf=cfg.crf,
     )
 
 
@@ -496,29 +524,34 @@ def _force_transcode_source_video(
     h264_dir: Path,
     cfg: DictConfig,
 ) -> Path:
-    return transcode_h264_video(
-        source_video=source_video,
-        output_path=h264_dir / f"{video_id}.mp4",
-        enabled=True,
-        overwrite=bool(cfg.overwrite),
-        ffmpeg_binary=str(cfg.ffmpeg_binary),
-        encoder=str(cfg.encoder),
-        hwaccel=None if cfg.get("hwaccel") is None else str(cfg.hwaccel),
-        hwaccel_output_format=(
-            None
-            if cfg.get("hwaccel_output_format") is None
-            else str(cfg.hwaccel_output_format)
+    return cast(
+        Path,
+        transcode_h264_video(
+            source_video=source_video,
+            output_path=h264_dir / f"{video_id}.mp4",
+            enabled=True,
+            overwrite=bool(cfg.overwrite),
+            ffmpeg_binary=str(cfg.ffmpeg_binary),
+            encoder=str(cfg.encoder),
+            hwaccel=None if cfg.get("hwaccel") is None else str(cfg.hwaccel),
+            hwaccel_output_format=(
+                None
+                if cfg.get("hwaccel_output_format") is None
+                else str(cfg.hwaccel_output_format)
+            ),
+            preset=str(cfg.preset),
+            tune=None if cfg.get("tune") is None else str(cfg.tune),
+            rate_control=None
+            if cfg.get("rate_control") is None
+            else str(cfg.rate_control),
+            cq=None if cfg.get("cq") is None else cfg.cq,
+            bitrate=None if cfg.get("bitrate") is None else str(cfg.bitrate),
+            maxrate=None if cfg.get("maxrate") is None else str(cfg.maxrate),
+            bufsize=None if cfg.get("bufsize") is None else str(cfg.bufsize),
+            profile=None if cfg.get("profile") is None else str(cfg.profile),
+            pix_fmt=str(cfg.pix_fmt),
+            crf=cfg.crf,
         ),
-        preset=str(cfg.preset),
-        tune=None if cfg.get("tune") is None else str(cfg.tune),
-        rate_control=None if cfg.get("rate_control") is None else str(cfg.rate_control),
-        cq=None if cfg.get("cq") is None else cfg.cq,
-        bitrate=None if cfg.get("bitrate") is None else str(cfg.bitrate),
-        maxrate=None if cfg.get("maxrate") is None else str(cfg.maxrate),
-        bufsize=None if cfg.get("bufsize") is None else str(cfg.bufsize),
-        profile=None if cfg.get("profile") is None else str(cfg.profile),
-        pix_fmt=str(cfg.pix_fmt),
-        crf=cfg.crf,
     )
 
 
@@ -535,7 +568,7 @@ def _sample_video_frames(
         existing_records = read_jsonl(manifest_path)
         if existing_records:
             print(f"  sampled frames exist: {len(existing_records)} -> {output_dir}")
-            return existing_records
+            return cast(list[JSONDict], existing_records)
 
     ensure_dirs([output_dir])
     info = probe_video_info(video_path)
@@ -639,7 +672,11 @@ def _build_gate(cfg: DictConfig) -> FrameGate:
     if backend == "command":
         return CommandVlmGate(cfg.command_backend)
     if backend == "openai_compatible":
-        return OpenAICompatibleVlmGate(cfg.openai_compatible)
+        return OpenAICompatibleVlmGate(
+            cfg.openai_compatible, backend_name="openai_compatible"
+        )
+    if backend == "vllm":
+        return OpenAICompatibleVlmGate(cfg.vllm, backend_name="vllm")
     raise ValueError(f"Unsupported gate.backend={backend!r}.")
 
 
@@ -660,6 +697,8 @@ def _gate_record(
         "reason": decision.reason,
         "backend": decision.backend,
         "raw_response": decision.raw_response,
+        "reasoning": decision.reasoning,
+        "raw_payload": decision.raw_payload,
         "contact_sheet": relative_path(contact_sheet, root),
         "processed_at": utc_now_iso(),
     }
@@ -685,6 +724,51 @@ def _parse_gate_label(text: str) -> str:
     if "unknown" in normalized or "uncertain" in normalized:
         return "unknown"
     return normalized.split()[0] if normalized.split() else "unknown"
+
+
+def _parse_gate_output(text: str) -> JSONDict:
+    payload = _parse_json_object(text)
+    if payload is not None:
+        label = _parse_gate_label(str(payload.get("label", "")))
+        confidence = payload.get("confidence")
+        reason = payload.get("reason")
+        return {
+            "label": label,
+            "confidence": float(confidence)
+            if isinstance(confidence, int | float)
+            else None,
+            "reason": str(reason)
+            if reason is not None
+            else f"vLLM gate returned label={label!r}",
+        }
+    label = _parse_gate_label(text)
+    return {
+        "label": label,
+        "confidence": None,
+        "reason": f"vLLM gate returned label={label!r}",
+    }
+
+
+def _parse_json_object(text: str) -> JSONDict | None:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    candidates = [stripped]
+    if "```" in stripped:
+        fenced = stripped.split("```")
+        candidates.extend(part.strip() for part in fenced if part.strip())
+    if "{" in stripped and "}" in stripped:
+        candidates.append(stripped[stripped.find("{") : stripped.rfind("}") + 1])
+    for candidate in candidates:
+        if candidate.startswith("json"):
+            candidate = candidate[4:].strip()
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return cast(JSONDict, parsed)
+    return None
 
 
 def _duration_seconds(value: Any) -> float | None:

--- a/src/tasks/ball_detection/scripts/youtube/prepare_youtube_dataset.py
+++ b/src/tasks/ball_detection/scripts/youtube/prepare_youtube_dataset.py
@@ -14,11 +14,7 @@ Notes:
 
 from __future__ import annotations
 
-import json
-import subprocess
-import sys
 from collections.abc import Callable, Iterable
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
@@ -26,6 +22,21 @@ import cv2
 import hydra
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
+
+from src.utils.io import (
+    ensure_dirs,
+    load_json_if_exists,
+    read_jsonl,
+    relative_path,
+    save_json_atomic,
+    utc_now_iso,
+    write_jsonl,
+)
+from src.utils.video.youtube import (
+    download_youtube_video,
+    h264_encoder_args,
+    transcode_h264_video,
+)
 
 F = TypeVar("F", bound=Callable[..., Any])
 JSONDict = dict[str, Any]
@@ -50,7 +61,7 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
     h264_dir = root / str(paths.videos_dir) / str(paths.h264_dir)
     frames_root = root / str(paths.frames_dir)
     manifests_dir = root / str(paths.manifests_dir)
-    _ensure_dirs([av1_dir, h264_dir, frames_root, manifests_dir])
+    ensure_dirs([av1_dir, h264_dir, frames_root, manifests_dir])
 
     source_records: list[JSONDict] = []
     download_records: list[JSONDict] = []
@@ -62,22 +73,28 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
         source = {**raw_source, "source_id": video_id}
         split = str(source.get("split") or "train")
         if split not in frame_counts:
-            raise ValueError(f"Unsupported source split={split!r}; expected train or val.")
+            raise ValueError(
+                f"Unsupported source split={split!r}; expected train or val."
+            )
         source_records.append(source)
         video_counts[split] += 1
 
         print(f"[prepare_ball_youtube_dataset] source={video_id} split={split}")
         source_video = _download_video(source, video_id, av1_dir, workflow.download)
-        h264_video = _transcode_h264(source_video, video_id, h264_dir, workflow.transcode)
+        h264_video = _transcode_h264(
+            source_video, video_id, h264_dir, workflow.transcode
+        )
         info = _read_info_json(av1_dir / f"{video_id}.info.json")
-        download_records.append({
-            "video_id": video_id,
-            "source_url": source["url"],
-            "source_title": info.get("title"),
-            "source_video": _relative_path(source_video, root),
-            "h264_video": _relative_path(h264_video, root),
-            "processed_at": _utc_now(),
-        })
+        download_records.append(
+            {
+                "video_id": video_id,
+                "source_url": source["url"],
+                "source_title": info.get("title"),
+                "source_video": relative_path(source_video, root),
+                "h264_video": relative_path(h264_video, root),
+                "processed_at": utc_now_iso(),
+            }
+        )
 
         raw_dir = frames_root / video_id / str(paths.raw_dir)
         records = _extract_continuous_frames(
@@ -91,16 +108,16 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
         )
         frame_counts[split] += len(records)
 
-    _write_jsonl(manifests_dir / "sources.jsonl", source_records)
-    _write_jsonl(manifests_dir / "download_manifest.jsonl", download_records)
-    _write_json_atomic(
-        manifests_dir / "split_manifest.json",
+    write_jsonl(manifests_dir / "sources.jsonl", source_records)
+    write_jsonl(manifests_dir / "download_manifest.jsonl", download_records)
+    save_json_atomic(
         {
             "schema_name": "ball_youtube_split_manifest_v1",
             "video_counts": video_counts,
             "raw_frame_counts": frame_counts,
-            "written_at": _utc_now(),
+            "written_at": utc_now_iso(),
         },
+        manifests_dir / "split_manifest.json",
     )
     return 0
 
@@ -115,104 +132,72 @@ def _source_dicts(raw_sources: Iterable[Any]) -> list[JSONDict]:
     return sources
 
 
-def _download_video(source: JSONDict, video_id: str, output_dir: Path, cfg: DictConfig) -> Path:
-    existing = _find_video(output_dir, video_id)
-    if existing is not None and (not bool(cfg.enabled) or not bool(cfg.overwrite)):
-        print(f"  source video exists: {existing}")
-        return existing
-    if not bool(cfg.enabled):
-        raise FileNotFoundError(f"Download disabled and no source video found for {video_id}.")
-
-    output_template = output_dir / f"{video_id}.%(ext)s"
-    cmd = [
-        sys.executable,
-        "-m",
-        "yt_dlp",
-        str(source["url"]),
-        "-f",
-        str(cfg.strict_format if bool(cfg.require_av1) else cfg.format),
-        "-o",
-        str(output_template),
-        "--merge-output-format",
-        str(cfg.merge_output_format),
-        "--write-info-json",
-        "--no-playlist",
-    ]
-    if cfg.get("js_runtimes") is not None:
-        cmd.extend(["--js-runtimes", str(cfg.js_runtimes)])
-    if cfg.get("remote_components") is not None:
-        cmd.extend(["--remote-components", str(cfg.remote_components)])
+def _download_video(
+    source: JSONDict, video_id: str, output_dir: Path, cfg: DictConfig
+) -> Path:
+    archive = None
     if cfg.get("download_archive") is not None:
         archive = Path(to_absolute_path(str(cfg.download_archive))).resolve()
-        archive.parent.mkdir(parents=True, exist_ok=True)
-        cmd.extend(["--download-archive", str(archive)])
-    cmd.append("--force-overwrites" if bool(cfg.overwrite) else "--no-overwrites")
-    cmd.extend(str(value) for value in cfg.get("extra_args", []))
-    _run(cmd)
+    return download_youtube_video(
+        url=str(source["url"]),
+        video_id=video_id,
+        output_dir=output_dir,
+        format_selector=str(cfg.strict_format if bool(cfg.require_av1) else cfg.format),
+        merge_output_format=str(cfg.merge_output_format),
+        enabled=bool(cfg.enabled),
+        overwrite=bool(cfg.overwrite),
+        js_runtimes=None if cfg.get("js_runtimes") is None else str(cfg.js_runtimes),
+        remote_components=(
+            None if cfg.get("remote_components") is None else str(cfg.remote_components)
+        ),
+        download_archive=archive,
+        extra_args=[str(value) for value in cfg.get("extra_args", [])],
+    )
 
-    downloaded = _find_video(output_dir, video_id)
-    if downloaded is None:
-        raise FileNotFoundError(f"yt-dlp finished but no video was found for {video_id}.")
-    return downloaded
 
-
-def _transcode_h264(source_video: Path, video_id: str, output_dir: Path, cfg: DictConfig) -> Path:
-    output_path = output_dir / f"{video_id}.mp4"
-    if output_path.exists() and not bool(cfg.overwrite):
-        print(f"  H.264 exists: {output_path}")
-        return output_path
-    if not bool(cfg.enabled):
-        raise FileNotFoundError(f"H.264 transcode disabled and output missing: {output_path}")
-
-    cmd = [str(cfg.ffmpeg_binary), "-y" if bool(cfg.overwrite) else "-n"]
-    if cfg.get("hwaccel") is not None:
-        cmd.extend(["-hwaccel", str(cfg.hwaccel)])
-    if cfg.get("hwaccel_output_format") is not None:
-        cmd.extend(["-hwaccel_output_format", str(cfg.hwaccel_output_format)])
-    cmd.extend(["-i", str(source_video), "-map", "0:v:0"])
-    cmd.extend(_h264_encoder_args(cfg))
-    cmd.extend(["-movflags", "+faststart", "-an", str(output_path)])
-    _run(cmd)
-    return output_path
+def _transcode_h264(
+    source_video: Path, video_id: str, output_dir: Path, cfg: DictConfig
+) -> Path:
+    return transcode_h264_video(
+        source_video=source_video,
+        output_path=output_dir / f"{video_id}.mp4",
+        enabled=bool(cfg.enabled),
+        overwrite=bool(cfg.overwrite),
+        ffmpeg_binary=str(cfg.ffmpeg_binary),
+        encoder=str(cfg.encoder),
+        hwaccel=None if cfg.get("hwaccel") is None else str(cfg.hwaccel),
+        hwaccel_output_format=(
+            None
+            if cfg.get("hwaccel_output_format") is None
+            else str(cfg.hwaccel_output_format)
+        ),
+        preset=str(cfg.preset),
+        tune=None if cfg.get("tune") is None else str(cfg.tune),
+        rate_control=None if cfg.get("rate_control") is None else str(cfg.rate_control),
+        cq=None if cfg.get("cq") is None else cfg.cq,
+        bitrate=None if cfg.get("bitrate") is None else str(cfg.bitrate),
+        maxrate=None if cfg.get("maxrate") is None else str(cfg.maxrate),
+        bufsize=None if cfg.get("bufsize") is None else str(cfg.bufsize),
+        profile=None if cfg.get("profile") is None else str(cfg.profile),
+        pix_fmt=str(cfg.pix_fmt),
+        crf=cfg.crf,
+    )
 
 
 def _h264_encoder_args(cfg: DictConfig) -> list[str]:
-    encoder = str(cfg.encoder)
-    if encoder == "libx264":
-        return [
-            "-c:v",
-            encoder,
-            "-preset",
-            str(cfg.preset),
-            "-crf",
-            str(cfg.crf),
-            "-pix_fmt",
-            str(cfg.pix_fmt),
-        ]
-    if encoder not in {"h264_nvenc", "avc_nvenc"}:
-        raise ValueError(f"Unsupported H.264 encoder: {encoder!r}")
-    args = [
-        "-c:v",
-        encoder,
-        "-preset",
-        str(cfg.preset),
-        "-tune",
-        str(cfg.tune),
-        "-rc",
-        str(cfg.rate_control),
-        "-cq",
-        str(cfg.cq),
-        "-pix_fmt",
-        str(cfg.pix_fmt),
-        "-b:v",
-        "0" if cfg.get("bitrate") is None else str(cfg.bitrate),
-    ]
-    for option in ("maxrate", "bufsize", "profile"):
-        value = cfg.get(option)
-        if value is not None:
-            flag = "-profile:v" if option == "profile" else f"-{option}"
-            args.extend([flag, str(value)])
-    return args
+    return h264_encoder_args(
+        encoder=str(cfg.encoder),
+        preset=str(cfg.preset),
+        tune=None if cfg.get("tune") is None else str(cfg.tune),
+        rate_control=None if cfg.get("rate_control") is None else str(cfg.rate_control),
+        cq=None if cfg.get("cq") is None else cfg.cq,
+        bitrate=None if cfg.get("bitrate") is None else str(cfg.bitrate),
+        maxrate=None if cfg.get("maxrate") is None else str(cfg.maxrate),
+        bufsize=None if cfg.get("bufsize") is None else str(cfg.bufsize),
+        profile=None if cfg.get("profile") is None else str(cfg.profile),
+        pix_fmt=str(cfg.pix_fmt),
+        crf=cfg.crf,
+    )
 
 
 def _extract_continuous_frames(
@@ -227,12 +212,12 @@ def _extract_continuous_frames(
 ) -> list[JSONDict]:
     manifest_path = raw_dir / "frames.jsonl"
     if not bool(cfg.enabled):
-        return _read_jsonl(manifest_path)
+        return read_jsonl(manifest_path)
     if manifest_path.exists() and not bool(cfg.overwrite):
-        records = _read_jsonl(manifest_path)
-        if records:
-            print(f"  raw frames exist: {len(records)} -> {raw_dir}")
-            return records
+        existing_records = read_jsonl(manifest_path)
+        if existing_records:
+            print(f"  raw frames exist: {len(existing_records)} -> {raw_dir}")
+            return existing_records
 
     raw_dir.mkdir(parents=True, exist_ok=True)
     capture = cv2.VideoCapture(str(video_path))
@@ -258,82 +243,31 @@ def _extract_continuous_frames(
             params = [cv2.IMWRITE_JPEG_QUALITY, int(cfg.jpeg_quality)]
             if not cv2.imwrite(str(output_path), frame, params):
                 raise RuntimeError(f"Failed to write raw frame: {output_path}")
-        records.append({
-            "frame_id": frame_id,
-            "image_path": _relative_path(output_path, root),
-            "video_id": source["source_id"],
-            "source_frame_index": frame_index,
-            "timestamp_sec": frame_index / fps,
-            "fps": fps,
-            "width": width,
-            "height": height,
-            "split": split,
-            "source_url": source["url"],
-            "source_title": info.get("title"),
-        })
+        records.append(
+            {
+                "frame_id": frame_id,
+                "image_path": relative_path(output_path, root),
+                "video_id": source["source_id"],
+                "source_frame_index": frame_index,
+                "timestamp_sec": frame_index / fps,
+                "fps": fps,
+                "width": width,
+                "height": height,
+                "split": split,
+                "source_url": source["url"],
+                "source_title": info.get("title"),
+            }
+        )
         frame_index += 1
     capture.release()
-    _write_jsonl(manifest_path, records)
+    write_jsonl(manifest_path, records)
     print(f"  raw frames: {len(records)} -> {raw_dir}")
     return records
 
 
-def _find_video(directory: Path, video_id: str) -> Path | None:
-    candidates = [
-        path
-        for path in sorted(directory.glob(f"{video_id}.*"))
-        if path.suffix not in {".json", ".part", ".ytdl"} and not path.name.endswith(".info.json")
-    ]
-    return candidates[0] if candidates else None
-
-
 def _read_info_json(path: Path) -> JSONDict:
-    return {} if not path.exists() else cast(JSONDict, json.loads(path.read_text(encoding="utf-8")))
-
-
-def _read_jsonl(path: Path) -> list[JSONDict]:
-    if not path.exists():
-        return []
-    return [
-        cast(JSONDict, json.loads(line))
-        for line in path.read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
-
-
-def _write_jsonl(path: Path, records: list[JSONDict]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    text = "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records)
-    path.write_text(text, encoding="utf-8")
-
-
-def _write_json_atomic(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    temporary.write_text(
-        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
-        encoding="utf-8",
-    )
-    temporary.replace(path)
-
-
-def _ensure_dirs(paths: Iterable[Path]) -> None:
-    for path in paths:
-        path.mkdir(parents=True, exist_ok=True)
-
-
-def _relative_path(path: Path, root: Path) -> str:
-    return str(path.resolve().relative_to(root.resolve()))
-
-
-def _utc_now() -> str:
-    return datetime.now(UTC).isoformat()
-
-
-def _run(cmd: list[str]) -> None:
-    print("  $ " + " ".join(cmd))
-    subprocess.run(cmd, check=True)
+    return cast(JSONDict, load_json_if_exists(path, {}))
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main())  # type: ignore[call-arg]

--- a/src/tasks/court_detection/scripts/prepare_youtube_dataset.py
+++ b/src/tasks/court_detection/scripts/prepare_youtube_dataset.py
@@ -13,12 +13,8 @@ Notes:
 
 from __future__ import annotations
 
-import json
 import math
-import subprocess
-import sys
 from collections.abc import Callable, Iterable
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
@@ -27,7 +23,27 @@ import hydra
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
 
+from src.utils.io import (
+    ensure_dirs,
+    load_json,
+    load_json_if_exists,
+    read_jsonl,
+    relative_path,
+    save_json_atomic,
+    utc_now_iso,
+    write_jsonl,
+)
 from src.utils.schema.court import COURT_KP_NAMES
+from src.utils.video.sampling import (
+    parse_time_seconds,
+    sample_frame_indices_by_time_ranges,
+    sample_step_seconds,
+)
+from src.utils.video.youtube import (
+    download_youtube_video,
+    h264_encoder_args,
+    transcode_h264_video,
+)
 
 F = TypeVar("F", bound=Callable[..., Any])
 JSONDict = dict[str, Any]
@@ -53,7 +69,7 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
     frames_root = root / str(paths_cfg.frames_dir)
     annotations_dir = root / str(paths_cfg.annotations_dir)
     manifests_dir = root / str(paths_cfg.manifests_dir)
-    _ensure_dirs([av1_dir, h264_dir, frames_root, annotations_dir, manifests_dir])
+    ensure_dirs([av1_dir, h264_dir, frames_root, annotations_dir, manifests_dir])
 
     sources = _source_dicts(workflow_cfg.sources)
     frame_records_by_split: dict[str, list[JSONDict]] = {"train": [], "val": []}
@@ -68,16 +84,20 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
 
         print(f"[prepare_youtube_dataset] source={video_id} split={split}")
         av1_video = _download_av1(source, video_id, av1_dir, workflow_cfg.download)
-        h264_video = _transcode_h264(av1_video, video_id, h264_dir, workflow_cfg.transcode)
+        h264_video = _transcode_h264(
+            av1_video, video_id, h264_dir, workflow_cfg.transcode
+        )
         info = _read_info_json(av1_dir / f"{video_id}.info.json")
-        download_records.append({
-            "video_id": video_id,
-            "source_url": source["url"],
-            "source_title": info.get("title"),
-            "av1_video": _relative_path(av1_video, root),
-            "h264_video": _relative_path(h264_video, root),
-            "processed_at": _utc_now(),
-        })
+        download_records.append(
+            {
+                "video_id": video_id,
+                "source_url": source["url"],
+                "source_title": info.get("title"),
+                "av1_video": relative_path(av1_video, root),
+                "h264_video": relative_path(h264_video, root),
+                "processed_at": utc_now_iso(),
+            }
+        )
 
         frame_records = _extract_frames(
             source,
@@ -90,16 +110,18 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
         )
         frame_records_by_split.setdefault(split, []).extend(frame_records)
 
-    _write_jsonl(manifests_dir / "sources.jsonl", source_records)
-    _write_jsonl(manifests_dir / "download_manifest.jsonl", download_records)
+    write_jsonl(manifests_dir / "sources.jsonl", source_records)
+    write_jsonl(manifests_dir / "download_manifest.jsonl", download_records)
     _write_annotations(annotations_dir, frame_records_by_split, workflow_cfg.annotation)
-    _write_json_atomic(
-        manifests_dir / "split_manifest.json",
+    save_json_atomic(
         {
             "schema_name": "court_youtube_split_manifest_v1",
-            "counts": {split: len(records) for split, records in frame_records_by_split.items()},
-            "written_at": _utc_now(),
+            "counts": {
+                split: len(records) for split, records in frame_records_by_split.items()
+            },
+            "written_at": utc_now_iso(),
         },
+        manifests_dir / "split_manifest.json",
     )
     return 0
 
@@ -114,126 +136,73 @@ def _source_dicts(raw_sources: Iterable[Any]) -> list[JSONDict]:
     return sources
 
 
-def _download_av1(source: JSONDict, video_id: str, av1_dir: Path, cfg: DictConfig) -> Path:
-    existing = _find_video(av1_dir, video_id)
-    if existing is not None and (not bool(cfg.enabled) or not bool(cfg.overwrite)):
-        print(f"  AV1 exists: {existing}")
-        return existing
-    if not bool(cfg.enabled):
-        raise FileNotFoundError(f"AV1 download disabled and no existing video found for {video_id}.")
-
-    output_template = av1_dir / f"{video_id}.%(ext)s"
-    cmd = [
-        sys.executable,
-        "-m",
-        "yt_dlp",
-        str(source["url"]),
-        "-f",
-        str(cfg.strict_format if bool(cfg.require_av1) else cfg.format),
-        "-o",
-        str(output_template),
-        "--merge-output-format",
-        str(cfg.merge_output_format),
-        "--write-info-json",
-        "--no-playlist",
-    ]
-    js_runtimes = cfg.get("js_runtimes")
-    if js_runtimes is not None:
-        cmd.extend(["--js-runtimes", str(js_runtimes)])
-    remote_components = cfg.get("remote_components")
-    if remote_components is not None:
-        cmd.extend(["--remote-components", str(remote_components)])
-    archive_path = cfg.get("download_archive")
-    if archive_path is not None:
-        cmd.extend(["--download-archive", str(Path(to_absolute_path(str(archive_path))).resolve())])
-    cmd.append("--force-overwrites" if bool(cfg.overwrite) else "--no-overwrites")
-    cmd.extend(str(value) for value in cfg.get("extra_args", []))
-    _run(cmd)
-
-    downloaded = _find_video(av1_dir, video_id)
-    if downloaded is None:
-        raise FileNotFoundError(f"yt-dlp finished but no AV1 video was found for {video_id}.")
-    return downloaded
+def _download_av1(
+    source: JSONDict, video_id: str, av1_dir: Path, cfg: DictConfig
+) -> Path:
+    archive = None
+    if cfg.get("download_archive") is not None:
+        archive = Path(to_absolute_path(str(cfg.download_archive))).resolve()
+    return download_youtube_video(
+        url=str(source["url"]),
+        video_id=video_id,
+        output_dir=av1_dir,
+        format_selector=str(cfg.strict_format if bool(cfg.require_av1) else cfg.format),
+        merge_output_format=str(cfg.merge_output_format),
+        enabled=bool(cfg.enabled),
+        overwrite=bool(cfg.overwrite),
+        js_runtimes=None if cfg.get("js_runtimes") is None else str(cfg.js_runtimes),
+        remote_components=(
+            None if cfg.get("remote_components") is None else str(cfg.remote_components)
+        ),
+        download_archive=archive,
+        extra_args=[str(value) for value in cfg.get("extra_args", [])],
+    )
 
 
-def _transcode_h264(av1_video: Path, video_id: str, h264_dir: Path, cfg: DictConfig) -> Path:
-    output_path = h264_dir / f"{video_id}.mp4"
-    if output_path.exists() and not bool(cfg.overwrite):
-        print(f"  H.264 exists: {output_path}")
-        return output_path
-    if not bool(cfg.enabled):
-        raise FileNotFoundError(f"H.264 transcode disabled and output missing: {output_path}")
-
-    cmd = [
-        str(cfg.ffmpeg_binary),
-        "-y" if bool(cfg.overwrite) else "-n",
-    ]
-    hwaccel = cfg.get("hwaccel")
-    if hwaccel is not None:
-        cmd.extend(["-hwaccel", str(hwaccel)])
-    hwaccel_output_format = cfg.get("hwaccel_output_format")
-    if hwaccel_output_format is not None:
-        cmd.extend(["-hwaccel_output_format", str(hwaccel_output_format)])
-
-    cmd.extend([
-        "-i",
-        str(av1_video),
-        "-map",
-        "0:v:0",
-    ])
-    cmd.extend(_h264_encoder_args(cfg))
-    cmd.extend(["-movflags", "+faststart", "-an", str(output_path)])
-    _run(cmd)
-    return output_path
+def _transcode_h264(
+    av1_video: Path, video_id: str, h264_dir: Path, cfg: DictConfig
+) -> Path:
+    return transcode_h264_video(
+        source_video=av1_video,
+        output_path=h264_dir / f"{video_id}.mp4",
+        enabled=bool(cfg.enabled),
+        overwrite=bool(cfg.overwrite),
+        ffmpeg_binary=str(cfg.ffmpeg_binary),
+        encoder=str(cfg.encoder),
+        hwaccel=None if cfg.get("hwaccel") is None else str(cfg.hwaccel),
+        hwaccel_output_format=(
+            None
+            if cfg.get("hwaccel_output_format") is None
+            else str(cfg.hwaccel_output_format)
+        ),
+        preset=str(cfg.preset),
+        tune=None if cfg.get("tune") is None else str(cfg.tune),
+        rate_control=None if cfg.get("rate_control") is None else str(cfg.rate_control),
+        cq=None if cfg.get("cq") is None else cfg.cq,
+        bitrate=None if cfg.get("bitrate") is None else str(cfg.bitrate),
+        maxrate=None if cfg.get("maxrate") is None else str(cfg.maxrate),
+        bufsize=None if cfg.get("bufsize") is None else str(cfg.bufsize),
+        profile=None if cfg.get("profile") is None else str(cfg.profile),
+        pix_fmt=str(cfg.pix_fmt),
+        crf=cfg.crf,
+    )
 
 
 def _h264_encoder_args(cfg: DictConfig) -> list[str]:
     """Return FFmpeg arguments for H.264 encoding."""
-    encoder = str(cfg.encoder)
-    if encoder == "libx264":
-        return [
-            "-c:v",
-            encoder,
-            "-preset",
-            str(cfg.preset),
-            "-crf",
-            str(cfg.crf),
-            "-pix_fmt",
-            str(cfg.pix_fmt),
-        ]
-
-    if encoder in {"h264_nvenc", "avc_nvenc"}:
-        args = [
-            "-c:v",
-            encoder,
-            "-preset",
-            str(cfg.preset),
-            "-tune",
-            str(cfg.tune),
-            "-rc",
-            str(cfg.rate_control),
-            "-cq",
-            str(cfg.cq),
-            "-pix_fmt",
-            str(cfg.pix_fmt),
-        ]
-        bitrate = cfg.get("bitrate")
-        if bitrate is None:
-            args.extend(["-b:v", "0"])
-        else:
-            args.extend(["-b:v", str(bitrate)])
-        maxrate = cfg.get("maxrate")
-        if maxrate is not None:
-            args.extend(["-maxrate", str(maxrate)])
-        bufsize = cfg.get("bufsize")
-        if bufsize is not None:
-            args.extend(["-bufsize", str(bufsize)])
-        profile = cfg.get("profile")
-        if profile is not None:
-            args.extend(["-profile:v", str(profile)])
-        return args
-
-    raise ValueError(f"Unsupported H.264 encoder: {encoder!r}")
+    return h264_encoder_args(
+        encoder=str(cfg.encoder),
+        preset=str(cfg.preset),
+        tune=None if cfg.get("tune") is None else str(cfg.tune),
+        rate_control=None if cfg.get("rate_control") is None else str(cfg.rate_control),
+        cq=None if cfg.get("cq") is None else cfg.cq,
+        bitrate=None if cfg.get("bitrate") is None else str(cfg.bitrate),
+        maxrate=None if cfg.get("maxrate") is None else str(cfg.maxrate),
+        bufsize=None if cfg.get("bufsize") is None else str(cfg.bufsize),
+        profile=None if cfg.get("profile") is None else str(cfg.profile),
+        pix_fmt=str(cfg.pix_fmt),
+        crf=cfg.crf,
+    )
 
 
 def _extract_frames(
@@ -246,12 +215,14 @@ def _extract_frames(
     info: JSONDict,
 ) -> list[JSONDict]:
     if not bool(cfg.enabled):
-        return _read_jsonl(output_dir / "frames.jsonl")
+        return read_jsonl(output_dir / "frames.jsonl")
 
     output_dir.mkdir(parents=True, exist_ok=True)
     capture = cv2.VideoCapture(str(video_path))
     if not capture.isOpened():
-        raise RuntimeError(f"Failed to open H.264 video for frame extraction: {video_path}")
+        raise RuntimeError(
+            f"Failed to open H.264 video for frame extraction: {video_path}"
+        )
 
     fps = float(capture.get(cv2.CAP_PROP_FPS) or 0.0)
     width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
@@ -260,10 +231,16 @@ def _extract_frames(
     if fps <= 0:
         raise RuntimeError(f"Invalid FPS reported by OpenCV for {video_path}: {fps}")
 
-    duration = frame_count / fps if frame_count > 0 else float(info.get("duration") or 0.0)
-    frame_indices = _sample_frame_indices(source.get("time_ranges", []), duration, fps, cfg)
+    duration = (
+        frame_count / fps if frame_count > 0 else float(info.get("duration") or 0.0)
+    )
+    frame_indices = _sample_frame_indices(
+        source.get("time_ranges", []), duration, fps, cfg
+    )
     if frame_count > 0:
-        frame_indices = [frame_index for frame_index in frame_indices if frame_index < frame_count]
+        frame_indices = [
+            frame_index for frame_index in frame_indices if frame_index < frame_count
+        ]
     max_frames = cfg.get("max_frames_per_video")
     if max_frames is not None:
         frame_indices = frame_indices[: int(max_frames)]
@@ -282,71 +259,56 @@ def _extract_frames(
             if not cv2.imwrite(str(output_path), frame, write_params):
                 raise RuntimeError(f"Failed to write frame: {output_path}")
 
-        records.append({
-            "id": image_id,
-            "image_path": _relative_path(output_path, root),
-            "video_id": source["source_id"],
-            "source_url": source["url"],
-            "source_title": info.get("title"),
-            "source_frame_index": frame_index,
-            "timestamp_sec": frame_index / fps,
-            "fps": fps,
-            "width": width,
-            "height": height,
-            "split": split,
-            "status": "pending_annotation",
-            "processed_at": _utc_now(),
-        })
+        records.append(
+            {
+                "id": image_id,
+                "image_path": relative_path(output_path, root),
+                "video_id": source["source_id"],
+                "source_url": source["url"],
+                "source_title": info.get("title"),
+                "source_frame_index": frame_index,
+                "timestamp_sec": frame_index / fps,
+                "fps": fps,
+                "width": width,
+                "height": height,
+                "split": split,
+                "status": "pending_annotation",
+                "processed_at": utc_now_iso(),
+            }
+        )
 
     capture.release()
-    _write_jsonl(output_dir / "frames.jsonl", records)
+    write_jsonl(output_dir / "frames.jsonl", records)
     print(f"  frames: {len(records)} -> {output_dir}")
     return records
 
 
-def _sample_frame_indices(raw_ranges: Any, duration: float, fps: float, cfg: DictConfig) -> list[int]:
-    ranges = list(raw_ranges or [])
-    if not ranges:
-        ranges = [{"start": 0.0, "end": duration}]
-    step_sec = _sample_step_seconds(cfg, fps)
-    frame_indices: list[int] = []
-    seen: set[int] = set()
-    for time_range in ranges:
-        start_sec = _parse_time_seconds(time_range.get("start", 0.0))
-        end_value = time_range.get("end")
-        end_sec = duration if end_value is None else _parse_time_seconds(end_value)
-        timestamp = max(start_sec, 0.0)
-        while timestamp <= max(end_sec, start_sec):
-            frame_index = int(round(timestamp * fps))
-            if frame_index not in seen:
-                seen.add(frame_index)
-                frame_indices.append(frame_index)
-            timestamp += step_sec
-    return frame_indices
+def _sample_frame_indices(
+    raw_ranges: Any, duration: float, fps: float, cfg: DictConfig
+) -> list[int]:
+    return sample_frame_indices_by_time_ranges(
+        raw_ranges,
+        duration=duration,
+        fps=fps,
+        sample_mode=str(cfg.sample_mode),
+        interval_seconds=float(cfg.interval_seconds),
+        target_fps=float(cfg.fps),
+        every_n_frames=int(cfg.every_n_frames),
+    )
 
 
 def _sample_step_seconds(cfg: DictConfig, fps: float) -> float:
-    mode = str(cfg.sample_mode)
-    if mode == "interval_seconds":
-        return float(cfg.interval_seconds)
-    if mode == "fps":
-        return 1.0 / float(cfg.fps)
-    if mode == "every_n_frames":
-        return float(cfg.every_n_frames) / fps
-    raise ValueError(f"Unsupported frames.sample_mode={mode!r}.")
+    return sample_step_seconds(
+        sample_mode=str(cfg.sample_mode),
+        fps=fps,
+        interval_seconds=float(cfg.interval_seconds),
+        target_fps=float(cfg.fps),
+        every_n_frames=int(cfg.every_n_frames),
+    )
 
 
 def _parse_time_seconds(value: Any) -> float:
-    if isinstance(value, int | float):
-        return float(value)
-    text = str(value)
-    parts = text.split(":")
-    if len(parts) == 1:
-        return float(parts[0])
-    seconds = 0.0
-    for part in parts:
-        seconds = seconds * 60.0 + float(part)
-    return seconds
+    return parse_time_seconds(value)
 
 
 def _write_annotations(
@@ -356,7 +318,9 @@ def _write_annotations(
 ) -> None:
     for split in ("train", "val"):
         path = annotations_dir / f"{split}.json"
-        existing_by_id = _existing_annotation_items(path) if bool(cfg.merge_existing) else {}
+        existing_by_id = (
+            _existing_annotation_items(path) if bool(cfg.merge_existing) else {}
+        )
         items: list[JSONDict] = []
         generated_ids: set[str] = set()
         for frame in frame_records_by_split.get(split, []):
@@ -366,7 +330,9 @@ def _write_annotations(
             if existing is None:
                 items.append(_initial_annotation_item(frame, split, cfg))
             else:
-                items.append(_normalize_youtube_annotation_item(existing, frame, split, cfg))
+                items.append(
+                    _normalize_youtube_annotation_item(existing, frame, split, cfg)
+                )
         if bool(cfg.merge_existing):
             items.extend(
                 item
@@ -390,8 +356,10 @@ def _write_annotations(
             "items": items,
         }
         if path.exists() and not bool(cfg.overwrite) and not bool(cfg.merge_existing):
-            raise FileExistsError(f"Annotation file exists. Set overwrite=true or merge_existing=true: {path}")
-        _write_json_atomic(path, payload)
+            raise FileExistsError(
+                f"Annotation file exists. Set overwrite=true or merge_existing=true: {path}"
+            )
+        save_json_atomic(payload, path)
         print(f"[prepare_youtube_dataset] annotations {split}: {len(items)} -> {path}")
 
 
@@ -445,27 +413,31 @@ def _normalize_youtube_annotation_item(
     """Normalize an existing YouTube item without discarding annotations."""
     output = dict(existing)
     keypoint_format = str(cfg.keypoint_format)
-    output.update({
-        "id": frame["id"],
-        "image_path": frame["image_path"],
-        "width": frame["width"],
-        "height": frame["height"],
-        "split": split,
-        "keypoint_format": keypoint_format,
-        "labeled_keypoint_indices": _labeled_keypoint_indices(keypoint_format),
-        "is_yastrebksv_kp15": False,
-    })
+    output.update(
+        {
+            "id": frame["id"],
+            "image_path": frame["image_path"],
+            "width": frame["width"],
+            "height": frame["height"],
+            "split": split,
+            "keypoint_format": keypoint_format,
+            "labeled_keypoint_indices": _labeled_keypoint_indices(keypoint_format),
+            "is_yastrebksv_kp15": False,
+        }
+    )
     source = dict(output.get("source", {}))
     for key in ("dataset", "keypoint_format", "labeled_keypoint_indices"):
         source.pop(key, None)
-    source.update({
-        "type": "youtube",
-        "video_id": frame["video_id"],
-        "source_url": frame["source_url"],
-        "source_title": frame.get("source_title"),
-        "source_frame_index": frame["source_frame_index"],
-        "timestamp_sec": frame["timestamp_sec"],
-    })
+    source.update(
+        {
+            "type": "youtube",
+            "video_id": frame["video_id"],
+            "source_url": frame["source_url"],
+            "source_title": frame.get("source_title"),
+            "source_frame_index": frame["source_frame_index"],
+            "timestamp_sec": frame["timestamp_sec"],
+        }
+    )
     output["source"] = source
     if output.get("annotation_status") == "completed" and not _named_keypoints_complete(
         output.get("keypoints"),
@@ -495,7 +467,12 @@ def _named_keypoints_complete(keypoints: Any, required_indices: list[int]) -> bo
             return False
         x = point.get("x")
         y = point.get("y")
-        if x is None or y is None or not math.isfinite(float(x)) or not math.isfinite(float(y)):
+        if (
+            x is None
+            or y is None
+            or not math.isfinite(float(x))
+            or not math.isfinite(float(y))
+        ):
             return False
     return True
 
@@ -511,62 +488,14 @@ def _labeled_keypoint_indices(keypoint_format: str) -> list[int]:
 def _existing_annotation_items(path: Path) -> dict[str, JSONDict]:
     if not path.exists():
         return {}
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = load_json(path)
     items = payload.get("items", []) if isinstance(payload, dict) else payload
     return {str(item["id"]): item for item in items}
 
 
-def _find_video(directory: Path, video_id: str) -> Path | None:
-    candidates = [
-        path
-        for path in sorted(directory.glob(f"{video_id}.*"))
-        if path.suffix not in {".json", ".part", ".ytdl"} and not path.name.endswith(".info.json")
-    ]
-    return candidates[0] if candidates else None
-
-
 def _read_info_json(path: Path) -> JSONDict:
-    if not path.exists():
-        return {}
-    return cast(JSONDict, json.loads(path.read_text(encoding="utf-8")))
-
-
-def _read_jsonl(path: Path) -> list[JSONDict]:
-    if not path.exists():
-        return []
-    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
-
-
-def _write_jsonl(path: Path, records: list[JSONDict]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    text = "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records)
-    path.write_text(text, encoding="utf-8")
-
-
-def _write_json_atomic(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_suffix(path.suffix + ".tmp")
-    tmp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    tmp_path.replace(path)
-
-
-def _ensure_dirs(paths: Iterable[Path]) -> None:
-    for path in paths:
-        path.mkdir(parents=True, exist_ok=True)
-
-
-def _relative_path(path: Path, root: Path) -> str:
-    return str(path.resolve().relative_to(root.resolve()))
-
-
-def _utc_now() -> str:
-    return datetime.now(UTC).isoformat()
-
-
-def _run(cmd: list[str]) -> None:
-    print("  $ " + " ".join(cmd))
-    subprocess.run(cmd, check=True)
+    return cast(JSONDict, load_json_if_exists(path, {}))
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main())  # type: ignore[call-arg]

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -22,6 +22,8 @@ types**, it belongs here (or should be promoted here), not in the task module.
 | Per-sample dataloader RNG | `make_sample_rng()` | `from src.utils.seeding import make_sample_rng` |
 | `mkdir(parents=True, exist_ok=True)` | `ensure_dir()` | `from src.utils.io import ensure_dir` |
 | Write/read JSON (creates dirs) | `save_json()` / `load_json()` | `from src.utils.io import save_json, load_json` |
+| Write/read JSONL manifests | `write_jsonl()` / `read_jsonl()` | `from src.utils.io import write_jsonl, read_jsonl` |
+| Atomic JSON write | `save_json_atomic()` | `from src.utils.io import save_json_atomic` |
 | Clone a `dict[str, Tensor]` sample | `clone_tensor_dict()` | `from src.utils.tensor_utils import clone_tensor_dict` |
 | Tensor → numpy (bf16-safe) | `to_numpy()` | `from src.utils.tensor_utils import to_numpy` |
 | Masked mean / padding mask | `masked_mean()`, `normalize_padding_mask()` | `from src.utils.tensor_utils import masked_mean, normalize_padding_mask` |
@@ -41,6 +43,8 @@ types**, it belongs here (or should be promoted here), not in the task module.
 | Court / player schema constants | court & COCO/SMPL keypoint definitions | `from src.utils.schema.court import ...` / `from src.utils.schema.player import ...` |
 | Read/stream video frames | `probe_video_info()`, `OpenCVVideoFrameReader`, `iter_temporal_windows/batches()` | `from src.utils.video import ...` |
 | Encode/select JPEG video frames | `encode_jpeg()`, `iter_selected_video_jpegs()` | `from src.utils.video import ...` |
+| Sample video frame indices | `sample_uniform_frame_indices()`, `sample_frame_indices_by_time_ranges()` | `from src.utils.video import ...` |
+| Download/transcode YouTube videos | `download_youtube_video()`, `transcode_h264_video()` | `from src.utils.video import ...` |
 | Transformer / MoE / RoPE blocks | `TransformerBlock`, `MoELayer`, RoPE helpers, `MLPHead` | `from src.utils.models import ...` |
 
 ## Modules
@@ -56,6 +60,7 @@ types**, it belongs here (or should be promoted here), not in the task module.
   `make_sample_rng()`. Training entry points needing full Lightning determinism
   should still use `lightning.pytorch.seed_everything`.
 - **`io.py`** — `ensure_dir()`, `save_json()`, `load_json()`.
+- **`commands.py`** — `run_command()` for logged `subprocess.run(..., check=True)`.
 - **`tensor_utils.py`** — `clone_tensor_dict()`, `to_numpy()` (detaches, moves to
   CPU, upcasts bf16/fp16), `masked_mean()`, `normalize_padding_mask()`.
 
@@ -92,7 +97,8 @@ types**, it belongs here (or should be promoted here), not in the task module.
 - **`video/`** — OpenCV streaming: `probe_video_info`, `read_video_frame`,
   `OpenCVVideoFrameReader`, `iter_temporal_windows/batches`, `PrefetchIterator`,
   `BgrToTensorTransform`, `normalize_tensor_imagenet`, JPEG encoding and
-  selected-frame extraction.
+  selected-frame extraction, frame index sampling, YouTube download, and H.264
+  transcode helpers.
 
 ## Adding a new utility
 

--- a/src/utils/commands.py
+++ b/src/utils/commands.py
@@ -1,0 +1,16 @@
+"""Subprocess command helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+
+
+def run_command(cmd: Sequence[str], *, echo: bool = True) -> None:
+    """Run ``cmd`` with ``check=True`` and optional shell-like echoing."""
+    if echo:
+        print("  $ " + " ".join(cmd))
+    subprocess.run(list(cmd), check=True)
+
+
+__all__ = ["run_command"]

--- a/src/utils/io.py
+++ b/src/utils/io.py
@@ -8,8 +8,12 @@ writers, pipeline ``Result.save()`` methods and scripts.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+
+JSONDict = dict[str, Any]
 
 
 def ensure_dir(path: str | Path) -> Path:
@@ -20,6 +24,11 @@ def ensure_dir(path: str | Path) -> Path:
     directory = Path(path)
     directory.mkdir(parents=True, exist_ok=True)
     return directory
+
+
+def ensure_dirs(paths: Iterable[str | Path]) -> list[Path]:
+    """Create multiple directories and return them as ``Path`` objects."""
+    return [ensure_dir(path) for path in paths]
 
 
 def save_json(data: Any, path: str | Path, *, indent: int = 2) -> Path:
@@ -40,10 +49,83 @@ def save_json(data: Any, path: str | Path, *, indent: int = 2) -> Path:
     return destination
 
 
+def save_json_atomic(
+    data: Any,
+    path: str | Path,
+    *,
+    indent: int = 2,
+    ensure_ascii: bool = False,
+) -> Path:
+    """Atomically serialize ``data`` to ``path`` as UTF-8 JSON."""
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    text = json.dumps(data, ensure_ascii=ensure_ascii, indent=indent) + "\n"
+    temporary.write_text(text, encoding="utf-8")
+    temporary.replace(destination)
+    return destination
+
+
 def load_json(path: str | Path) -> Any:
     """Load and return the JSON content of ``path`` (UTF-8)."""
     with Path(path).open("r", encoding="utf-8") as handle:
         return json.load(handle)
 
 
-__all__ = ["ensure_dir", "save_json", "load_json"]
+def load_json_if_exists(path: str | Path, default: Any = None) -> Any:
+    """Load JSON from ``path`` or return ``default`` when it is missing."""
+    source = Path(path)
+    return default if not source.exists() else load_json(source)
+
+
+def read_jsonl(path: str | Path) -> list[JSONDict]:
+    """Read a UTF-8 JSONL file into a list of dictionaries."""
+    source = Path(path)
+    if not source.exists():
+        return []
+    return [
+        cast(JSONDict, json.loads(line))
+        for line in source.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def write_jsonl(
+    path: str | Path,
+    records: Iterable[JSONDict],
+    *,
+    ensure_ascii: bool = False,
+) -> Path:
+    """Write dictionaries to ``path`` as UTF-8 JSONL."""
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    text = "".join(
+        json.dumps(record, ensure_ascii=ensure_ascii) + "\n" for record in records
+    )
+    destination.write_text(text, encoding="utf-8")
+    return destination
+
+
+def relative_path(path: str | Path, root: str | Path) -> str:
+    """Return ``path`` relative to ``root`` after resolving both."""
+    return str(Path(path).resolve().relative_to(Path(root).resolve()))
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(UTC).isoformat()
+
+
+__all__ = [
+    "JSONDict",
+    "ensure_dir",
+    "ensure_dirs",
+    "load_json",
+    "load_json_if_exists",
+    "read_jsonl",
+    "relative_path",
+    "save_json",
+    "save_json_atomic",
+    "utc_now_iso",
+    "write_jsonl",
+]

--- a/src/utils/video/__init__.py
+++ b/src/utils/video/__init__.py
@@ -8,9 +8,21 @@ from src.utils.video.reader import (
     probe_video_info,
     read_video_frame,
 )
+from src.utils.video.sampling import (
+    parse_time_seconds,
+    sample_frame_indices_by_time_ranges,
+    sample_step_seconds,
+    sample_uniform_frame_indices,
+)
 from src.utils.video.transforms import BgrToTensorTransform, normalize_tensor_imagenet
 from src.utils.video.types import FramePacket, TemporalBatch, TemporalWindow, VideoInfo
 from src.utils.video.windows import iter_temporal_windows
+from src.utils.video.youtube import (
+    download_youtube_video,
+    find_downloaded_video,
+    h264_encoder_args,
+    transcode_h264_video,
+)
 
 __all__ = [
     "BgrToTensorTransform",
@@ -24,7 +36,15 @@ __all__ = [
     "iter_temporal_batches",
     "iter_temporal_windows",
     "iter_selected_video_jpegs",
+    "download_youtube_video",
+    "find_downloaded_video",
+    "h264_encoder_args",
     "normalize_tensor_imagenet",
+    "parse_time_seconds",
     "probe_video_info",
     "read_video_frame",
+    "sample_frame_indices_by_time_ranges",
+    "sample_step_seconds",
+    "sample_uniform_frame_indices",
+    "transcode_h264_video",
 ]

--- a/src/utils/video/sampling.py
+++ b/src/utils/video/sampling.py
@@ -1,0 +1,102 @@
+"""Frame-index sampling helpers for decoded videos."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def parse_time_seconds(value: Any) -> float:
+    """Parse seconds from a number or ``HH:MM:SS``-style string."""
+    if isinstance(value, int | float):
+        return float(value)
+    parts = str(value).split(":")
+    if len(parts) == 1:
+        return float(parts[0])
+    seconds = 0.0
+    for part in parts:
+        seconds = seconds * 60.0 + float(part)
+    return seconds
+
+
+def sample_step_seconds(
+    *,
+    sample_mode: str,
+    fps: float,
+    interval_seconds: float,
+    target_fps: float,
+    every_n_frames: int,
+) -> float:
+    """Return frame sampling step in seconds for a named sampling mode."""
+    if fps <= 0:
+        raise ValueError(f"fps must be positive, got {fps}.")
+    if sample_mode == "interval_seconds":
+        return float(interval_seconds)
+    if sample_mode == "fps":
+        return 1.0 / float(target_fps)
+    if sample_mode == "every_n_frames":
+        return float(every_n_frames) / fps
+    raise ValueError(f"Unsupported sample_mode={sample_mode!r}.")
+
+
+def sample_frame_indices_by_time_ranges(
+    raw_ranges: Iterable[Mapping[str, Any]] | None,
+    *,
+    duration: float,
+    fps: float,
+    sample_mode: str,
+    interval_seconds: float,
+    target_fps: float,
+    every_n_frames: int,
+    max_frames: int | None = None,
+) -> list[int]:
+    """Sample unique frame indices from timestamp ranges."""
+    ranges = list(raw_ranges or [])
+    if not ranges:
+        ranges = [{"start": 0.0, "end": duration}]
+    step_sec = sample_step_seconds(
+        sample_mode=sample_mode,
+        fps=fps,
+        interval_seconds=interval_seconds,
+        target_fps=target_fps,
+        every_n_frames=every_n_frames,
+    )
+    frame_indices: list[int] = []
+    seen: set[int] = set()
+    for time_range in ranges:
+        start_sec = parse_time_seconds(time_range.get("start", 0.0))
+        end_value = time_range.get("end")
+        end_sec = duration if end_value is None else parse_time_seconds(end_value)
+        timestamp = max(start_sec, 0.0)
+        while timestamp <= max(end_sec, start_sec):
+            frame_index = int(round(timestamp * fps))
+            if frame_index not in seen:
+                seen.add(frame_index)
+                frame_indices.append(frame_index)
+                if max_frames is not None and len(frame_indices) >= max_frames:
+                    return frame_indices
+            timestamp += step_sec
+    return frame_indices
+
+
+def sample_uniform_frame_indices(frame_count: int, sample_count: int) -> list[int]:
+    """Sample up to ``sample_count`` unique indices uniformly over a video."""
+    if frame_count <= 0:
+        raise ValueError(f"frame_count must be positive, got {frame_count}.")
+    if sample_count <= 0:
+        raise ValueError(f"sample_count must be positive, got {sample_count}.")
+    if sample_count >= frame_count:
+        return list(range(frame_count))
+    if sample_count == 1:
+        return [frame_count // 2]
+
+    last_index = frame_count - 1
+    return [round(i * last_index / (sample_count - 1)) for i in range(sample_count)]
+
+
+__all__ = [
+    "parse_time_seconds",
+    "sample_frame_indices_by_time_ranges",
+    "sample_step_seconds",
+    "sample_uniform_frame_indices",
+]

--- a/src/utils/video/youtube.py
+++ b/src/utils/video/youtube.py
@@ -1,0 +1,208 @@
+"""YouTube download and FFmpeg transcode helpers."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from src.utils.commands import run_command
+
+VIDEO_EXCLUDED_SUFFIXES = {".json", ".part", ".ytdl"}
+
+
+def find_downloaded_video(directory: str | Path, video_id: str) -> Path | None:
+    """Return the first downloaded video matching ``video_id`` in ``directory``."""
+    root = Path(directory)
+    candidates = [
+        path
+        for path in sorted(root.glob(f"{video_id}.*"))
+        if path.suffix not in VIDEO_EXCLUDED_SUFFIXES
+        and not path.name.endswith(".info.json")
+    ]
+    return candidates[0] if candidates else None
+
+
+def download_youtube_video(
+    *,
+    url: str,
+    video_id: str,
+    output_dir: str | Path,
+    format_selector: str,
+    merge_output_format: str = "mkv",
+    enabled: bool = True,
+    overwrite: bool = False,
+    write_info_json: bool = True,
+    no_playlist: bool = True,
+    js_runtimes: str | None = None,
+    remote_components: str | None = None,
+    download_archive: str | Path | None = None,
+    extra_args: Sequence[str] = (),
+    python_executable: str = sys.executable,
+) -> Path:
+    """Download one YouTube video with ``yt-dlp`` and return its local path."""
+    destination = Path(output_dir)
+    existing = find_downloaded_video(destination, video_id)
+    if existing is not None and (not enabled or not overwrite):
+        print(f"  source video exists: {existing}")
+        return existing
+    if not enabled:
+        raise FileNotFoundError(f"Download disabled and no video found for {video_id}.")
+
+    destination.mkdir(parents=True, exist_ok=True)
+    output_template = destination / f"{video_id}.%(ext)s"
+    cmd = [
+        python_executable,
+        "-m",
+        "yt_dlp",
+        url,
+        "-f",
+        format_selector,
+        "-o",
+        str(output_template),
+        "--merge-output-format",
+        merge_output_format,
+    ]
+    if write_info_json:
+        cmd.append("--write-info-json")
+    if no_playlist:
+        cmd.append("--no-playlist")
+    if js_runtimes is not None:
+        cmd.extend(["--js-runtimes", js_runtimes])
+    if remote_components is not None:
+        cmd.extend(["--remote-components", remote_components])
+    if download_archive is not None:
+        archive = Path(download_archive).resolve()
+        archive.parent.mkdir(parents=True, exist_ok=True)
+        cmd.extend(["--download-archive", str(archive)])
+    cmd.append("--force-overwrites" if overwrite else "--no-overwrites")
+    cmd.extend(str(value) for value in extra_args)
+    run_command(cmd)
+
+    downloaded = find_downloaded_video(destination, video_id)
+    if downloaded is None:
+        raise FileNotFoundError(
+            f"yt-dlp finished but no video was found for {video_id}."
+        )
+    return downloaded
+
+
+def h264_encoder_args(
+    *,
+    encoder: str,
+    preset: str,
+    pix_fmt: str,
+    crf: int | float,
+    tune: str | None = None,
+    rate_control: str | None = None,
+    cq: int | float | None = None,
+    bitrate: str | None = None,
+    maxrate: str | None = None,
+    bufsize: str | None = None,
+    profile: str | None = None,
+) -> list[str]:
+    """Return FFmpeg arguments for H.264 encoding."""
+    if encoder == "libx264":
+        return [
+            "-c:v",
+            encoder,
+            "-preset",
+            preset,
+            "-crf",
+            str(crf),
+            "-pix_fmt",
+            pix_fmt,
+        ]
+
+    if encoder not in {"h264_nvenc", "avc_nvenc"}:
+        raise ValueError(f"Unsupported H.264 encoder: {encoder!r}")
+
+    args = [
+        "-c:v",
+        encoder,
+        "-preset",
+        preset,
+        "-tune",
+        "hq" if tune is None else tune,
+        "-rc",
+        "vbr" if rate_control is None else rate_control,
+        "-cq",
+        "20" if cq is None else str(cq),
+        "-pix_fmt",
+        pix_fmt,
+        "-b:v",
+        "0" if bitrate is None else bitrate,
+    ]
+    if maxrate is not None:
+        args.extend(["-maxrate", maxrate])
+    if bufsize is not None:
+        args.extend(["-bufsize", bufsize])
+    if profile is not None:
+        args.extend(["-profile:v", profile])
+    return args
+
+
+def transcode_h264_video(
+    *,
+    source_video: str | Path,
+    output_path: str | Path,
+    enabled: bool = True,
+    overwrite: bool = False,
+    ffmpeg_binary: str = "ffmpeg",
+    encoder: str = "libx264",
+    hwaccel: str | None = None,
+    hwaccel_output_format: str | None = None,
+    preset: str = "medium",
+    tune: str | None = None,
+    rate_control: str | None = None,
+    cq: int | float | None = None,
+    bitrate: str | None = None,
+    maxrate: str | None = None,
+    bufsize: str | None = None,
+    profile: str | None = None,
+    pix_fmt: str = "yuv420p",
+    crf: int | float = 20,
+) -> Path:
+    """Transcode a video to H.264 MP4 and return the output path."""
+    destination = Path(output_path)
+    if destination.exists() and not overwrite:
+        print(f"  H.264 exists: {destination}")
+        return destination
+    if not enabled:
+        raise FileNotFoundError(
+            f"H.264 transcode disabled and output missing: {destination}"
+        )
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [ffmpeg_binary, "-y" if overwrite else "-n"]
+    if hwaccel is not None:
+        cmd.extend(["-hwaccel", hwaccel])
+    if hwaccel_output_format is not None:
+        cmd.extend(["-hwaccel_output_format", hwaccel_output_format])
+    cmd.extend(["-i", str(source_video), "-map", "0:v:0"])
+    cmd.extend(
+        h264_encoder_args(
+            encoder=encoder,
+            preset=preset,
+            tune=tune,
+            rate_control=rate_control,
+            cq=cq,
+            bitrate=bitrate,
+            maxrate=maxrate,
+            bufsize=bufsize,
+            profile=profile,
+            pix_fmt=pix_fmt,
+            crf=crf,
+        )
+    )
+    cmd.extend(["-movflags", "+faststart", "-an", str(destination)])
+    run_command(cmd)
+    return destination
+
+
+__all__ = [
+    "download_youtube_video",
+    "find_downloaded_video",
+    "h264_encoder_args",
+    "transcode_h264_video",
+]

--- a/tests/e2e/ball_detection/test_prepare_dinov3_ssl_images.py
+++ b/tests/e2e/ball_detection/test_prepare_dinov3_ssl_images.py
@@ -8,6 +8,7 @@ from numpy.typing import NDArray
 from omegaconf import OmegaConf
 
 from src.tasks.ball_detection.scripts.youtube.prepare_dinov3_ssl_images import (
+    _parse_gate_output,
     run_pipeline,
 )
 
@@ -109,6 +110,19 @@ def test_prepare_dinov3_ssl_images_promotes_mock_accepted_frames(
     assert result["image_count"] == 4
     assert len(images) == 4
     assert (tmp_path / "dino_ssl" / "manifests" / "images.jsonl").exists()
+
+
+def test_prepare_dinov3_ssl_images_parses_vllm_json_gate_output() -> None:
+    parsed = _parse_gate_output(
+        '```json\n{"label": "non_tennis", "confidence": 0.91, '
+        '"reason": "basketball court"}\n```'
+    )
+
+    assert parsed == {
+        "label": "non_tennis",
+        "confidence": 0.91,
+        "reason": "basketball court",
+    }
 
 
 def _write_tiny_video(path: Path, *, frame_count: int) -> None:

--- a/tests/e2e/ball_detection/test_prepare_dinov3_ssl_images.py
+++ b/tests/e2e/ball_detection/test_prepare_dinov3_ssl_images.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+from omegaconf import OmegaConf
+
+from src.tasks.ball_detection.scripts.youtube.prepare_dinov3_ssl_images import (
+    run_pipeline,
+)
+
+
+def test_prepare_dinov3_ssl_images_promotes_mock_accepted_frames(
+    tmp_path: Path,
+) -> None:
+    source_video = tmp_path / "tennis_source.mp4"
+    _write_tiny_video(source_video, frame_count=8)
+    cfg = OmegaConf.create(
+        {
+            "workflow": {
+                "root": str(tmp_path / "dino_ssl"),
+                "sources": [
+                    {
+                        "video_id": "local_tennis",
+                        "url": "https://www.youtube.com/watch?v=local_tennis",
+                        "local_video": str(source_video),
+                        "title": "tennis rally test clip",
+                    }
+                ],
+                "discovery": {
+                    "enabled": False,
+                    "queries": [],
+                    "max_results_per_query": 0,
+                },
+                "paths": {
+                    "videos_dir": "videos",
+                    "source_dir": "source",
+                    "h264_dir": "h264",
+                    "sampled_dir": "sampled",
+                    "images_dir": "images",
+                    "manifests_dir": "manifests",
+                },
+                "processing": {"max_new_videos": 1, "reprocess_existing": False},
+                "download": {
+                    "enabled": False,
+                    "format": "best",
+                    "merge_output_format": "mkv",
+                    "js_runtimes": None,
+                    "remote_components": None,
+                    "download_archive": None,
+                    "overwrite": False,
+                    "extra_args": [],
+                },
+                "transcode": {
+                    "enabled": True,
+                    "ffmpeg_binary": "ffmpeg",
+                    "encoder": "libx264",
+                    "hwaccel": None,
+                    "hwaccel_output_format": None,
+                    "preset": "ultrafast",
+                    "tune": None,
+                    "rate_control": None,
+                    "cq": None,
+                    "bitrate": None,
+                    "maxrate": None,
+                    "bufsize": None,
+                    "profile": None,
+                    "pix_fmt": "yuv420p",
+                    "crf": 30,
+                    "overwrite": False,
+                },
+                "frames": {
+                    "frames_per_video": 4,
+                    "output_ext": "jpg",
+                    "jpeg_quality": 90,
+                    "overwrite": False,
+                },
+                "gate": {
+                    "backend": "mock",
+                    "mock": {"accept_all": False},
+                    "contact_sheet": {
+                        "max_images": 4,
+                        "columns": 2,
+                        "thumb_width": 64,
+                        "thumb_height": 36,
+                    },
+                    "command_backend": {
+                        "command": ["echo", "tennis"],
+                        "prompt": "",
+                        "accept_labels": ["tennis"],
+                    },
+                    "openai_compatible": {
+                        "base_url": "http://127.0.0.1:8000/v1",
+                        "model": "unused",
+                        "timeout_sec": 1,
+                        "accept_labels": ["tennis"],
+                        "prompt": "",
+                    },
+                },
+            }
+        }
+    )
+
+    result = run_pipeline(cfg)
+
+    images = sorted((tmp_path / "dino_ssl" / "images").glob("*.jpg"))
+    assert result["image_count"] == 4
+    assert len(images) == 4
+    assert (tmp_path / "dino_ssl" / "manifests" / "images.jsonl").exists()
+
+
+def _write_tiny_video(path: Path, *, frame_count: int) -> None:
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # type: ignore[attr-defined]
+    writer = cv2.VideoWriter(str(path), fourcc, 4.0, (64, 36))
+    assert writer.isOpened()
+    try:
+        for index in range(frame_count):
+            frame: NDArray[np.uint8] = np.full(
+                (36, 64, 3),
+                index * 20,
+                dtype=np.uint8,
+            )
+            writer.write(frame)
+    finally:
+        writer.release()

--- a/tests/e2e/ball_detection/test_prepare_dinov3_ssl_images.py
+++ b/tests/e2e/ball_detection/test_prepare_dinov3_ssl_images.py
@@ -87,16 +87,13 @@ def test_prepare_dinov3_ssl_images_promotes_mock_accepted_frames(
                         "thumb_width": 64,
                         "thumb_height": 36,
                     },
-                    "command_backend": {
-                        "command": ["echo", "tennis"],
-                        "prompt": "",
-                        "accept_labels": ["tennis"],
-                    },
-                    "openai_compatible": {
+                    "vllm": {
                         "base_url": "http://127.0.0.1:8000/v1",
                         "model": "unused",
                         "timeout_sec": 1,
+                        "max_tokens": 4096,
                         "accept_labels": ["tennis"],
+                        "extra_body": {},
                         "prompt": "",
                     },
                 },

--- a/tests/unit/utils/test_io.py
+++ b/tests/unit/utils/test_io.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.utils.io import (
+    JSONDict,
+    read_jsonl,
+    relative_path,
+    save_json_atomic,
+    write_jsonl,
+)
+
+
+def test_jsonl_roundtrip(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "records.jsonl"
+    records: list[JSONDict] = [{"id": "a", "text": "tennis"}, {"id": "b", "value": 2}]
+
+    write_jsonl(path, records)
+
+    assert read_jsonl(path) == records
+
+
+def test_save_json_atomic_replaces_target(tmp_path: Path) -> None:
+    path = tmp_path / "payload.json"
+    save_json_atomic({"value": 1}, path)
+    save_json_atomic({"value": 2}, path)
+
+    assert path.read_text(encoding="utf-8") == '{\n  "value": 2\n}\n'
+    assert not path.with_suffix(".json.tmp").exists()
+
+
+def test_relative_path_resolves_paths(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    child = root / "a" / "b.txt"
+    child.parent.mkdir(parents=True)
+    child.write_text("x", encoding="utf-8")
+
+    assert relative_path(child, root) == "a/b.txt"

--- a/tests/unit/utils/video/test_sampling.py
+++ b/tests/unit/utils/video/test_sampling.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+
+from src.utils.video.sampling import (
+    parse_time_seconds,
+    sample_frame_indices_by_time_ranges,
+    sample_step_seconds,
+    sample_uniform_frame_indices,
+)
+
+
+def test_parse_time_seconds_supports_colon_format() -> None:
+    assert parse_time_seconds("01:02:03.5") == 3723.5
+    assert parse_time_seconds(12) == 12.0
+
+
+def test_sample_step_seconds_modes() -> None:
+    assert (
+        sample_step_seconds(
+            sample_mode="interval_seconds",
+            fps=30,
+            interval_seconds=2,
+            target_fps=1,
+            every_n_frames=60,
+        )
+        == 2
+    )
+    assert (
+        sample_step_seconds(
+            sample_mode="fps",
+            fps=30,
+            interval_seconds=2,
+            target_fps=2,
+            every_n_frames=60,
+        )
+        == 0.5
+    )
+    assert (
+        sample_step_seconds(
+            sample_mode="every_n_frames",
+            fps=30,
+            interval_seconds=2,
+            target_fps=2,
+            every_n_frames=15,
+        )
+        == 0.5
+    )
+
+
+def test_sample_frame_indices_by_time_ranges_deduplicates_and_limits() -> None:
+    indices = sample_frame_indices_by_time_ranges(
+        [{"start": 0, "end": 1}, {"start": 0.5, "end": 1.5}],
+        duration=2,
+        fps=2,
+        sample_mode="interval_seconds",
+        interval_seconds=0.5,
+        target_fps=1,
+        every_n_frames=1,
+        max_frames=4,
+    )
+
+    assert indices == [0, 1, 2, 3]
+
+
+def test_sample_uniform_frame_indices_spans_video() -> None:
+    assert sample_uniform_frame_indices(100, 5) == [0, 25, 50, 74, 99]
+    assert sample_uniform_frame_indices(3, 10) == [0, 1, 2]
+
+
+def test_sample_uniform_frame_indices_rejects_invalid_values() -> None:
+    with pytest.raises(ValueError):
+        sample_uniform_frame_indices(0, 5)
+    with pytest.raises(ValueError):
+        sample_uniform_frame_indices(10, 0)

--- a/tests/unit/utils/video/test_youtube.py
+++ b/tests/unit/utils/video/test_youtube.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.utils.video.youtube import find_downloaded_video, h264_encoder_args
+
+
+def test_find_downloaded_video_ignores_metadata_and_partial_files(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "abc.info.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "abc.part").write_text("", encoding="utf-8")
+    video = tmp_path / "abc.mkv"
+    video.write_text("video", encoding="utf-8")
+
+    assert find_downloaded_video(tmp_path, "abc") == video
+
+
+def test_h264_encoder_args_libx264() -> None:
+    assert h264_encoder_args(
+        encoder="libx264",
+        preset="veryfast",
+        pix_fmt="yuv420p",
+        crf=24,
+    ) == [
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-crf",
+        "24",
+        "-pix_fmt",
+        "yuv420p",
+    ]
+
+
+def test_h264_encoder_args_nvenc_optional_values() -> None:
+    args = h264_encoder_args(
+        encoder="h264_nvenc",
+        preset="p5",
+        pix_fmt="yuv420p",
+        crf=20,
+        tune="hq",
+        rate_control="vbr",
+        cq=20,
+        profile="high",
+    )
+
+    assert args[:2] == ["-c:v", "h264_nvenc"]
+    assert args[-2:] == ["-profile:v", "high"]


### PR DESCRIPTION
## 概要

DINOv3 LoRA SSL向けに、YouTube由来の短尺テニス動画から `data/tennis/dino_ssl/images` を構築するパイプラインを追加します。

既存のball/court YouTube準備スクリプトで重複していた `yt-dlp`、H.264変換、JSONL、frame sampling の共通処理を `src/utils` へ抽出しました。

## 変更内容

- `src/utils` に共通処理を追加: JSONL/atomic JSON、logged subprocess、動画frame sampling、YouTube download、H.264 transcode
- 既存の `prepare_youtube_dataset.py` 2本を共有utils利用へリファクタ
- `prepare_dinov3_ssl_images.py` とHydra configを追加
- discovery段階と `yt-dlp --match-filter` で長尺動画を除外し、短尺動画を多本数集める設計に変更
- Qwen3.5-0.8B LiteRT/ONNX INT8想定のVLM gateを `openai_compatible` / `command` backendとして用意
- mock gateによるdry-run/e2eテストを追加

## 検証

- `.venv/bin/python -m ruff check src/utils/io.py src/utils/commands.py src/utils/video/sampling.py src/utils/video/youtube.py src/utils/video/__init__.py src/tasks/ball_detection/scripts/youtube/prepare_youtube_dataset.py src/tasks/court_detection/scripts/prepare_youtube_dataset.py src/tasks/ball_detection/scripts/youtube/prepare_dinov3_ssl_images.py tests/unit/utils/test_io.py tests/unit/utils/video/test_sampling.py tests/unit/utils/video/test_youtube.py tests/e2e/ball_detection/test_prepare_dinov3_ssl_images.py`
- `.venv/bin/python -m pytest --no-cov tests/unit/utils/test_io.py tests/unit/utils/video/test_sampling.py tests/unit/utils/video/test_youtube.py tests/e2e/ball_detection/test_prepare_dinov3_ssl_images.py`
- `.venv/bin/python -m mypy --follow-imports=skip src/utils/io.py src/utils/commands.py src/utils/video/sampling.py src/utils/video/youtube.py src/utils/video/__init__.py src/tasks/ball_detection/scripts/youtube/prepare_youtube_dataset.py src/tasks/court_detection/scripts/prepare_youtube_dataset.py src/tasks/ball_detection/scripts/youtube/prepare_dinov3_ssl_images.py tests/unit/utils/test_io.py tests/unit/utils/video/test_sampling.py tests/unit/utils/video/test_youtube.py tests/e2e/ball_detection/test_prepare_dinov3_ssl_images.py`
- 実行確認: mock gateで短尺YouTube動画1本から50枚を `data/tennis/dino_ssl/images` に保存

## 関連Issue

- Closes #565
- References #549

## 補足

- `Qwen3.5-0.8B LiteRT/ONNX INT8` はvLLMが直接読むモデル形式ではないため、実運用にはOpenAI互換HTTPサーバまたはCLI wrapperが必要です。このPRではpipeline側の呼び出し口を実装し、ローカルサーバ未起動環境では `workflow.gate.backend=mock` でdry-runできるようにしています。
