### PR TITLE
ball/courtのtest推論結果保存を追加

### DIFF
--- a/src/tasks/ball_detection/data/dataset.py
+++ b/src/tasks/ball_detection/data/dataset.py
@@ -187,6 +187,7 @@ class BallDetectionDataset(Dataset[BallDetectionSample]):
             "visibility": torch.tensor(visibility_padded, dtype=torch.float32),
             "original_size": torch.tensor([original_w, original_h], dtype=torch.float32),
             "heatmap_size": torch.tensor([heatmap_w, heatmap_h], dtype=torch.float32),
+            "window_id": f"{window.clip_dir.parent.name}/{window.clip_dir.name}:{window.start_index}",
         }
         return sample
 

--- a/src/tasks/ball_detection/data/types.py
+++ b/src/tasks/ball_detection/data/types.py
@@ -45,6 +45,7 @@ class BallDetectionSample(TypedDict):
             ``(width, height)`` ordering.
         heatmap_size: Heatmap size with shape ``(2,)`` in
             ``(width, height)`` ordering.
+        window_id: Stable TrackNet window identifier for persisted predictions.
     """
 
     images: Tensor
@@ -53,6 +54,7 @@ class BallDetectionSample(TypedDict):
     visibility: Tensor
     original_size: Tensor
     heatmap_size: Tensor
+    window_id: str
 
 
 class BallDetectionBatch(TypedDict):
@@ -68,6 +70,7 @@ class BallDetectionBatch(TypedDict):
             ``(width, height)`` ordering.
         heatmap_size: Heatmap sizes with shape ``(B, 2)`` in
             ``(width, height)`` ordering.
+        window_id: Stable TrackNet window identifiers for persisted predictions.
     """
 
     images: Tensor
@@ -76,6 +79,7 @@ class BallDetectionBatch(TypedDict):
     visibility: Tensor
     original_size: Tensor
     heatmap_size: Tensor
+    window_id: list[str]
 
 
 __all__ = [

--- a/src/tasks/ball_detection/training/lightning_module.py
+++ b/src/tasks/ball_detection/training/lightning_module.py
@@ -189,6 +189,19 @@ class BallDetectionLightningModule(ManualGANSupportMixin, BaseLightningModule):
         self.log(f"{stage}/loss", loss, prog_bar=True, sync_dist=True)
         self._log_gan_metrics(stage, metrics)
 
+    def test_prediction_payload(
+        self, batch: dict[str, Any], result: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Persist TrackNet test-split heatmap predictions and targets."""
+        return {
+            "window_id": batch["window_id"],
+            "pred_heatmaps": result["pred_heatmaps"],
+            "target_coords": batch["coords"],
+            "target_visibility": batch["visibility"],
+            "original_size": batch["original_size"],
+            "heatmap_size": batch["heatmap_size"],
+        }
+
     def configure_optimizers(self) -> Any:
         """Configure generator/discriminator optimizers through the shared GAN helper."""
         return self.configure_gan_optimizers(self.model.parameters())

--- a/src/tasks/court_detection/data/court_kp_dataset.py
+++ b/src/tasks/court_detection/data/court_kp_dataset.py
@@ -123,5 +123,6 @@ class CourtKPDataset(Dataset):
             "image": img_tensor,
             "heatmap": heatmap_tensor,
             "keypoints": kps_tensor,
+            "image_size": torch.tensor([h, w], dtype=torch.int64),
             "image_id": image_id,
         }

--- a/src/tasks/court_detection/data/court_line_dataset.py
+++ b/src/tasks/court_detection/data/court_line_dataset.py
@@ -94,6 +94,7 @@ class CourtLineDataset(Dataset):
 
         img_tensor = _pil_to_tensor_image(img)
         img_tensor = TF.normalize(img_tensor, IMAGENET_MEAN, IMAGENET_STD)
+        _, h, w = img_tensor.shape
 
         mask_np = (np.array(mask, dtype=np.uint8) > 0).astype(np.float32)
         mask_tensor = torch.from_numpy(mask_np).unsqueeze(0)
@@ -101,5 +102,6 @@ class CourtLineDataset(Dataset):
         return {
             "image": img_tensor,
             "mask": mask_tensor,
+            "image_size": torch.tensor([h, w], dtype=torch.int64),
             "image_id": image_id,
         }

--- a/src/tasks/court_detection/data/court_seg_dataset.py
+++ b/src/tasks/court_detection/data/court_seg_dataset.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import torch
 import torchvision.transforms.functional as TF
 from PIL import Image
 from torch import Tensor
@@ -111,9 +112,11 @@ class CourtSegDataset(Dataset):
         img_tensor = _pil_to_tensor_image(img)
         img_tensor = TF.normalize(img_tensor, IMAGENET_MEAN, IMAGENET_STD)
         mask_tensor = _mask_pil_to_tensor(mask)
+        _, h, w = img_tensor.shape
 
         return {
             "image": img_tensor,
             "mask": mask_tensor,
+            "image_size": torch.tensor([h, w], dtype=torch.int64),
             "image_id": image_id,
         }

--- a/src/tasks/court_detection/data/datamodule.py
+++ b/src/tasks/court_detection/data/datamodule.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytorch_lightning as pl
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Dataset
 
 from src.tasks.court_detection.data.court_kp_dataset import CourtKPDataset
 from src.tasks.court_detection.data.court_line_dataset import CourtLineDataset
@@ -47,7 +48,7 @@ def _pad_collate_seg(batch: list[dict]) -> dict:
     """Pad variable-size images/masks to the max size in the batch."""
     max_h, max_w = _pad_max_hw(batch)
 
-    images, masks, ids = [], [], []
+    images, masks, sizes, ids = [], [], [], []
     for b in batch:
         images.append(_pad_image(b["image"], max_h, max_w))
 
@@ -55,16 +56,22 @@ def _pad_collate_seg(batch: list[dict]) -> dict:
         padded_mask = torch.zeros(max_h, max_w, dtype=b["mask"].dtype)
         padded_mask[:h, :w] = b["mask"]
         masks.append(padded_mask)
+        sizes.append(b.get("image_size", torch.tensor([h, w], dtype=torch.int64)))
         ids.append(b["image_id"])
 
-    return {"image": torch.stack(images), "mask": torch.stack(masks), "image_id": ids}
+    return {
+        "image": torch.stack(images),
+        "mask": torch.stack(masks),
+        "image_size": torch.stack(sizes),
+        "image_id": ids,
+    }
 
 
 def _pad_collate_line(batch: list[dict]) -> dict:
     """Pad variable-size images/binary masks to the max size in the batch."""
     max_h, max_w = _pad_max_hw(batch)
 
-    images, masks, ids = [], [], []
+    images, masks, sizes, ids = [], [], [], []
     for b in batch:
         images.append(_pad_image(b["image"], max_h, max_w))
 
@@ -72,16 +79,23 @@ def _pad_collate_line(batch: list[dict]) -> dict:
         padded_mask = torch.zeros(1, max_h, max_w, dtype=b["mask"].dtype)
         padded_mask[:, :mh, :mw] = b["mask"]
         masks.append(padded_mask)
+        _, h, w = b["image"].shape
+        sizes.append(b.get("image_size", torch.tensor([h, w], dtype=torch.int64)))
         ids.append(b["image_id"])
 
-    return {"image": torch.stack(images), "mask": torch.stack(masks), "image_id": ids}
+    return {
+        "image": torch.stack(images),
+        "mask": torch.stack(masks),
+        "image_size": torch.stack(sizes),
+        "image_id": ids,
+    }
 
 
 def _pad_collate_kp(batch: list[dict]) -> dict:
     """Pad variable-size images/heatmaps to the max size in the batch."""
     max_h, max_w = _pad_max_hw(batch)
 
-    images, heatmaps, keypoints, ids = [], [], [], []
+    images, heatmaps, keypoints, sizes, ids = [], [], [], [], []
     for b in batch:
         images.append(_pad_image(b["image"], max_h, max_w))
 
@@ -90,12 +104,15 @@ def _pad_collate_kp(batch: list[dict]) -> dict:
         padded_hm[:, :hh, :hw] = b["heatmap"]
         heatmaps.append(padded_hm)
         keypoints.append(b["keypoints"])
+        _, h, w = b["image"].shape
+        sizes.append(b.get("image_size", torch.tensor([h, w], dtype=torch.int64)))
         ids.append(b["image_id"])
 
     return {
         "image": torch.stack(images),
         "heatmap": torch.stack(heatmaps),
         "keypoints": torch.stack(keypoints),
+        "image_size": torch.stack(sizes),
         "image_id": ids,
     }
 
@@ -121,8 +138,9 @@ class CourtDetectionDataModule(pl.LightningDataModule):
         self.num_workers = int(data_cfg.get("num_workers", 4))
         self.pin_memory = bool(data_cfg.get("pin_memory", True))
 
-        self.train_dataset = None
-        self.val_dataset = None
+        self.train_dataset: Dataset[Any] | None = None
+        self.val_dataset: Dataset[Any] | None = None
+        self.test_dataset: Dataset[Any] | None = None
 
     def _build_config_dict(self) -> dict:
         """Build a flat config dict for dataset constructors."""
@@ -150,49 +168,77 @@ class CourtDetectionDataModule(pl.LightningDataModule):
 
     def setup(self, stage: str | None = None) -> None:
         """Set up datasets for each stage."""
-        if stage not in ("fit", None):
+        if stage not in ("fit", "validate", "test", None):
             return
 
         cfg_dict = self._build_config_dict()
         data_cfg = self.config.get("data", {})
+        build_train = stage in ("fit", None)
+        build_val = stage in ("fit", "validate", None)
+        build_test = stage in ("test", None)
 
         if self.task == "seg":
-            self.train_dataset = CourtSegDataset(
-                self.data_dir, split="train", is_train=True, config=cfg_dict,
-            )
-            self.val_dataset = CourtSegDataset(
-                self.data_dir, split="val", is_train=False, config=cfg_dict,
-            )
+            if build_train:
+                self.train_dataset = CourtSegDataset(
+                    self.data_dir, split="train", is_train=True, config=cfg_dict,
+                )
+            if build_val:
+                self.val_dataset = CourtSegDataset(
+                    self.data_dir, split="val", is_train=False, config=cfg_dict,
+                )
+            if build_test:
+                self.test_dataset = CourtSegDataset(
+                    self.data_dir, split="val", is_train=False, config=cfg_dict,
+                )
         elif self.task == "kp":
-            self.train_dataset = CourtKPDataset(
-                self.data_dir, split="train", is_train=True, config=cfg_dict,
-            )
-            self.val_dataset = CourtKPDataset(
-                self.data_dir, split="val", is_train=False, config=cfg_dict,
-            )
+            if build_train:
+                self.train_dataset = CourtKPDataset(
+                    self.data_dir, split="train", is_train=True, config=cfg_dict,
+                )
+            if build_val:
+                self.val_dataset = CourtKPDataset(
+                    self.data_dir, split="val", is_train=False, config=cfg_dict,
+                )
+            if build_test:
+                self.test_dataset = CourtKPDataset(
+                    self.data_dir, split="val", is_train=False, config=cfg_dict,
+                )
         elif self.task == "line":
             mask_dir = str(data_cfg.get("mask_dir_name", "line_masks"))
-            self.train_dataset = CourtLineDataset(
-                self.data_dir, split="train", is_train=True,
-                config=cfg_dict, mask_dir_name=mask_dir,
-            )
-            self.val_dataset = CourtLineDataset(
-                self.data_dir, split="val", is_train=False,
-                config=cfg_dict, mask_dir_name=mask_dir,
-            )
+            if build_train:
+                self.train_dataset = CourtLineDataset(
+                    self.data_dir, split="train", is_train=True,
+                    config=cfg_dict, mask_dir_name=mask_dir,
+                )
+            if build_val:
+                self.val_dataset = CourtLineDataset(
+                    self.data_dir, split="val", is_train=False,
+                    config=cfg_dict, mask_dir_name=mask_dir,
+                )
+            if build_test:
+                self.test_dataset = CourtLineDataset(
+                    self.data_dir, split="val", is_train=False,
+                    config=cfg_dict, mask_dir_name=mask_dir,
+                )
         else:
             raise ValueError(f"Unknown task: {self.task!r}")
 
-    def _collate_fn(self):
+    def _collate_fn(self) -> Callable[[list[dict[str, Any]]], dict[str, Any]]:
         if self.task == "seg":
             return _pad_collate_seg
         if self.task == "kp":
             return _pad_collate_kp
         return _pad_collate_line
 
+    @staticmethod
+    def _require_dataset(dataset: Dataset[Any] | None, *, stage: str) -> Dataset[Any]:
+        if dataset is None:
+            raise RuntimeError(f"CourtDetectionDataModule.setup({stage!r}) was not called.")
+        return dataset
+
     def train_dataloader(self) -> DataLoader:
         return DataLoader(
-            self.train_dataset,
+            self._require_dataset(self.train_dataset, stage="fit"),
             batch_size=self.batch_size,
             shuffle=True,
             num_workers=self.num_workers,
@@ -203,7 +249,17 @@ class CourtDetectionDataModule(pl.LightningDataModule):
 
     def val_dataloader(self) -> DataLoader:
         return DataLoader(
-            self.val_dataset,
+            self._require_dataset(self.val_dataset, stage="validate"),
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            collate_fn=self._collate_fn(),
+        )
+
+    def test_dataloader(self) -> DataLoader:
+        return DataLoader(
+            self._require_dataset(self.test_dataset, stage="test"),
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=self.num_workers,

--- a/src/tasks/court_detection/training/lightning_module.py
+++ b/src/tasks/court_detection/training/lightning_module.py
@@ -18,6 +18,7 @@ from src.tasks.court_detection.training.losses import (
     FocalBCEWithLogitsLoss,
 )
 from src.tasks.court_detection.training.metrics import CourtDetectionMetrics
+from src.utils.data.heatmaps import heatmaps_to_pixel_coords
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -71,6 +72,7 @@ class CourtDetectionLightningModule(BaseLightningModule):
         # Metrics
         self.train_metrics = CourtDetectionMetrics(self.task, data_cfg)
         self.val_metrics = CourtDetectionMetrics(self.task, data_cfg)
+        self.test_metrics = CourtDetectionMetrics(self.task, data_cfg)
 
     def forward(self, images: Tensor) -> Tensor:
         return self.model(images)
@@ -94,12 +96,29 @@ class CourtDetectionLightningModule(BaseLightningModule):
     def _shared_step(
         self, batch: dict[str, Tensor], stage: str,
     ) -> dict[str, Tensor]:
-        """Shared computation for train/val steps."""
+        """Shared computation for train/val/test steps."""
         images = batch["image"]
         logits = self.model(images)
         loss = self._compute_loss(logits, batch)
         self.log(f"{stage}/loss", loss, prog_bar=True, sync_dist=True)
         return {"loss": loss, "logits": logits}
+
+    def _metric_tracker_for_stage(self, stage: str) -> CourtDetectionMetrics:
+        if stage == "train":
+            return self.train_metrics
+        if stage == "val":
+            return self.val_metrics
+        return self.test_metrics
+
+    def _flush_stage_metrics(self, stage: str) -> None:
+        metrics = self._metric_tracker_for_stage(stage).compute()
+        for name, value in metrics.items():
+            self.log(
+                f"{stage}/{name}",
+                value,
+                prog_bar=(stage == "val" and name in ("miou", "mean_dist", "dice")),
+            )
+        self._metric_tracker_for_stage(stage).reset()
 
     def training_step(self, batch: dict[str, Tensor], batch_idx: int) -> Tensor:
         outputs = self._shared_step(batch, "train")
@@ -107,20 +126,75 @@ class CourtDetectionLightningModule(BaseLightningModule):
         return outputs["loss"]
 
     def on_train_epoch_end(self) -> None:
-        metrics = self.train_metrics.compute()
-        for name, value in metrics.items():
-            self.log(f"train/{name}", value)
-        self.train_metrics.reset()
+        self._flush_stage_metrics("train")
 
     def validation_step(self, batch: dict[str, Tensor], batch_idx: int) -> None:
         outputs = self._shared_step(batch, "val")
         self.val_metrics.update(outputs["logits"], batch)
 
     def on_validation_epoch_end(self) -> None:
-        metrics = self.val_metrics.compute()
-        for name, value in metrics.items():
-            self.log(f"val/{name}", value, prog_bar=(name in ("miou", "mean_dist", "dice")))
-        self.val_metrics.reset()
+        self._flush_stage_metrics("val")
+
+    def on_test_epoch_start(self) -> None:
+        self._reset_test_prediction_buffer()
+
+    def test_step(self, batch: dict[str, Tensor], batch_idx: int) -> None:
+        _ = batch_idx
+        outputs = self._shared_step(batch, "test")
+        self.test_metrics.update(outputs["logits"], batch)
+        self.collect_test_predictions(batch, outputs)
+
+    def on_test_epoch_end(self) -> None:
+        metrics = self.test_metrics.compute()
+        saved = self.save_test_predictions(metrics=metrics)
+        if saved is not None:
+            print(f"[test] saved test-split predictions -> {saved}")
+        self._flush_stage_metrics("test")
+
+    def test_prediction_payload(
+        self, batch: dict[str, Any], result: dict[str, Tensor]
+    ) -> dict[str, Any]:
+        """Persist court predictions from ``data/court/data_val.json``."""
+        logits = result["logits"]
+        payload: dict[str, Any] = {
+            "image_id": batch["image_id"],
+            "image_size": batch["image_size"],
+        }
+        if self.task == "kp":
+            payload.update(
+                {
+                    "pred_keypoints": heatmaps_to_pixel_coords(logits),
+                    "target_keypoints": batch["keypoints"],
+                }
+            )
+            return payload
+
+        if self.task == "seg":
+            payload.update(
+                {
+                    "pred_mask_flat": logits.argmax(dim=1).reshape(logits.shape[0], -1),
+                    "target_mask_flat": batch["mask"].reshape(batch["mask"].shape[0], -1),
+                    "padded_size": logits.new_tensor(
+                        [logits.shape[-2], logits.shape[-1]],
+                        dtype=torch.int64,
+                    ).repeat(logits.shape[0], 1),
+                }
+            )
+            return payload
+
+        pred_line = torch.sigmoid(logits).reshape(logits.shape[0], -1)
+        target_line = batch["mask"].reshape(batch["mask"].shape[0], -1)
+        payload.update(
+            {
+                "pred_line_prob_flat": pred_line,
+                "target_line_mask_flat": target_line,
+                "padded_size": logits.new_tensor(
+                    [logits.shape[-2], logits.shape[-1]],
+                    dtype=torch.int64,
+                ).repeat(logits.shape[0], 1),
+            }
+        )
+        return payload
 
     # ------------------------------------------------------------------
     # Qualitative validation logging

--- a/src/tasks/court_detection/training/runner.py
+++ b/src/tasks/court_detection/training/runner.py
@@ -30,7 +30,3 @@ class CourtDetectionTrainingRunner(BaseTrainingRunner):
         steps_per_epoch: int | None = None,
     ) -> pl.LightningModule:
         return CourtDetectionLightningModule(config)
-
-    def skip_test(self, config: Any) -> bool:
-        """Court detection currently has fit/validation support only."""
-        return True

--- a/tests/unit/tasks/ball_detection/training/test_lightning_module.py
+++ b/tests/unit/tasks/ball_detection/training/test_lightning_module.py
@@ -1,0 +1,36 @@
+"""Unit tests for ball detection Lightning test-prediction payloads."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.tasks.ball_detection.training.lightning_module import (
+    BallDetectionLightningModule,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_test_prediction_payload_persists_tracknet_predictions_and_targets() -> None:
+    module = object.__new__(BallDetectionLightningModule)
+    pred_heatmaps = torch.rand(2, 3, 4, 5)
+    batch = {
+        "coords": torch.rand(2, 3, 4, 2),
+        "visibility": torch.ones(2, 3, 4),
+        "original_size": torch.tensor([[1280.0, 720.0], [1280.0, 720.0]]),
+        "heatmap_size": torch.tensor([[5.0, 4.0], [5.0, 4.0]]),
+        "window_id": ["Game1/Clip1:0", "Game1/Clip1:4"],
+    }
+
+    payload = module.test_prediction_payload(
+        batch,
+        {"pred_heatmaps": pred_heatmaps},
+    )
+
+    assert payload["pred_heatmaps"] is pred_heatmaps
+    assert payload["window_id"] == ["Game1/Clip1:0", "Game1/Clip1:4"]
+    assert payload["target_coords"] is batch["coords"]
+    assert payload["target_visibility"] is batch["visibility"]
+    assert payload["original_size"] is batch["original_size"]
+    assert payload["heatmap_size"] is batch["heatmap_size"]

--- a/tests/unit/tasks/court_detection/data/test_datamodule.py
+++ b/tests/unit/tasks/court_detection/data/test_datamodule.py
@@ -1,0 +1,61 @@
+"""Unit tests for court detection DataModule test-split wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from omegaconf import OmegaConf
+
+from src.tasks.court_detection.data import datamodule as dm_mod
+from src.tasks.court_detection.data.datamodule import CourtDetectionDataModule
+
+pytestmark = pytest.mark.unit
+
+
+def test_setup_test_uses_data_val_json_split_for_kp(monkeypatch, tmp_path: Path) -> None:
+    created: list[dict[str, Any]] = []
+
+    class _FakeCourtKPDataset:
+        def __init__(
+            self,
+            root: str | Path,
+            split: str,
+            is_train: bool,
+            config: dict[str, Any],
+        ) -> None:
+            created.append(
+                {
+                    "root": Path(root),
+                    "split": split,
+                    "is_train": is_train,
+                    "config": config,
+                }
+            )
+
+        def __len__(self) -> int:
+            return 0
+
+    monkeypatch.setattr(dm_mod, "CourtKPDataset", _FakeCourtKPDataset)
+    datamodule = CourtDetectionDataModule(
+        OmegaConf.create(
+            {
+            "data": {
+                "task": "kp",
+                "data_dir": str(tmp_path),
+                "batch_size": 2,
+                "num_workers": 0,
+                "pin_memory": False,
+            }
+            }
+        )
+    )
+
+    datamodule.setup("test")
+
+    assert len(created) == 1
+    assert created[0]["root"] == tmp_path
+    assert created[0]["split"] == "val"
+    assert created[0]["is_train"] is False
+    assert datamodule.test_dataset is not None

--- a/tests/unit/tasks/court_detection/training/test_lightning_module.py
+++ b/tests/unit/tasks/court_detection/training/test_lightning_module.py
@@ -1,0 +1,76 @@
+"""Unit tests for court detection Lightning test-prediction payloads."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.tasks.court_detection.training.lightning_module import (
+    CourtDetectionLightningModule,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _module_for_task(task: str) -> CourtDetectionLightningModule:
+    module = object.__new__(CourtDetectionLightningModule)
+    module.task = task
+    return module
+
+
+def test_kp_test_prediction_payload_saves_predicted_and_target_keypoints() -> None:
+    module = _module_for_task("kp")
+    logits = torch.zeros(2, 3, 4, 5)
+    logits[0, :, 1, 2] = 10.0
+    logits[1, :, 3, 4] = 10.0
+    batch = {
+        "keypoints": torch.rand(2, 3, 2),
+        "image_size": torch.tensor([[4, 5], [4, 5]]),
+        "image_id": ["a", "b"],
+    }
+
+    payload = module.test_prediction_payload(batch, {"logits": logits})
+
+    assert payload["image_id"] == ["a", "b"]
+    assert payload["image_size"] is batch["image_size"]
+    assert payload["pred_keypoints"].shape == (2, 3, 2)
+    assert payload["target_keypoints"] is batch["keypoints"]
+    assert torch.all(payload["pred_keypoints"][0] == torch.tensor([2.0, 1.0]))
+    assert torch.all(payload["pred_keypoints"][1] == torch.tensor([4.0, 3.0]))
+
+
+def test_seg_test_prediction_payload_flattens_variable_spatial_masks() -> None:
+    module = _module_for_task("seg")
+    logits = torch.zeros(2, 4, 2, 3)
+    logits[:, 2] = 1.0
+    target = torch.ones(2, 2, 3, dtype=torch.long)
+    batch = {
+        "mask": target,
+        "image_size": torch.tensor([[2, 3], [2, 3]]),
+        "image_id": ["a", "b"],
+    }
+
+    payload = module.test_prediction_payload(batch, {"logits": logits})
+
+    assert payload["pred_mask_flat"].shape == (2, 6)
+    assert payload["target_mask_flat"].shape == (2, 6)
+    assert payload["padded_size"].tolist() == [[2, 3], [2, 3]]
+    assert torch.all(payload["pred_mask_flat"] == 2)
+
+
+def test_line_test_prediction_payload_flattens_probabilities_and_targets() -> None:
+    module = _module_for_task("line")
+    logits = torch.zeros(2, 1, 2, 3)
+    target = torch.ones(2, 1, 2, 3)
+    batch = {
+        "mask": target,
+        "image_size": torch.tensor([[2, 3], [2, 3]]),
+        "image_id": ["a", "b"],
+    }
+
+    payload = module.test_prediction_payload(batch, {"logits": logits})
+
+    assert payload["pred_line_prob_flat"].shape == (2, 6)
+    assert payload["target_line_mask_flat"].shape == (2, 6)
+    assert payload["padded_size"].tolist() == [[2, 3], [2, 3]]
+    assert torch.allclose(payload["pred_line_prob_flat"], torch.full((2, 6), 0.5))


### PR DESCRIPTION
## 概要

ball_detection と court_detection の test ステップで推論結果を `pred_test.npz` として保存できるようにしました。
保存済み推論結果があれば、training queue の `--prune-ckpt` が checkpoint を削除でき、評価時の再推論を避けられます。

## 変更内容

- ball_detection の TrackNet test split で `pred_heatmaps`、GT座標/visibility、サイズ情報、`window_id` を保存
- court_detection の test 実行を有効化し、`data/court/data_val.json` 相当の `split="val"` を test dataset として使用
- court_detection の kp/seg/line それぞれで再評価用の推論payloadを保存
- court dataset/collate に `image_size` を通し、可変サイズseg/lineはフラット化して保存
- payload変換とcourt test split wiringのunit testを追加

## 検証

- `.venv/bin/python -m ruff check src/tasks/ball_detection/data/dataset.py src/tasks/ball_detection/data/types.py src/tasks/ball_detection/training/lightning_module.py src/tasks/court_detection/data/datamodule.py src/tasks/court_detection/data/court_kp_dataset.py src/tasks/court_detection/data/court_seg_dataset.py src/tasks/court_detection/data/court_line_dataset.py src/tasks/court_detection/training/lightning_module.py src/tasks/court_detection/training/runner.py tests/unit/tasks/ball_detection/training/test_lightning_module.py tests/unit/tasks/court_detection/data/test_datamodule.py tests/unit/tasks/court_detection/training/test_lightning_module.py`
- `.venv/bin/python -m pytest tests/unit/tasks/ball_detection/training/test_lightning_module.py tests/unit/tasks/court_detection/data/test_datamodule.py tests/unit/tasks/court_detection/training/test_lightning_module.py tests/unit/tasks/base/training/test_lightning_module.py`
- commit hook: `ruff (fix)`, `mypy`

## 関連Issue

- なし
