### PR TITLE
docs(worktree-create): worktree への .venv リンクと main 誤編集ガードを追加

### DIFF
--- a/.agents/skills/worktree-create/SKILL.md
+++ b/.agents/skills/worktree-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: worktree-create
-description: Use this skill when creating a git worktree in Motoki0705/tennis-lab with Claude Code's native EnterWorktree tool. It is strictly for worktree creation and naming, and does not cover worktree removal or cleanup.
+description: Use this skill when creating a git worktree in Motoki0705/tennis-lab with Claude Code's native EnterWorktree tool. Covers naming, the post-creation `.venv` symlink, and the guardrails that keep edits inside the worktree instead of accidentally landing on `main` (for both Claude Code and Codex). Does not cover worktree removal or cleanup.
 ---
 
 # Worktree Creation Workflow
@@ -9,7 +9,7 @@ description: Use this skill when creating a git worktree in Motoki0705/tennis-la
 
 Use this skill when the user (or project instructions) explicitly asks to start work in a git worktree in `Motoki0705/tennis-lab`. It standardizes how worktrees are **named** when created through Claude Code's native `EnterWorktree` tool.
 
-Scope is **creation and naming only**. Worktree removal/cleanup is intentionally out of scope and handled separately (for example, after the PR is merged).
+Scope is **creation, naming, and the first-touch setup that makes a new worktree safe to work in** — linking the project `.venv` and following the guardrails that keep edits inside the worktree rather than on `main`. Worktree removal/cleanup is intentionally out of scope and handled separately (for example, after the PR is merged).
 
 Use `.agents/skills/git-branch-create/SKILL.md` instead when the checkout is clean and the user only needs a branch in place.
 
@@ -57,12 +57,126 @@ Because a `/` becomes a `+` in both the directory and the branch, slashes produc
 EnterWorktree(name: "issue-533-experiment-log-format")
 ```
 
-3. The session switches into `.claude/worktrees/<name>/` on a new branch. Confirm the new working directory to the user.
-4. Optional — match the repository's PR branch convention (`<prefix>/issue-<n>-<topic>`): rename the auto-generated branch before pushing.
+3. The session switches into `.claude/worktrees/<name>/` on a new branch. Confirm the new working directory to the user, and run the [location guard](#location-guard) to verify you are on the worktree branch — not `main`.
+4. **Link the project `.venv` into the worktree** so `.venv/bin/python` works — see [Post-creation setup](#post-creation-setup-link-the-project-venv).
+5. Optional — match the repository's PR branch convention (`<prefix>/issue-<n>-<topic>`): rename the auto-generated branch before pushing.
 
 ```bash
 git branch -m feat/issue-533-experiment-log-format
 ```
+
+## Post-creation setup: link the project `.venv`
+
+`EnterWorktree` checks out a clean tree, but `.venv/` is gitignored, so a fresh
+worktree has **no `.venv`** and the project-mandated `.venv/bin/python` (`AGENTS.md`)
+is missing. Link the main repository's interpreter in as the first thing you do
+after entering the worktree:
+
+```bash
+# from inside .claude/worktrees/<name>/
+ln -s ../../../.venv .venv     # relative: a worktree sits 3 levels below the repo root
+```
+
+- `../../../.venv` resolves to `<repo-root>/.venv` from any `.claude/worktrees/<name>/`.
+- The symlink is **already ignored** (`.git/info/exclude` carries `/.venv`), so it
+  never appears in `git status` and cannot be committed by accident — verified.
+- The absolute form works too (`ln -s /home/kamimura/projects/tennis-lab/.venv .venv`),
+  but the relative form survives the repo being cloned to a different path.
+- Verify: `.venv/bin/python --version` prints the same version as the main tree.
+- This also fixes **Codex**: `codex-auto.sh` prefers `$WORKDIR/.venv/bin/python`, so the
+  symlink gives Codex the right interpreter inside the worktree.
+
+## Never edit `main` from inside a worktree
+
+**Why this is a real hazard here.** Worktrees live *inside* the main working tree at
+`.claude/worktrees/<name>/` (not as siblings). So the **same relative path is two
+different files** depending on the current working directory:
+
+| working directory | what `src/foo.py` resolves to |
+| --- | --- |
+| `<repo-root>` | the **main** tree's file |
+| `<repo-root>/.claude/worktrees/<name>` | the **worktree**'s file |
+
+An agent that *believes* it is "in the worktree" but whose working directory is the
+repo root silently edits `main`. This already happened in a Codex session: relative
+edits intended for a worktree landed on `main`. The two ecosystems establish the
+working root differently, so the rules differ. (The behaviour below was verified on
+2026-06-25; Codex's was confirmed by having Codex itself investigate via a read-only
+`codex-auto.sh` run.)
+
+### Claude Code
+
+- **`EnterWorktree` relocates the whole session into the worktree** — verified: after
+  entering, `pwd`, `git rev-parse --show-toplevel`, and the Bash tool's cwd all point
+  at `.claude/worktrees/<name>/`, on the worktree branch. So relative paths and shell
+  commands are safe **as long as you stay in that session**.
+- Residual hazards to avoid:
+  - **Stale absolute paths.** A `<repo-root>/…` absolute path you `Read` *before*
+    entering still points at `main`. Don't reuse it — re-`Read` the worktree copy
+    (`<repo-root>/.claude/worktrees/<name>/…`) and edit *that* path. (The built-in
+    file tools track state per exact path, so an `Edit` keyed on the main-tree path
+    edits `main`.)
+  - **`cd` back to the repo root** (or `cd ../../..`) for shell work silently puts you
+    back on `main`. Prefer `git -C <worktree>` and worktree-rooted paths.
+  - **Pinned-cwd sub-agents.** A sub-agent launched with `isolation`/an explicit cwd
+    does *not* inherit your worktree; its cwd is pinned at launch. Give it the
+    worktree's absolute path explicitly, and keep the base-check guard (below) in mind.
+
+### Codex CLI
+
+Verified by Codex's own read-only investigation (`codex-auto.sh` self-report):
+
+- **Codex has no git-worktree awareness.** Its working root is whatever `-C`/`--cd`
+  points at; relative shell *and* `apply_patch` edit paths resolve from that root.
+  Nothing redirects a relative path into a different worktree.
+- `codex-auto.sh` defaults `--dir .` (the launch directory) and runs `codex exec -C
+  "$WORKDIR"`. **Launched from the repo root without `--dir`, Codex's entire context —
+  including relative edits — is the `main` tree.** That is exactly how the accident
+  happened.
+- **No sandbox stops it by default**: `~/.codex/config.toml` sets
+  `sandbox_mode = "danger-full-access"` and trusts this repo, so the working directory
+  is the *only* guard.
+- **Reliable mechanism** (Codex's own recommendation): for worktree work, always pass
+  the worktree path *and* keep the default workspace-write sandbox:
+
+  ```bash
+  .agents/skills/agent-auto/scripts/codex-auto.sh \
+    --dir /home/kamimura/projects/tennis-lab/.claude/worktrees/<name> \
+    --sandbox workspace-write \
+    "…task…"
+  ```
+
+  - `--dir <worktree>` sets `-C` to the worktree, so relative edits land there.
+  - `--sandbox workspace-write` confines writes to the **primary workspace** (the
+    `-C` directory). Because the worktree is a *child* of the repo root, the parent
+    `main` tree is then **not writable** — this alone would have prevented the accident.
+    Do **not** add `--dangerous`: it selects `danger-full-access` and removes this
+    confinement. (`--sandbox workspace-write` is already the wrapper's default.)
+  - For an interactive session, `codex --cd <worktree>` (or `cd` in first). Never run
+    Codex for worktree work from the repo root.
+
+### Location guard
+
+Run this before the first edit (Claude: in Bash; Codex: as a pre-flight on the same
+path you pass to `--dir`). It refuses the main tree and the `main`/`master` branch:
+
+```bash
+.agents/skills/worktree-create/scripts/worktree-guard.sh [DIR]   # DIR defaults to cwd
+```
+
+Inline equivalent if you can't call the script:
+
+```bash
+top=$(git -C "${DIR:-$PWD}" rev-parse --show-toplevel)
+case "$top" in
+  */.claude/worktrees/*) echo "OK: worktree -> $top" ;;
+  *) echo "STOP: cwd is the MAIN tree ($top); do not edit here"; exit 1 ;;
+esac
+```
+
+For `isolation: "worktree"` sub-agents, also keep the **base-check** in mind: they may
+branch from `main` and miss your foundation commits — have them confirm
+`git log --oneline -3` before relying on the base.
 
 ## Notes
 
@@ -70,3 +184,4 @@ git branch -m feat/issue-533-experiment-log-format
 - Always pass an explicit `name`. If neither `name` nor `path` is given, `EnterWorktree` generates a random name that will not follow this convention.
 - To enter an existing worktree instead of creating one, pass `path` (must appear in `git worktree list` for this repo) rather than `name`.
 - **Removal is out of scope.** Do not call `ExitWorktree(remove)` as part of this skill. A worktree entered via `path` cannot be removed by `ExitWorktree` anyway; cleanup of merged worktrees is done separately with `git worktree remove <path>`.
+- **Enforcement posture.** For Codex the guard is *real*: `--dir <worktree>` + workspace-write makes the sandbox refuse writes outside the worktree. For Claude Code there is no built-in confinement, so the rules above are advisory — a skill can only recommend. Hard enforcement on the Claude side would require a `PreToolUse` hook in `settings.json` rejecting `Edit`/`Write` targets outside the session's worktree; that is deliberately left out of this skill (settings/hook change, broader blast radius) and can be added separately if accidental main edits keep happening.

--- a/.agents/skills/worktree-create/scripts/worktree-guard.sh
+++ b/.agents/skills/worktree-create/scripts/worktree-guard.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# worktree-guard.sh — assert that a directory is a tennis-lab git *worktree*, not the
+# main tree, before anything edits there.
+#
+# Why: worktrees in this repo are nested at <repo-root>/.claude/worktrees/<name>/, so
+# the same relative path resolves to a different file depending on the working
+# directory. An agent that thinks it is "in the worktree" but whose working dir is the
+# repo root silently edits `main`. This guard is the cheap pre-flight that catches it.
+#
+# Usage:
+#   worktree-guard.sh [DIR]        # DIR defaults to the current directory
+#
+# Exit codes:
+#   0  DIR is a worktree under .claude/worktrees/ on a non-main branch -> safe to edit
+#   1  DIR is the main tree, or on main/master                         -> STOP
+#   2  DIR is not inside a git repository / bad usage
+#
+# Claude Code: run in Bash before your first edit after EnterWorktree.
+# Codex CLI:   run as a pre-flight on the same DIR you pass to `codex exec -C DIR`
+#              (i.e. `codex-auto.sh --dir DIR`).
+set -euo pipefail
+
+DIR="${1:-$PWD}"
+
+if ! top="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "STOP: '$DIR' is not inside a git repository" >&2
+  exit 2
+fi
+branch="$(git -C "$DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+
+case "$top" in
+  */.claude/worktrees/*)
+    if [[ "$branch" == "main" || "$branch" == "master" ]]; then
+      echo "STOP: worktree '$top' is on '$branch' — refusing to edit main/master" >&2
+      exit 1
+    fi
+    echo "OK: worktree -> $top (branch: $branch)"
+    ;;
+  *)
+    echo "STOP: '$top' is the MAIN tree (branch: $branch); do not edit here." >&2
+    echo "      For worktree work, point your working dir / --dir at" >&2
+    echo "      <repo-root>/.claude/worktrees/<name>/ instead." >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## 概要

`.claude/worktrees/<name>/` で作業する際に発生する2つの「最初の一手」の問題を、`worktree-create` スキルで解決します。

- **問題1: `.venv` が無い** — 新規 worktree は gitignore された `.venv` を持たないため、プロジェクト指定の `.venv/bin/python`（`AGENTS.md`）が使えない。
- **問題2: 誤って `main` を編集する** — worktree は main ツリーの内側 (`.claude/worktrees/<name>/`) にネストしているため、相対パスが cwd 次第で別ファイルを指し、worktree のつもりの編集が `main` に着弾し得る（直近の Codex セッションで実際に発生）。

> 補足: 同主旨の旧 PR #569 はクローズ済み。本 PR は **Claude / Codex 両エコシステムの挙動を実際に調査・実証**し直したうえで、ドキュメントだけでなく**再利用可能なガードと、サンドボックスによる実効的な防御**まで含めて作り直したものです。

## 変更内容

- `.agents/skills/worktree-create/SKILL.md`
  - 「Post-creation setup: link the project `.venv`」節を追加。entering 直後に `ln -s ../../../.venv .venv`（相対）でメインの interpreter をリンクする手順。`.git/info/exclude:/.venv` で無視済みのためコミットされない旨も明記。
  - 「Never edit `main` from inside a worktree」節を追加。なぜネスト構造が危険か（相対パス解決表）と、**Claude Code / Codex CLI それぞれの挙動に即した個別ルール**を記載。
  - 「Location guard」とスコープ/説明文・標準ワークフローの手順を更新。Notes に「enforcement posture（強制力の所在）」を追記。
- `.agents/skills/worktree-create/scripts/worktree-guard.sh`（新規, 実行可能）
  - main ツリー / `main`・`master` ブランチを拒否する pre-flight ガード。Claude は Bash で、Codex は `--dir` に渡すのと同じパスに対する pre-flight として利用可能。exit 0=worktree / 1=main / 2=非gitrepo。

## 調査結果（エコシステムの現状）と対策の根拠

**構造的な増幅要因（本リポジトリ固有）**: worktree は兄弟ディレクトリではなく main ツリーの**内側**に作られる。よって同一の相対パスが cwd により別ファイルを指す。

| 作業ディレクトリ | `src/foo.py` の指す先 |
| --- | --- |
| `<repo-root>` | **main** ツリー |
| `<repo-root>/.claude/worktrees/<name>` | **worktree** |

**Claude Code（実証済み）**: `EnterWorktree` はセッション全体（`pwd` / `git rev-parse --show-toplevel` / Bash ツールの cwd）を worktree 配下へ移す。本 PR 作成時にもそれを確認済み。よって相対パス・シェルは安全。残存リスクは (a) entering 前に `Read` した `<repo-root>/...` の**絶対パスの使い回し**（built-in ツールはパス単位で状態追跡するため main を編集してしまう）、(b) **cwd 固定のサブエージェント**（`isolation`/明示 cwd は worktree を継承しない）。→ worktree ルートの絶対パスを使う・worktree のコピーを `Read` し直す、をルール化。

**Codex CLI（`codex-auto.sh` で Codex 自身に read-only 調査させ確認）**:
- Codex に **git worktree の認識は無い**。作業ルートは `-C`/`--cd` が全て。相対シェルも相対 `apply_patch` も**そのルート基準**で解決される。
- `codex-auto.sh` は既定 `--dir .`（起動ディレクトリ）で `codex exec -C "$WORKDIR"`。**repo root から `--dir` 無しで起動すると、相対編集を含む文脈すべてが main ツリー**になる ＝ 事故の発生機序。
- `~/.codex/config.toml` は当リポジトリに対し `sandbox_mode = "danger-full-access"` + `trusted`。**既定では cross-tree 書き込みを止めるサンドボックス境界が無い**＝作業ディレクトリだけが唯一のガード。`approval_policy="never"` はパス解決に無関係。
- **対策の根拠**: `codex exec --help` より `--sandbox workspace-write` は書き込みを「primary workspace（＝ `-C` ディレクトリ）」に限定する。worktree は repo root の**子**なので、`--dir <worktree>` を指定すれば親の main は**書き込み不可**になり、事故を実効的に防げる（Codex 自身の推奨でもある）。よって worktree 作業では `--dir <worktree>` ＋ 既定の `workspace-write` を使い、`--dangerous`（= `danger-full-access`、この限定を解除する）は使わない、と規定。

```bash
.agents/skills/agent-auto/scripts/codex-auto.sh \
  --dir /home/kamimura/projects/tennis-lab/.claude/worktrees/<name> \
  --sandbox workspace-write \
  "…task…"
```

**強制力の所在**: Codex 側はサンドボックスによる**実効的な強制**になる。Claude 側は built-in の閉じ込めが無く、スキルは推奨しかできないため本 PR のルールは助言的。Claude で完全強制したい場合は `settings.json` の `PreToolUse` フックが必要だが、影響範囲が広いため本スキルからは意図的に除外（Notes に明記、必要なら別途追加可能）。

## 検証

- 本 PR は `EnterWorktree` で作成した worktree 内で、追加した手順を**ドッグフーディング**して作成。
  - `ln -s ../../../.venv .venv` → `.venv/bin/python --version` = `3.11.15`（main と一致）。`git status` に現れず（`.git/info/exclude:/.venv` で無視）。
  - `EnterWorktree` 後の `pwd` / `git rev-parse --show-toplevel` / branch がいずれも worktree を指すことを実測。
  - `worktree-guard.sh`: worktree から `OK`(exit 0)、main ツリー指定で `STOP`(exit 1)、非 git ディレクトリで exit 2 を確認。
  - `bash -n worktree-guard.sh` 構文チェック OK。
- Codex の挙動は `codex-auto.sh --sandbox read-only` での Codex 自己調査（`turn.completed`, 成功）で確認。

## 関連Issue

- References #569

## 補足

- スキルの「命名」「削除はスコープ外」という既存方針は変更していません（追加分は最初の一手のセットアップとガードのみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
