### PR TITLE
fix(ball_detection): visualize.pyのMDDパネルがbtchwモデルで壊れる不具合を修正

### DIFF
--- a/src/tasks/ball_detection/visualization/api/predict.py
+++ b/src/tasks/ball_detection/visualization/api/predict.py
@@ -103,7 +103,16 @@ def build_mdd_frames(
     red=darken). Computed from the same preprocessed images the predictor
     consumes to stay faithful to the model input.
     """
-    mdd_config = {**predictor.model_config, "input_mode": "mdd", "in_channels": 2}
+    # Force channels-first (bcthw) so ``features[0, c]`` selects the two MDD
+    # channels over all T frames regardless of the model's own input layout.
+    # ``btchw`` models would otherwise yield (1, T, 2, H, W) and collapse the
+    # panel to 2 "frames".
+    mdd_config = {
+        **predictor.model_config,
+        "input_mode": "mdd",
+        "in_channels": 2,
+        "input_layout": "bcthw",
+    }
     with torch.no_grad():
         # (1, T, 3, H, W) -> (1, 2, T, H, W)
         features = to_model_input(clip.model_images.unsqueeze(0), mdd_config)

--- a/tests/unit/tasks/ball_detection/visualization/test_predict_mdd.py
+++ b/tests/unit/tasks/ball_detection/visualization/test_predict_mdd.py
@@ -1,0 +1,34 @@
+"""Regression tests for MDD panel construction in the visualization API."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from src.tasks.ball_detection.visualization.api.predict import build_mdd_frames
+
+
+def _build(layout: str, *, num_frames: int = 5, h: int = 6, w: int = 8) -> list:
+    predictor = SimpleNamespace(
+        model_config={
+            "input_mode": "rgb",
+            "input_layout": layout,
+            "in_channels": 3,
+            "num_frames": num_frames,
+        }
+    )
+    clip = SimpleNamespace(model_images=torch.rand(num_frames, 3, h, w))
+    return build_mdd_frames(predictor=predictor, clip=clip)
+
+
+def test_btchw_model_yields_one_mdd_frame_per_input_frame() -> None:
+    """btchw models must not collapse the MDD panel to the channel count."""
+    frames = _build("btchw", num_frames=5, h=6, w=8)
+    assert len(frames) == 5
+    assert frames[0].shape == (6, 8, 3)
+
+
+def test_mdd_frame_count_is_layout_independent() -> None:
+    """bcthw and btchw layouts must produce the same number of MDD frames."""
+    assert len(_build("bcthw", num_frames=5)) == len(_build("btchw", num_frames=5))


### PR DESCRIPTION
## 概要

`visualize.py` を `input_layout=btchw` のモデル（`dinov3_rope` など）で実行すると、MDD パネル生成で `ValueError: zip() argument 3 is shorter than arguments 1-2` が発生し描画に失敗する不具合を修正する。

## 変更内容

- `build_mdd_frames`（`src/tasks/ball_detection/visualization/api/predict.py`）で MDD 計算時に `input_layout=bcthw` を強制。
  - `to_model_input` は `btchw` モデルだと MDD を `(B, T, 2, H, W)` で返すが、`build_mdd_frames` は `(B, 2, T, H, W)`（channels-first）前提で `features[0, 0]`/`features[0, 1]` を参照していたため、MDD パネルが入力フレーム数 `T` ではなくチャンネル数 `2` に潰れていた。
  - デフォルトの `stunet` は `bcthw` のため顕在化していなかった。
- 回帰テスト `tests/unit/tasks/ball_detection/visualization/test_predict_mdd.py` を追加（`btchw`/`bcthw` 両レイアウトで MDD フレーム数 == 入力フレーム数 を検証）。

## 検証

- `.venv/bin/python -m pytest tests/unit/tasks/ball_detection/visualization/test_predict_mdd.py` → 2 passed。
- 修正前のコードに対して同テストを実行すると 2 failed（`btchw` が 2 フレームに潰れる）ことを確認。
- pre-commit（ruff / mypy）通過。
- `dinov3_rope`（`num_frames=3`）checkpoint で `visualize.py` が GIF を最後まで生成できることを実機確認。

## 関連Issue

- References #551
- References #553

## 補足

- この不具合は #551 の T=3 checkpoint のヒートマップ可視化を行う過程で発見した。
