### PR TITLE
feat(skills): experiment-result-pr の discovery ヘルパー + kg_curves 高速化

### DIFF
--- a/.agents/skills/experiment-result-pr/SKILL.md
+++ b/.agents/skills/experiment-result-pr/SKILL.md
@@ -30,23 +30,29 @@ Identify the latest requested "next step" and the expected queue job names or co
 
 2. Work in a worktree.
 
-- Prefer an existing clean worktree for the same issue/PR.
+- Prefer an existing clean worktree for the same issue/PR; if its branch is already merged, branch fresh off `origin/main` inside it (don't commit onto the merged branch).
 - Otherwise create one using the `worktree-create` naming convention, then rename the branch to the repo convention if useful.
-- Do not edit from the main checkout.
+- Do not edit from the main checkout. A linked worktree's `.training_queue` / `.venv` are symlinks to the main checkout and are **not** gitignored there — never `git add -A`; stage `knowledge/` and other intended files explicitly.
 
 3. Locate finished queue artifacts.
 
-Check `.training_queue/repro/` and `.training_queue/logs/` for matching job names. If the active worktree does not have `.training_queue` or `.venv`, add local ignored symlinks to the main checkout equivalents so project commands still use `.venv/bin/python`.
+If the worktree lacks `.training_queue` / `.venv`, symlink them to the main checkout first. Then list the issue's finished runs **by run.json issue field** (not job name — one queue batch can mix issues):
+
+```bash
+.venv/bin/python .agents/skills/experiment-result-pr/scripts/discover_runs.py --issue <issue>
+```
+
+It marks status / predictions / already-registered, prints a ready-to-paste `kg_register.py` line per run, and flags jobs named `i<issue>…` that actually belong to another issue. Register only the runs it lists for this issue.
 
 4. Register every finished run.
 
-For each job:
+Run the lines `discover_runs.py` printed (`--provider` is taken from run.json; add `--id <run-id>` only to override the default `run-<name>`):
 
 ```bash
-.venv/bin/python .agents/skills/knowledge-control/scripts/kg_register.py <job-name> --issue <issue> --provider codex --id <run-id>
+.venv/bin/python .agents/skills/knowledge-control/scripts/kg_register.py <job-name> --issue <issue> --provider <from run.json>
 ```
 
-If the queue artifact is outside the worktree, pass `--repro-dir <path>`.
+If the queue artifact is outside the worktree, pass `--repro-dir <path>`. Registration records `artifacts.output_dir`, so `kg_curves` resolves the run's TensorBoard directly instead of scanning every event file.
 
 5. Write knowledge findings.
 
@@ -83,7 +89,7 @@ Use `gh issue comment <issue> --repo Motoki0705/tennis-lab --body-file <tmpfile>
 
 ## Validation Checklist
 
-- `git status --short --branch` is clean except intended changes before committing.
+- `git status --short --branch` is clean except intended changes before committing (the `.training_queue` symlink must stay unstaged).
 - `kg_validate.py` exits 0.
 - Every new run has `knowledge/runs/<run-id>/{run.json,repro.sh,metrics.json,pred_test.npz}`.
 - Every new run has a findings body and meaningful graph links.

--- a/.agents/skills/experiment-result-pr/scripts/discover_runs.py
+++ b/.agents/skills/experiment-result-pr/scripts/discover_runs.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+"""List finished training-queue runs for a GitHub issue (experiment-result-pr step 3).
+
+Filters queue jobs by the ``issue`` field recorded in each job's ``run.json`` —
+not by job name — so a batch that mixes issues (e.g. ``i545_*`` jobs actually
+tagged ``issue: 560``) is split correctly. For the target issue it shows each
+job's status, whether its test-split predictions exist, whether it is already
+registered under ``knowledge/``, and a ready-to-paste ``kg_register.py`` line
+(provider taken from run.json). Jobs whose *name* implies the issue but whose
+``run.json`` issue differs are flagged separately so they are not mis-registered.
+
+Usage:
+    .venv/bin/python .agents/skills/experiment-result-pr/scripts/discover_runs.py --issue 545
+    .venv/bin/python .agents/skills/experiment-result-pr/scripts/discover_runs.py --issue 545 --json
+
+Notes:
+    - Run from the repo root; reads .training_queue/ and knowledge/ (honors KNOWLEDGE_DIR).
+    - "done" jobs with predictions that are not yet registered are the ones to register.
+    - Registration is detected by the job id appearing in a knowledge node's artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+KG_REGISTER = ".agents/skills/knowledge-control/scripts/kg_register.py"
+NAME_ISSUE_RE = re.compile(r"\bi(\d+)")
+LOG_JOBID_RE = re.compile(r"logs/(\d+_\d+_\S+?)\.log")
+
+
+def repo_root() -> Path:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        return Path(out)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path.cwd()
+
+
+ROOT = repo_root()
+QUEUE = ROOT / ".training_queue"
+KNOWLEDGE = Path(os.environ.get("KNOWLEDGE_DIR") or ROOT / "knowledge")
+
+
+def job_status(jobid: str) -> str:
+    for sub in ("running", "done", "failed", "jobs"):
+        if (QUEUE / sub / f"{jobid}.job").exists():
+            return "pending" if sub == "jobs" else sub
+    return "?"
+
+
+def registered_jobids() -> set[str]:
+    """Job ids already promoted into the graph (a node records logs/<jobid>.log)."""
+    nodes = KNOWLEDGE / "nodes"
+    if not nodes.exists():
+        return set()
+    blob = "\n".join(p.read_text(encoding="utf-8", errors="replace") for p in nodes.glob("*.md"))
+    return set(LOG_JOBID_RE.findall(blob))
+
+
+def collect() -> list[dict]:
+    repro = QUEUE / "repro"
+    if not repro.exists():
+        return []
+    reg = registered_jobids()
+    rows: list[dict] = []
+    for rj in sorted(repro.glob("*/run.json")):
+        jobid = rj.parent.name
+        try:
+            data = json.loads(rj.read_text(encoding="utf-8"))
+        except (ValueError, OSError):
+            data = {}
+        name = data.get("name") or jobid
+        m = NAME_ISSUE_RE.search(name)
+        rows.append({
+            "jobid": jobid,
+            "name": name,
+            "issue": str(data.get("issue") or "").strip(),
+            "name_issue": m.group(1) if m else "",
+            "provider": data.get("provider") or "",
+            "status": job_status(jobid),
+            "preds": (rj.parent / "predictions" / "metrics.json").exists(),
+            "registered": jobid in reg,
+        })
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--issue", required=True, help="target issue number")
+    ap.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = ap.parse_args()
+    issue = str(args.issue).lstrip("#")
+
+    rows = collect()
+    mine = [r for r in rows if r["issue"] == issue]
+    misfiled = [r for r in rows if r["name_issue"] == issue and r["issue"] != issue]
+
+    if args.json:
+        print(json.dumps({"issue": issue, "runs": mine, "misfiled": misfiled},
+                         indent=2, ensure_ascii=False))
+        return 0
+
+    if not mine:
+        print(f"no queue runs with run.json issue == {issue}")
+    else:
+        print(f"issue #{issue} — {len(mine)} queue run(s) (by run.json issue field)\n")
+        print(f"  {'STATUS':7} {'PREDS':5} {'REG':3} {'PROVIDER':8} NAME")
+        for r in sorted(mine, key=lambda r: r["jobid"]):
+            print(f"  {r['status']:7} {('yes' if r['preds'] else 'no'):5} "
+                  f"{('yes' if r['registered'] else '-'):3} {r['provider']:8} {r['name']}")
+        todo = [r for r in mine if r["status"] == "done" and r["preds"] and not r["registered"]]
+        if todo:
+            print("\nto register (done + predictions + not yet registered):")
+            for r in todo:
+                prov = f" --provider {r['provider']}" if r["provider"] else ""
+                print(f"  .venv/bin/python {KG_REGISTER} {r['name']} --issue {issue}{prov}")
+
+    if misfiled:
+        print(f"\n⚠ named 'i{issue}…' but run.json issue differs — do NOT register under #{issue}:")
+        for r in sorted(misfiled, key=lambda r: r["jobid"]):
+            print(f"  {r['name']:32} issue={r['issue'] or '?'}")
+        print("  → register these under their own issue (discover_runs.py --issue <that-issue>)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/knowledge-control/scripts/kg_curves.py
+++ b/.agents/skills/knowledge-control/scripts/kg_curves.py
@@ -9,6 +9,11 @@ directory, then plots the train/val curves (loss + headline errors) into
 ``knowledge/runs/<id>/curves.png`` and records ``artifacts.curves`` /
 ``artifacts.tb_logdir`` in the node so the webui can show it.
 
+As a fast path, a node that already records ``artifacts.tb_logdir`` or
+``artifacts.output_dir`` (kg_register fills the latter from the run's
+``output_dir.txt``) resolves its event dir directly — the repo-wide fingerprint
+scan only runs for older nodes that have neither. ``--refresh`` forces the scan.
+
 The goal is qualitative: *see how a run converged* when clicking a node.
 
 If no event directory matches a node's metrics within tolerance, the node is
@@ -244,7 +249,11 @@ def match_event_dir(
         if matched / len(shared) < MIN_MATCH_FRAC:
             continue
         mean_err = sum(rel) / len(rel)
-        # prefer more matched keys, then lower error
+        # a near-exact match on every shared key is the run itself; stop scanning
+        # (avoids reading the remaining event dirs).
+        if matched == len(shared) and mean_err < REL_TOL / 10:
+            return (d, mean_err, matched)
+        # otherwise prefer more matched keys, then lower error
         if (matched, -mean_err) > (best[2], -best[1]):
             best = (d, mean_err, matched)
     return best
@@ -377,13 +386,21 @@ def main() -> int:
     p.add_argument("--dry-run", action="store_true", help="report matches; write no files")
     args = p.parse_args()
 
-    roots = default_scan_roots() + [r.resolve() for r in args.scan_roots if r.exists()]
-    if not roots:
-        print("no scan roots exist; nothing to do", file=sys.stderr)
-        return 1
-    print(f"scan roots: {', '.join(rel(r) for r in roots)}")
-    event_dirs = find_event_dirs(roots)
-    print(f"found {len(event_dirs)} event dirs")
+    extra_roots = [r.resolve() for r in args.scan_roots if r.exists()]
+
+    # Scanning every event file under the repo + worktrees is the slow part, so
+    # build the fingerprint index lazily — only once a node has no fast path hint
+    # (artifacts.tb_logdir / artifacts.output_dir) to resolve directly. Nodes
+    # registered with an output_dir never trigger it.
+    _index: dict[str, list[Path]] = {}
+
+    def event_dirs_index() -> list[Path]:
+        if "dirs" not in _index:
+            roots = default_scan_roots() + extra_roots
+            print(f"scan roots: {', '.join(rel(r) for r in roots)}")
+            _index["dirs"] = find_event_dirs(roots)
+            print(f"found {len(_index['dirs'])} event dirs")
+        return _index["dirs"]
 
     all_nodes = {n.id: n for n in load_nodes()}
     if args.all:
@@ -409,20 +426,24 @@ def main() -> int:
         }
         artifacts = node.meta.get("artifacts") or {}
         event_dir: Path | None = None
-        if not args.refresh and artifacts.get("tb_logdir"):
-            cand = repo_root() / str(artifacts["tb_logdir"])
-            if cand.exists():
-                event_dir = cand
+        # Fast paths first (no global scan): the cached tb_logdir, then the
+        # output_dir/checkpoint path recorded at registration. --refresh forces
+        # the fingerprint scan to re-derive from scratch.
+        if not args.refresh:
+            if artifacts.get("tb_logdir"):
+                cand = repo_root() / str(artifacts["tb_logdir"])
+                if cand.exists():
+                    event_dir = cand
+            if event_dir is None:
+                event_dir = path_hint_event_dir(artifacts, bases)
+                if event_dir is not None:
+                    print(f"  hint  {node.id}: {rel(event_dir)} (from artifacts path)")
+        # Fallback: fingerprint the run by its test/* metrics (builds the event
+        # index lazily). Needed for older nodes with no output_dir recorded.
         if event_dir is None and metrics:
-            event_dir, err, matched = match_event_dir(metrics, event_dirs)
+            event_dir, err, matched = match_event_dir(metrics, event_dirs_index())
             if event_dir is not None:
                 print(f"  match {node.id}: {rel(event_dir)} ({matched} keys, {err*100:.2f}% mean err)")
-        if event_dir is None:
-            # fallback: runs without test/* scalars (e.g. court seg) record their
-            # output_dir directly, so resolve the event dir from that path hint.
-            event_dir = path_hint_event_dir(artifacts, bases)
-            if event_dir is not None:
-                print(f"  hint  {node.id}: {rel(event_dir)} (from artifacts path)")
         if event_dir is None:
             print(f"  skip {node.id}: no event dir matched its metrics or path hints")
             skipped += 1

--- a/.agents/skills/knowledge-control/scripts/kg_register.py
+++ b/.agents/skills/knowledge-control/scripts/kg_register.py
@@ -40,8 +40,27 @@ QUEUE_DIR = repo_root() / ".training_queue"
 OVERRIDE_RE = re.compile(r"(?:^|\s)([\w.]+)=([^\s]+)")
 CONFIG_KEYS = ("model", "loss", "data")
 METRIC_ROW_RE = re.compile(r"^[│|]\s*(test/\S+)\s*[│|]\s*([0-9.eE+-]+)\s*[│|]\s*$")
-BUNDLE_FILES = ("run.json", "repro.sh", "uncommitted.patch", "git_status.txt")
+BUNDLE_FILES = ("run.json", "repro.sh", "uncommitted.patch", "git_status.txt", "output_dir.txt")
 PREDICTION_FILES = ("pred_test.npz", "metrics.json")
+
+
+def portable_output_dir(raw: str, run: dict) -> str:
+    """Make the runner's output dir portable for ``artifacts.output_dir``.
+
+    The runner records the Lightning ``version_N/checkpoints`` dir; the
+    TensorBoard event files live in its parent ``version_N``. Drop a trailing
+    ``checkpoints`` and store the path relative to the checkout that produced it,
+    so kg_curves can resolve the event dir directly (no fingerprint scan)."""
+    odir = Path(raw)
+    if odir.name == "checkpoints":
+        odir = odir.parent
+    for base in (run.get("cwd"), str(repo_root())):
+        if base:
+            try:
+                return str(odir.relative_to(base))
+            except ValueError:
+                continue
+    return str(odir)
 
 
 def find_repro_dir(name: str) -> Path | None:
@@ -152,6 +171,11 @@ def main() -> int:
     log = find_log(name)
     if log and log.exists():
         artifacts["log"] = str(log.relative_to(repo_root()))
+    out_txt = repro / "output_dir.txt"
+    if out_txt.exists():
+        odir = out_txt.read_text(encoding="utf-8").strip()
+        if odir:
+            artifacts["output_dir"] = portable_output_dir(odir, run)
 
     repro_meta = {k: run[k] for k in ("commit", "branch", "remote") if run.get(k)}
     if cmd:


### PR DESCRIPTION
## 概要

`experiment-result-pr` ワークフローを #545 で初運用した際に詰まった点を、ツール側で解消する。discovery ヘルパーの新設、`kg_curves` の高速化、SKILL.md への注意書き 4 点の凝縮追記。

## 変更内容

- **discovery ヘルパー追加** `.agents/skills/experiment-result-pr/scripts/discover_runs.py`
  - `--issue N` で `.training_queue` の finished run を **run.json の `issue` フィールド**(ジョブ名ではない)で抽出。status / predictions / 登記済みを表示し、`kg_register` コマンドを生成(`--provider` は run.json 由来)。
  - 名前は `i<issue>…` でも run.json issue が異なる run(例: `i545_nocanon_*` は実際 #560)を別枠で警告し、別 issue への誤登記を防ぐ。`--json` 出力対応。
- **`kg_register.py`**: `output_dir.txt` を bundle に取り込み、`artifacts.output_dir` を記録(`version_N/checkpoints` を親に剥がし checkout 相対化)。
- **`kg_curves.py` 高速化**: `artifacts.output_dir` / `tb_logdir` があれば event dir を直接解決し、リポジトリ全体の event ファイル fingerprint スキャンを回避。スキャンは hint の無い旧ノードのみ**遅延実行**。near-exact 一致で early-exit。`--refresh` で従来スキャンを強制。
- **SKILL.md**: 各ステップに 4 点を凝縮追記 — (a) run.json issue 突合(discover 経由)、(b) worktree の `.training_queue` symlink は gitignore されない→明示 add、(c) merged worktree は `origin/main` から新ブランチ、(d) provider は run.json 由来。

## 検証

- `discover_runs.py --issue 545 / 560`: #545/#560 混在バッチを run.json issue で正しく分離、misfiled 8 件を警告。`--json` も確認。
- `kg_register` → `kg_curves` を scratch `KNOWLEDGE_DIR` で end-to-end 確認: `artifacts.output_dir` が記録され、`kg_curves` は global scan を回避(`hint` 解決)、`--refresh` で 133 event dirs のスキャンに復帰。
- `ruff check`: 追加分 clean(`kg_curves.py` の既存 3 件は origin/main 由来・本 PR 非導入、pre-commit ruff は `^(src|tests)/` スコープ外)。
- `kg_validate.py`: 0 error。

## 関連Issue

- References #545

## 補足

- 追加スクリプトは `.agents/skills/**` 配下で `src/` `experiments/` 外のため、`script-conventions`(Hydra 必須・argparse 禁止)は適用対象外。既存 `kg_*.py` と同じ argparse スタイルに統一。
