### PR TITLE
docs(worktree-create): link .venv into worktrees and guard against editing main

### DIFF
--- a/.agents/skills/worktree-create/SKILL.md
+++ b/.agents/skills/worktree-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: worktree-create
-description: Use this skill when creating a git worktree in Motoki0705/tennis-lab with Claude Code's native EnterWorktree tool. It is strictly for worktree creation and naming, and does not cover worktree removal or cleanup.
+description: Use this skill when creating a git worktree in Motoki0705/tennis-lab with Claude Code's native EnterWorktree tool. Covers worktree naming, the post-creation `.venv` symlink, and the guardrails that keep edits inside the worktree instead of accidentally hitting main. Does not cover worktree removal or cleanup.
 ---
 
 # Worktree Creation Workflow
@@ -9,7 +9,7 @@ description: Use this skill when creating a git worktree in Motoki0705/tennis-la
 
 Use this skill when the user (or project instructions) explicitly asks to start work in a git worktree in `Motoki0705/tennis-lab`. It standardizes how worktrees are **named** when created through Claude Code's native `EnterWorktree` tool.
 
-Scope is **creation and naming only**. Worktree removal/cleanup is intentionally out of scope and handled separately (for example, after the PR is merged).
+Scope is **creation, naming, and the first-touch setup that makes the new worktree safe to work in** — linking the project `.venv` and following the rules that keep edits inside the worktree rather than on `main`. Worktree removal/cleanup is intentionally out of scope and handled separately (for example, after the PR is merged).
 
 Use `.agents/skills/git-branch-create/SKILL.md` instead when the checkout is clean and the user only needs a branch in place.
 
@@ -57,12 +57,104 @@ Because a `/` becomes a `+` in both the directory and the branch, slashes produc
 EnterWorktree(name: "issue-533-experiment-log-format")
 ```
 
-3. The session switches into `.claude/worktrees/<name>/` on a new branch. Confirm the new working directory to the user.
-4. Optional — match the repository's PR branch convention (`<prefix>/issue-<n>-<topic>`): rename the auto-generated branch before pushing.
+3. The session switches into `.claude/worktrees/<name>/` on a new branch. **Confirm the new working directory to the user, and verify you are on the worktree branch — not `main`** (run the [location guard](#location-guard-run-before-your-first-edit)).
+4. **Link the project `.venv` into the worktree** so `.venv/bin/python` works — see [Post-creation setup](#post-creation-setup-link-the-project-venv).
+5. Optional — match the repository's PR branch convention (`<prefix>/issue-<n>-<topic>`): rename the auto-generated branch before pushing.
 
 ```bash
 git branch -m feat/issue-533-experiment-log-format
 ```
+
+## Post-creation setup: link the project `.venv`
+
+`EnterWorktree` checks out a clean tree, but `.venv/` is gitignored, so a fresh
+worktree has **no `.venv`** and the project-mandated `.venv/bin/python`
+(see `AGENTS.md`) is missing. Link the main repository's interpreter in as the
+first thing you do after entering:
+
+```bash
+# from inside .claude/worktrees/<name>/
+ln -s ../../../.venv .venv     # relative: worktree -> main repo root is 3 levels up
+```
+
+- `../../../.venv` resolves to `<repo-root>/.venv` from any
+  `.claude/worktrees/<name>/`.
+- The symlink is **already ignored** (`.git/info/exclude` carries `/.venv`), so it
+  never appears in `git status` and cannot be committed by accident — verified.
+- Absolute form works too: `ln -s <repo-root>/.venv .venv` (e.g.
+  `ln -s /home/kamimura/projects/tennis-lab/.venv .venv`). The relative form
+  survives the repo being cloned to a different path; the absolute form does not.
+- Verify: `.venv/bin/python --version` prints the same version as the main tree.
+
+## Never edit `main` from inside a worktree
+
+**Why this is a real hazard here.** In this repo, worktrees live *inside* the main
+working tree at `.claude/worktrees/<name>/` (not as sibling directories). So the
+**same relative path means two different files** depending on the current
+directory:
+
+| current directory | what `src/foo.py` resolves to |
+| --- | --- |
+| `<repo-root>` | the **main** tree's file |
+| `<repo-root>/.claude/worktrees/<name>` | the **worktree**'s file |
+
+An agent that *believes* it is "in the worktree" but whose working directory is
+actually the repo root will silently edit `main`. This already happened in a Codex
+session: relative-path edits intended for the worktree landed on `main`.
+
+The two ecosystems establish the working root differently, so the rule is split.
+
+### Claude Code
+
+- `EnterWorktree` switches the session's working directory **into** the worktree,
+  and the built-in `Read`/`Edit`/`Write` tools take **absolute** paths. As long as
+  you address files by their **worktree-rooted absolute path**
+  (`<repo-root>/.claude/worktrees/<name>/...`), edits stay in the worktree.
+- **Do not reuse a bare `<repo-root>/...` path** (for example one you read earlier
+  from the main tree) while working in a worktree — that path points at `main`.
+  Re-`Read` the worktree copy, then edit that path.
+- For shell work prefer `git -C <worktree>` and worktree-rooted paths; avoid
+  `cd <repo-root>` (or `cd ../../..`), which silently puts you back on `main`.
+
+### Codex CLI
+
+- Codex's working root is whatever `--cd`/`-C` points at. `scripts/codex-auto.sh`
+  defaults to `--dir .` (the directory you launch it from) and does
+  `cd "$WORKDIR"` before running. Launched from the repo root **without** `--dir`,
+  Codex's entire context — including relative `apply_patch` edits — is the **main**
+  tree.
+- Codex trusts this repo with `danger-full-access` (`~/.codex/config.toml`), so
+  there is **no sandbox** stopping a cross-tree write; the working directory is the
+  only guard.
+- When the work belongs to a worktree, point Codex at it explicitly:
+
+  ```bash
+  .agents/skills/agent-auto/scripts/codex-auto.sh \
+    --dir /home/kamimura/projects/tennis-lab/.claude/worktrees/<name> \
+    "…task…"
+  ```
+
+  For an interactive Codex session, `cd` into the worktree first (or launch
+  `codex --cd <worktree>`). Never run Codex for worktree work from the repo root.
+- `codex-auto.sh` already prefers `$WORKDIR/.venv/bin/python`, so the `.venv`
+  symlink above also fixes Codex's Python resolution inside the worktree.
+
+### Location guard (run before your first edit)
+
+A cheap assertion that you are in the worktree, not on `main`:
+
+```bash
+top=$(git rev-parse --show-toplevel)
+case "$top" in
+  */.claude/worktrees/*) echo "OK: worktree -> $top" ;;
+  *) echo "STOP: cwd is the MAIN tree ($top); do not edit here"; exit 1 ;;
+esac
+git rev-parse --abbrev-ref HEAD   # must be the worktree branch, never 'main'
+```
+
+For `isolation: "worktree"` sub-agents, also keep the **base-check** guard in mind:
+such agents may branch from `main` and miss your foundation commits — have them
+confirm `git log --oneline -3` before relying on the base.
 
 ## Notes
 


### PR DESCRIPTION
## What & why

Two problems hit agents working in `.claude/worktrees/<name>/`. This PR fixes both in `.agents/skills/worktree-create/SKILL.md` (the skill is the right home since both are first-touch, at-creation concerns).

### Problem 1 — a fresh worktree has no `.venv`
`.venv/` is gitignored, so `EnterWorktree` produces a tree with no `.venv`, and the project-mandated `.venv/bin/python` (`AGENTS.md`) is missing. Added a post-creation step:
```bash
ln -s ../../../.venv .venv     # worktree -> main repo root is 3 levels up
```

### Problem 2 — accidental edits land on `main`
In a recent **Codex** session, relative-path edits intended for a worktree silently rewrote files on `main`. Added a "Never edit `main` from inside a worktree" section with per-ecosystem rules and a copy-paste location guard.

## Investigation: how the two ecosystems handle worktrees & cwd

**Structural amplifier (this repo specifically).** Worktrees are created by Claude Code's native `EnterWorktree` at `.claude/worktrees/<name>/` — i.e. **nested inside the main working tree**, not as siblings. Consequence: the *same relative path* resolves to a different file depending on the current directory.

| current directory | `src/foo.py` resolves to |
| --- | --- |
| `<repo-root>` | the **main** tree |
| `<repo-root>/.claude/worktrees/<name>` | the **worktree** |

So an agent that believes it is "in the worktree" but whose cwd is the repo root silently edits `main`.

**Claude Code.** `EnterWorktree` switches the session cwd **into** the worktree, and `Read`/`Edit`/`Write` take **absolute** paths — safe *as long as* the path is worktree-rooted. The trap is reusing a `<repo-root>/...` absolute path read earlier from the main tree (points at `main`), or `cd`-ing back to the repo root for shell work.

**Codex CLI** (`.agents/skills/agent-auto/scripts/codex-auto.sh`). Codex's working root is whatever `--cd`/`-C` points at. The wrapper defaults to `--dir .` (the launch directory) and does `cd "$WORKDIR"` before running. **Launched from the repo root without `--dir`, Codex's entire context — including relative `apply_patch` edits — is the main tree.** Codex also trusts this repo with `danger-full-access` (`~/.codex/config.toml`), so there is no sandbox stopping a cross-tree write; the working directory is the only guard. (`codex-auto.sh`'s `agent_auto_pick_python` already prefers `$WORKDIR/.venv/bin/python`, so the Problem 1 symlink also fixes Codex's Python resolution in the worktree.)

## Rationale for the chosen mechanisms
- **Relative `.venv` symlink** over absolute: survives the repo being cloned to a different path. Verified it resolves to the main interpreter and is **already ignored** by `.git/info/exclude:/.venv`, so it never appears in `git status` or gets committed.
- **Per-ecosystem rules + a location guard** rather than a hard hook: Claude Code skills can only *recommend*, and Codex reads `AGENTS.md`/SKILL docs, so documented rules + a cheap copy-paste assertion (`git rev-parse --show-toplevel` must be under `.claude/worktrees/`, branch must not be `main`) is the most portable guard that works for both. Cross-linked the existing `isolation: "worktree"` sub-agent base-check pitfall.

## Validation (dogfooded)
This PR was authored from a worktree created via `EnterWorktree`, applying the documented steps:
- `ln -s ../../../.venv .venv` → `.venv/bin/python --version` = `3.11.15` (same as main), not shown in `git status`.
- Location guard prints `OK` from the worktree and `STOP` (exit 1) from the repo root.
- Edits were made to the **worktree's** `SKILL.md` path, not the main-root path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)