### PR TITLE
feat(ball_detection): Web接写フレームの変換時ドメインクリーニング

### DIFF
--- a/src/tasks/ball_detection/configs/analyze_web_bbox_ratio.yaml
+++ b/src/tasks/ball_detection/configs/analyze_web_bbox_ratio.yaml
@@ -1,0 +1,32 @@
+# Sweep the bbox max-side ratio of web ball-detection sources and export
+# candidate "ball-too-close" frames for visual threshold selection.
+#
+# Usage:
+#   python -m src.tasks.ball_detection.scripts.analyze_web_bbox_ratio
+#   python -m src.tasks.ball_detection.scripts.analyze_web_bbox_ratio analyze.samples_per_bin=64
+analyze:
+  web_root: data/tennis/web
+  output_dir: outputs/web_bbox_ratio_sweep
+
+  # Which bbox-bearing sources to analyze. The temporal point-only sources
+  # (racketvision, kaggle) carry no bbox and are skipped by construction.
+  sources:
+    roboflow: true
+    ball_yolo: true
+
+  # Metric: per-frame ratio = max over boxes of max(bbox_w / W, bbox_h / H).
+
+  # Thresholds reported in the removal-count sweep table.
+  sweep_thresholds: [0.03, 0.05, 0.08, 0.10, 0.12, 0.15, 0.20, 0.25, 0.30, 0.40, 0.50]
+
+  # Ratio bin edges used to bucket exported sample frames for visual review.
+  export_bin_edges: [0.0, 0.05, 0.10, 0.15, 0.20, 0.30, 0.50, 1.01]
+
+  # Up to this many annotated sample frames are exported per (source, bin).
+  samples_per_bin: 24
+
+  # Deterministic sampling of which frames to export.
+  seed: 1234
+
+  # JPEG quality used when decoding ball_yolo video frames for export.
+  jpeg_quality: 90

--- a/src/tasks/ball_detection/configs/convert_web_dataset.yaml
+++ b/src/tasks/ball_detection/configs/convert_web_dataset.yaml
@@ -23,6 +23,14 @@ convert:
   # fractional size is retained as an explicit negative frame.
   kaggle_corner_frac: 0.05
 
+  # Domain cleaning: drop a frame when any ball bbox spans at least this
+  # fraction of the matching image side (max(w/W, h/H)). Targets zoomed-in
+  # close-ups (a different domain than rally-camera detection). Only the
+  # bbox-bearing sources (roboflow, ball_yolo) are affected; the point-only
+  # temporal sources carry no bbox and pass through unchanged. null disables.
+  # Threshold chosen from the outputs/web_bbox_ratio_sweep visual review.
+  max_bbox_side_ratio: 0.10
+
   # 0 = all samples; >0 caps each source for fast smoke validation.
   limit_per_source: 0
 

--- a/src/tasks/ball_detection/data/components/web/data_access_layer/writer.py
+++ b/src/tasks/ball_detection/data/components/web/data_access_layer/writer.py
@@ -237,6 +237,7 @@ def write_manifest(
     output_dir: Path,
     index: IndexBuilder,
     writer: ShardWriter,
+    max_bbox_side_ratio: float | None = None,
 ) -> None:
     """Write a human-readable store summary."""
     split_sequence_counts = {
@@ -265,6 +266,7 @@ def write_manifest(
         "shard_count": writer.shard_count,
         "packed_bytes": writer.total_bytes,
         "referenced_files": len(index.paths.values),
+        "max_bbox_side_ratio": max_bbox_side_ratio,
     }
     save_json(payload, output_dir / MANIFEST_FILE)
 

--- a/src/tasks/ball_detection/data/components/web/parser/ball_yolo.py
+++ b/src/tasks/ball_detection/data/components/web/parser/ball_yolo.py
@@ -15,6 +15,7 @@ from src.tasks.ball_detection.data.components.web.parser.base import (
     WebDatasetParser,
 )
 from src.utils.data.splits import GroupSplitConfig, make_group_split_map
+from src.utils.geometry.bbox import bbox_max_side_ratio
 from src.utils.geometry.keypoints import clamp_pixel_coordinate
 from src.utils.video import iter_selected_video_jpegs, probe_video_info
 
@@ -27,10 +28,12 @@ class BallYoloParser(WebDatasetParser):
         web_root: Path,
         jpeg_quality: int,
         split_config: GroupSplitConfig,
+        max_bbox_side_ratio: float | None = None,
     ) -> None:
         self.web_root = web_root
         self.jpeg_quality = jpeg_quality
         self.split_config = split_config
+        self.max_bbox_side_ratio = max_bbox_side_ratio
 
     def sources(self) -> Iterator[ParsedSource]:
         """Yield the Ball-YOLO source."""
@@ -75,6 +78,7 @@ class BallYoloParser(WebDatasetParser):
             if not parts:
                 continue
             frame_boxes: dict[int, list[tuple[float, float, int]]] = {}
+            dominant_frames: set[int] = set()
             for label_file in folder.glob("*.txt"):
                 frame_index = int(label_file.stem.rsplit("_", 1)[1])
                 for line in label_file.read_text(encoding="utf-8").splitlines():
@@ -82,9 +86,18 @@ class BallYoloParser(WebDatasetParser):
                     if len(fields) < 5:
                         continue
                     center_x, center_y = float(fields[1]), float(fields[2])
+                    box_w, box_h = float(fields[3]), float(fields[4])
                     frame_boxes.setdefault(frame_index, []).append(
                         (center_x, center_y, 1)
                     )
+                    if (
+                        self.max_bbox_side_ratio is not None
+                        and bbox_max_side_ratio(box_w, box_h, 1.0, 1.0)
+                        >= self.max_bbox_side_ratio
+                    ):
+                        dominant_frames.add(frame_index)
+            for frame_index in dominant_frames:
+                frame_boxes.pop(frame_index, None)
             if not frame_boxes:
                 continue
             video_info = probe_video_info(parts[0])

--- a/src/tasks/ball_detection/data/components/web/parser/roboflow.py
+++ b/src/tasks/ball_detection/data/components/web/parser/roboflow.py
@@ -16,6 +16,7 @@ from src.tasks.ball_detection.data.components.web.parser.base import (
     WebDatasetParser,
 )
 from src.utils.data.splits import GroupSplitConfig, make_group_split_map
+from src.utils.geometry.bbox import bbox_max_side_ratio
 from src.utils.geometry.keypoints import clamp_pixel_coordinate
 from src.utils.io import load_json
 
@@ -36,9 +37,15 @@ def roboflow_source_group(file_name: str) -> str:
 class RoboflowParser(WebDatasetParser):
     """Normalize all configured Roboflow COCO exports."""
 
-    def __init__(self, web_root: Path, split_config: GroupSplitConfig) -> None:
+    def __init__(
+        self,
+        web_root: Path,
+        split_config: GroupSplitConfig,
+        max_bbox_side_ratio: float | None = None,
+    ) -> None:
         self.web_root = web_root
         self.split_config = split_config
+        self.max_bbox_side_ratio = max_bbox_side_ratio
 
     def sources(self) -> Iterator[ParsedSource]:
         """Yield one logical source per Roboflow export."""
@@ -66,6 +73,21 @@ class RoboflowParser(WebDatasetParser):
             )
         return dict(counts)
 
+    def _is_dominant(
+        self,
+        boxes: list[tuple[float, float, float, float, int]],
+        img_w: int,
+        img_h: int,
+    ) -> bool:
+        """Whether any ball box is too dominant relative to the frame."""
+        if self.max_bbox_side_ratio is None:
+            return False
+        return any(
+            bbox_max_side_ratio(box_w, box_h, img_w, img_h)
+            >= self.max_bbox_side_ratio
+            for _cx, _cy, box_w, box_h, _vis in boxes
+        )
+
     def _records(
         self,
         name: str,
@@ -83,27 +105,27 @@ class RoboflowParser(WebDatasetParser):
                 for category in coco["categories"]
                 if str(category.get("supercategory", "none")).lower() != "none"
             }
-            boxes_by_image: dict[int, list[tuple[float, float, int]]] = {}
+            boxes_by_image: dict[int, list[tuple[float, float, float, float, int]]] = {}
             for annotation in coco["annotations"]:
                 if annotation["category_id"] not in ball_categories:
                     continue
                 x, y, width, height = annotation["bbox"]
                 boxes_by_image.setdefault(annotation["image_id"], []).append(
-                    (x + width / 2.0, y + height / 2.0, 1)
+                    (x + width / 2.0, y + height / 2.0, width, height, 1)
                 )
             for image in coco["images"]:
                 width = int(image["width"])
                 height = int(image["height"])
+                boxes = boxes_by_image.get(image["id"], [])
+                if self._is_dominant(boxes, width, height):
+                    continue
                 instances = [
                     (
                         clamp_pixel_coordinate(center_x, width),
                         clamp_pixel_coordinate(center_y, height),
                         visibility,
                     )
-                    for center_x, center_y, visibility in boxes_by_image.get(
-                        image["id"],
-                        [],
-                    )
+                    for center_x, center_y, _box_w, _box_h, visibility in boxes
                 ]
                 group = roboflow_source_group(str(image["file_name"]))
                 sequence = f"{name}:{group}"

--- a/src/tasks/ball_detection/scripts/analyze_web_bbox_ratio.py
+++ b/src/tasks/ball_detection/scripts/analyze_web_bbox_ratio.py
@@ -1,0 +1,385 @@
+"""
+Sweep the bbox max-side ratio of the web ball-detection sources and export
+candidate "ball-too-close" frames for visual threshold selection.
+
+The per-frame metric is ``ratio = max over boxes of max(w / W, h / H)`` where
+``w, h`` is a ball bbox and ``W, H`` the frame size. Frames whose ratio is large
+show the ball zoomed in close, a domain that differs from the rally-camera
+detection task and is a candidate for cleaning. Only the bbox-bearing sources
+(Roboflow COCO and Ball-YOLO) are analyzed; the temporal point-only sources
+(racketvision, kaggle) carry no bbox and are skipped by construction.
+
+Outputs (under ``analyze.output_dir``):
+    - ``frame_ratios.csv``: one row per frame with its ratio + locator, reusable
+      by the later cleaning step.
+    - ``sweep.csv`` / ``sweep.md``: removal counts per threshold, overall and
+      per source.
+    - ``histogram.csv``: ratio histogram.
+    - ``samples/<source>/bin_<lo>-<hi>/*.jpg``: annotated example frames per
+      ratio bin for eyeballing.
+
+Usage:
+    python -m src.tasks.ball_detection.scripts.analyze_web_bbox_ratio
+    python -m src.tasks.ball_detection.scripts.analyze_web_bbox_ratio \
+        analyze.samples_per_bin=64 analyze.sources.ball_yolo=false
+
+Notes:
+    - Hydra config: ``src/tasks/ball_detection/configs/analyze_web_bbox_ratio.yaml``.
+    - No frames are deleted; this script only reports and exports samples.
+    - Ratios are computed from raw annotations, independent of the unified store
+      (which keeps ball centers only, not bbox sizes).
+"""
+
+from __future__ import annotations
+
+import csv
+import random
+from collections import defaultdict
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import cv2
+import hydra
+import numpy as np
+from hydra.utils import to_absolute_path
+from omegaconf import DictConfig
+from tqdm import tqdm
+
+from src.utils.geometry.bbox import bbox_max_side_ratio
+from src.utils.io import ensure_dir, load_json
+from src.utils.video.encoding import iter_selected_video_jpegs
+
+_ROBOFLOW_DATASETS = (
+    "roboflow_tennis_ball_tracking_detection_h9rat_v1",
+    "roboflow_tennis_ball_tracking_1wnxz_v2",
+    "roboflow_tennis_ball_wafqb_v2",
+)
+_RAW_SPLITS = ("train", "valid", "test")
+
+
+@dataclass
+class FrameRatio:
+    """One frame, its dominant-bbox ratio, and how to load it for export."""
+
+    source: str
+    ratio: float
+    n_boxes: int
+    # Normalized [0,1] boxes (x1, y1, x2, y2) for drawing at export time.
+    norm_boxes: list[tuple[float, float, float, float]]
+    # Locators (exactly one applies per source).
+    image_path: str | None = None
+    video_key: tuple[str, ...] | None = None
+    frame_index: int = -1
+
+
+def _roboflow_frames(web_root: Path) -> Iterator[FrameRatio]:
+    """Yield per-frame ratios for all configured Roboflow COCO exports."""
+    for name in _ROBOFLOW_DATASETS:
+        dataset_dir = web_root / name
+        for raw_split in _RAW_SPLITS:
+            split_dir = dataset_dir / raw_split
+            annotations = split_dir / "_annotations.coco.json"
+            if not annotations.exists():
+                continue
+            coco = load_json(annotations)
+            ball_categories = {
+                category["id"]
+                for category in coco["categories"]
+                if str(category.get("supercategory", "none")).lower() != "none"
+            }
+            boxes_by_image: dict[int, list[list[float]]] = defaultdict(list)
+            for ann in coco["annotations"]:
+                if ann["category_id"] not in ball_categories:
+                    continue
+                boxes_by_image[ann["image_id"]].append([float(v) for v in ann["bbox"]])
+            for image in coco["images"]:
+                boxes = boxes_by_image.get(image["id"], [])
+                if not boxes:
+                    continue
+                w_img = float(image["width"])
+                h_img = float(image["height"])
+                norm_boxes: list[tuple[float, float, float, float]] = []
+                ratio = 0.0
+                for x, y, bw, bh in boxes:
+                    ratio = max(ratio, bbox_max_side_ratio(bw, bh, w_img, h_img))
+                    norm_boxes.append(
+                        (x / w_img, y / h_img, (x + bw) / w_img, (y + bh) / h_img)
+                    )
+                yield FrameRatio(
+                    source=name,
+                    ratio=ratio,
+                    n_boxes=len(boxes),
+                    norm_boxes=norm_boxes,
+                    image_path=str(split_dir / image["file_name"]),
+                )
+
+
+def _ball_yolo_frames(web_root: Path) -> Iterator[FrameRatio]:
+    """Yield per-frame ratios for the Ball-YOLO labels mapped to source videos."""
+    labels_root = web_root / "ball_yolo_sport_ball_labels" / "tennis" / "Labels"
+    videos_dir = web_root / "sport_ball_detection_videos" / "tennis" / "Videos"
+    mapping_csv = web_root / "ball_yolo_tennis_video_mapping.csv"
+    if not mapping_csv.exists():
+        return
+    with mapping_csv.open(encoding="utf-8") as handle:
+        mapping = {row["label_folder"]: row for row in csv.DictReader(handle)}
+    for folder in sorted(labels_root.iterdir()):
+        if not folder.is_dir() or folder.name not in mapping:
+            continue
+        parts = [
+            videos_dir / part
+            for part in mapping[folder.name]["official_video_files"].split(";")
+        ]
+        parts = [part for part in parts if part.exists()]
+        if not parts:
+            continue
+        video_key = tuple(str(part) for part in parts)
+        for label_file in folder.glob("*.txt"):
+            frame_index = int(label_file.stem.rsplit("_", 1)[1])
+            norm_boxes: list[tuple[float, float, float, float]] = []
+            ratio = 0.0
+            for line in label_file.read_text(encoding="utf-8").splitlines():
+                fields = line.split()
+                if len(fields) < 5:
+                    continue
+                cx, cy, bw, bh = (float(v) for v in fields[1:5])
+                ratio = max(ratio, bbox_max_side_ratio(bw, bh, 1.0, 1.0))
+                norm_boxes.append(
+                    (cx - bw / 2.0, cy - bh / 2.0, cx + bw / 2.0, cy + bh / 2.0)
+                )
+            if not norm_boxes:
+                continue
+            yield FrameRatio(
+                source="ball_yolo",
+                ratio=ratio,
+                n_boxes=len(norm_boxes),
+                norm_boxes=norm_boxes,
+                video_key=video_key,
+                frame_index=frame_index,
+            )
+
+
+def _collect(cfg: DictConfig, web_root: Path) -> list[FrameRatio]:
+    """Run the enabled source readers and collect all frame ratios."""
+    frames: list[FrameRatio] = []
+    if bool(cfg.sources.roboflow):
+        for frame in tqdm(_roboflow_frames(web_root), desc="roboflow"):
+            frames.append(frame)
+    if bool(cfg.sources.ball_yolo):
+        for frame in tqdm(_ball_yolo_frames(web_root), desc="ball_yolo"):
+            frames.append(frame)
+    return frames
+
+
+def _write_frame_ratios(path: Path, frames: list[FrameRatio]) -> None:
+    """Persist the per-frame ratio table (reusable by the cleaning step)."""
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            ["source", "ratio", "n_boxes", "image_path", "video_key", "frame_index"]
+        )
+        for frame in frames:
+            writer.writerow(
+                [
+                    frame.source,
+                    f"{frame.ratio:.6f}",
+                    frame.n_boxes,
+                    frame.image_path or "",
+                    ";".join(frame.video_key) if frame.video_key else "",
+                    frame.frame_index,
+                ]
+            )
+
+
+def _write_sweep(
+    csv_path: Path,
+    md_path: Path,
+    frames: list[FrameRatio],
+    thresholds: list[float],
+) -> list[tuple[float, int, float]]:
+    """Write removal counts per threshold, overall and per source."""
+    sources = sorted({frame.source for frame in frames})
+    by_source: dict[str, np.ndarray] = {
+        source: np.array(
+            [frame.ratio for frame in frames if frame.source == source],
+            dtype=np.float64,
+        )
+        for source in sources
+    }
+    all_ratios = np.array([frame.ratio for frame in frames], dtype=np.float64)
+    total = len(all_ratios)
+
+    rows: list[list[Any]] = []
+    overall: list[tuple[float, int, float]] = []
+    for threshold in thresholds:
+        removed = int((all_ratios >= threshold).sum())
+        pct = 100.0 * removed / total if total else 0.0
+        overall.append((threshold, removed, pct))
+        row: list[Any] = [f"{threshold:.2f}", removed, f"{pct:.2f}"]
+        for source in sources:
+            ratios = by_source[source]
+            src_removed = int((ratios >= threshold).sum())
+            src_pct = 100.0 * src_removed / len(ratios) if len(ratios) else 0.0
+            row += [src_removed, f"{src_pct:.2f}"]
+        rows.append(row)
+
+    header = ["threshold", "removed", "removed_pct"]
+    for source in sources:
+        header += [f"{source}_removed", f"{source}_pct"]
+    with csv_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+    lines = [
+        f"# Web bbox max-side ratio sweep (total frames with boxes: {total})",
+        "",
+        "ratio = max over boxes of max(w/W, h/H); a frame is *removed* if ratio >= threshold.",
+        "",
+        "| " + " | ".join(header) + " |",
+        "|" + "|".join(["---"] * len(header)) + "|",
+    ]
+    lines += ["| " + " | ".join(str(value) for value in row) + " |" for row in rows]
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return overall
+
+
+def _write_histogram(path: Path, frames: list[FrameRatio]) -> None:
+    """Write a fixed-width ratio histogram."""
+    ratios = np.array([frame.ratio for frame in frames], dtype=np.float64)
+    edges = np.linspace(0.0, 1.0, 51)
+    counts, _ = np.histogram(np.clip(ratios, 0.0, 1.0), bins=edges)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["bin_lo", "bin_hi", "count"])
+        for lo, hi, count in zip(edges[:-1], edges[1:], counts, strict=False):
+            writer.writerow([f"{lo:.3f}", f"{hi:.3f}", int(count)])
+
+
+def _draw(image: np.ndarray, frame: FrameRatio) -> np.ndarray:
+    """Draw normalized boxes and the ratio label on a copy of the image."""
+    out = image.copy()
+    h, w = out.shape[:2]
+    for nx1, ny1, nx2, ny2 in frame.norm_boxes:
+        p1 = (int(round(nx1 * w)), int(round(ny1 * h)))
+        p2 = (int(round(nx2 * w)), int(round(ny2 * h)))
+        cv2.rectangle(out, p1, p2, (0, 0, 255), 2)
+    cv2.putText(
+        out,
+        f"ratio={frame.ratio:.3f} n={frame.n_boxes}",
+        (6, 22),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.7,
+        (0, 255, 0),
+        2,
+        cv2.LINE_AA,
+    )
+    return out
+
+
+def _bin_label(edges: list[float], ratio: float) -> tuple[int, str]:
+    """Return the bin index and a human label for a ratio."""
+    for index in range(len(edges) - 1):
+        if edges[index] <= ratio < edges[index + 1]:
+            return index, f"bin_{edges[index]:.2f}-{edges[index + 1]:.2f}"
+    last = len(edges) - 2
+    return last, f"bin_{edges[last]:.2f}-{edges[last + 1]:.2f}"
+
+
+def _export_samples(cfg: DictConfig, frames: list[FrameRatio], out_root: Path) -> None:
+    """Export up to ``samples_per_bin`` annotated frames per (source, ratio bin)."""
+    edges = [float(value) for value in cfg.export_bin_edges]
+    per_bin = int(cfg.samples_per_bin)
+    rng = random.Random(int(cfg.seed))
+
+    buckets: dict[tuple[str, str], list[FrameRatio]] = defaultdict(list)
+    for frame in frames:
+        _, label = _bin_label(edges, frame.ratio)
+        buckets[(frame.source, label)].append(frame)
+
+    selected: list[FrameRatio] = []
+    bucket_dir: dict[int, Path] = {}
+    for (source, label), members in buckets.items():
+        rng.shuffle(members)
+        chosen = members[:per_bin]
+        target = out_root / source / label
+        ensure_dir(target)
+        for frame in chosen:
+            bucket_dir[id(frame)] = target
+            selected.append(frame)
+
+    # Roboflow: still images on disk.
+    for frame in tqdm(
+        [f for f in selected if f.image_path], desc="export-roboflow"
+    ):
+        image = cv2.imread(frame.image_path)
+        if image is None:
+            continue
+        target = bucket_dir[id(frame)]
+        name = Path(cast(str, frame.image_path)).stem
+        cv2.imwrite(str(target / f"{name}.jpg"), _draw(image, frame))
+
+    # Ball-YOLO: decode only the sampled frames, grouped per video.
+    by_video: dict[tuple[str, ...], list[FrameRatio]] = defaultdict(list)
+    for frame in selected:
+        if frame.video_key is not None:
+            by_video[frame.video_key].append(frame)
+    for video_key, members in tqdm(by_video.items(), desc="export-ball_yolo"):
+        wanted = {frame.frame_index: frame for frame in members}
+        for index, jpeg in iter_selected_video_jpegs(
+            list(video_key), set(wanted), quality=int(cfg.jpeg_quality)
+        ):
+            frame = wanted[index]
+            buffer = np.frombuffer(jpeg, dtype=np.uint8)
+            image = cv2.imdecode(buffer, cv2.IMREAD_COLOR)
+            if image is None:
+                continue
+            target = bucket_dir[id(frame)]
+            stem = Path(video_key[0]).stem
+            cv2.imwrite(str(target / f"{stem}_f{index:06d}.jpg"), _draw(image, frame))
+
+
+def _hydra_main(*args: Any, **kwargs: Any) -> Callable[[Any], Any]:
+    return cast(Callable[[Any], Any], hydra.main(*args, **kwargs))
+
+
+@_hydra_main(
+    config_path="../configs",
+    config_name="analyze_web_bbox_ratio",
+    version_base="1.3",
+)
+def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
+    """Collect ratios, write the sweep tables, and export sample frames."""
+    analyze = cfg.analyze
+    web_root = Path(to_absolute_path(str(analyze.web_root)))
+    out_root = Path(to_absolute_path(str(analyze.output_dir)))
+    ensure_dir(out_root)
+
+    frames = _collect(analyze, web_root)
+    if not frames:
+        print("[analyze_web_bbox_ratio] no bbox-bearing frames found.")
+        return 1
+    print(f"[analyze_web_bbox_ratio] collected {len(frames)} frames with boxes.")
+
+    _write_frame_ratios(out_root / "frame_ratios.csv", frames)
+    overall = _write_sweep(
+        out_root / "sweep.csv",
+        out_root / "sweep.md",
+        frames,
+        [float(value) for value in analyze.sweep_thresholds],
+    )
+    _write_histogram(out_root / "histogram.csv", frames)
+
+    print("[analyze_web_bbox_ratio] removal sweep (threshold: removed frames, %):")
+    for threshold, removed, pct in overall:
+        print(f"    >= {threshold:.2f}: {removed:6d}  ({pct:5.2f}%)")
+
+    _export_samples(analyze, frames, out_root / "samples")
+    print(f"[analyze_web_bbox_ratio] wrote outputs under {out_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tasks/ball_detection/scripts/convert_web_dataset.py
+++ b/src/tasks/ball_detection/scripts/convert_web_dataset.py
@@ -102,7 +102,12 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
 
         writer.close()
         index.save(build_dir)
-        write_manifest(build_dir, index, writer)
+        write_manifest(
+            build_dir,
+            index,
+            writer,
+            max_bbox_side_ratio=_optional_float(convert.get("max_bbox_side_ratio")),
+        )
         write_store_readme(build_dir)
         publish_store(build_dir, output_dir)
     except BaseException:
@@ -137,9 +142,10 @@ def _build_parsers(convert: Any, web_root: Path) -> list[WebDatasetParser]:
         seed=int(convert.split_seed),
     )
     quality = int(convert.jpeg_quality)
+    max_ratio = _optional_float(convert.get("max_bbox_side_ratio"))
     parsers: list[WebDatasetParser] = []
     if bool(convert.sources.roboflow):
-        parsers.append(RoboflowParser(web_root, split_config))
+        parsers.append(RoboflowParser(web_root, split_config, max_ratio))
     if bool(convert.sources.racketvision):
         parsers.append(RacketVisionParser(web_root, quality))
     if bool(convert.sources.kaggle):
@@ -152,8 +158,13 @@ def _build_parsers(convert: Any, web_root: Path) -> list[WebDatasetParser]:
             )
         )
     if bool(convert.sources.ball_yolo):
-        parsers.append(BallYoloParser(web_root, quality, split_config))
+        parsers.append(BallYoloParser(web_root, quality, split_config, max_ratio))
     return parsers
+
+
+def _optional_float(value: Any) -> float | None:
+    """Coerce a possibly-null Hydra scalar to ``float | None``."""
+    return None if value is None else float(value)
 
 
 if __name__ == "__main__":

--- a/src/utils/geometry/bbox.py
+++ b/src/utils/geometry/bbox.py
@@ -1,0 +1,23 @@
+"""Generic bounding-box geometry helpers."""
+
+from __future__ import annotations
+
+
+def bbox_max_side_ratio(
+    box_w: float,
+    box_h: float,
+    img_w: float,
+    img_h: float,
+) -> float:
+    """Return the larger of ``box_w / img_w`` and ``box_h / img_h``.
+
+    This measures how dominant a box is relative to the frame: the fraction of
+    the image side spanned by the matching box side, taken over whichever side
+    is more dominant. For already-normalized boxes pass ``img_w = img_h = 1.0``.
+    """
+    if img_w <= 0.0 or img_h <= 0.0:
+        raise ValueError(f"image size must be positive, got ({img_w}, {img_h}).")
+    return max(box_w / img_w, box_h / img_h)
+
+
+__all__ = ["bbox_max_side_ratio"]

--- a/tests/unit/utils/geometry/test_bbox.py
+++ b/tests/unit/utils/geometry/test_bbox.py
@@ -1,0 +1,27 @@
+"""Unit tests for :mod:`src.utils.geometry.bbox`."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.geometry.bbox import bbox_max_side_ratio
+
+
+class TestBboxMaxSideRatio:
+    def test_picks_the_more_dominant_side(self) -> None:
+        # width spans 50% of the frame, height spans 10%; the max wins.
+        assert bbox_max_side_ratio(100.0, 20.0, 200.0, 200.0) == pytest.approx(0.5)
+
+    def test_height_can_be_the_dominant_side(self) -> None:
+        assert bbox_max_side_ratio(10.0, 80.0, 100.0, 100.0) == pytest.approx(0.8)
+
+    def test_normalized_boxes_use_unit_image_size(self) -> None:
+        # YOLO-style normalized w/h: ratio is just max(w, h).
+        assert bbox_max_side_ratio(0.3, 0.12, 1.0, 1.0) == pytest.approx(0.3)
+
+    def test_full_frame_box_is_one(self) -> None:
+        assert bbox_max_side_ratio(640.0, 480.0, 640.0, 480.0) == pytest.approx(1.0)
+
+    def test_non_positive_image_size_raises(self) -> None:
+        with pytest.raises(ValueError):
+            bbox_max_side_ratio(1.0, 1.0, 0.0, 10.0)


### PR DESCRIPTION
## 概要

Web由来の静止画ソース（Roboflow COCO / Ball-YOLO）に混在する「ボールのアップ（接写）」フレームを、変換時に除外するドメインクリーニングを追加します。接写はラリーカメラの検出ドメインと異なるため、本番学習データから外します。

## 変更内容

- 共有ヘルパ `src/utils/geometry/bbox.py` に `bbox_max_side_ratio`（`max(w/W, h/H)`）を追加。sweep ツールと変換器で指標を一元化。
- roboflow / ball_yolo パーサに max辺比フィルタを追加。フレームの max辺比が `convert.max_bbox_side_ratio`（既定 `0.10`）以上なら、そのフレームを丸ごと除外。点ラベルのみの temporal ソース（racketvision / kaggle）は bbox を持たず不変。
- `convert_web_dataset.yaml` に `max_bbox_side_ratio: 0.10` を追加（`null` で無効）。閾値を store manifest に記録（来歴）。
- 解析スクリプト `analyze_web_bbox_ratio.py` + config を追加。max辺比を sweep し、bin ごとに候補フレームを `outputs/` に出力して目視で閾値を決定可能。
- ユニットテスト `tests/unit/utils/geometry/test_bbox.py` を追加。

## 検証

- `pytest tests/unit/utils/geometry/test_bbox.py` → 5 passed。
- ruff / mypy / pre-commit（script reviewer 含む）通過。
- パーサ直接実行での除外数が sweep 予測と完全一致：roboflow_wafqb_v2 −7,987 / 1wnxz −3 / ball_yolo −120（計 −8,110）。
- `convert.overwrite=true` で unified store を再生成し、schema v2・`max_bbox_side_ratio: 0.1` 記録・ロード確認済み。

## 関連Issue

- References #552

## 補足

- 閾値 0.10 は `outputs/web_bbox_ratio_sweep` の目視レビューで決定（接写は確実に除去しつつ放送ズームの取りこぼしを抑制）。
- 再生成された store（`data/tennis/web/unified`）と sweep 成果物（`outputs/`）はいずれも .gitignore 対象のため本PRには含まれません。生データは無傷で、閾値変更時は config を変えて再生成可能。
