### PR TITLE
feat: DINOv3 バックボーンへの共通 LoRA 追加（ball/court detection）

### DIFF
--- a/src/tasks/ball_detection/configs/model/dinov3_rope.yaml
+++ b/src/tasks/ball_detection/configs/model/dinov3_rope.yaml
@@ -14,6 +14,15 @@ backbone:
   # frozen | last_n_blocks | full
   train_mode: frozen
   last_n_blocks: 0
+  # Low-rank adaptation of the frozen backbone. When `enabled: true` the base
+  # weights stay frozen and only the injected adapters train (overrides
+  # `train_mode`). Enable conveniently with `training=lora`.
+  lora:
+    enabled: false
+    rank: 8
+    alpha: 16.0
+    dropout: 0.0
+    target_modules: [qkv, proj, fc1, fc2]
 
 decoder:
   dim: 256

--- a/src/tasks/ball_detection/configs/training/_lora.yaml
+++ b/src/tasks/ball_detection/configs/training/_lora.yaml
@@ -1,0 +1,22 @@
+# @package _global_
+#
+# LoRA fine-tuning override for the DINOv3 backbone.
+#
+# This fragment is packaged at the global root so it can inject the LoRA block
+# into `model.backbone.lora`, which is read by `DINOv3RoPEBallDetector.from_config`.
+# It only takes effect with a DINOv3 backbone model, e.g.:
+#
+#   python -m src.tasks.ball_detection.scripts.train \
+#       model=dinov3_rope training=lora
+#
+# The base backbone weights stay frozen; only the low-rank adapters train.
+model:
+  backbone:
+    lora:
+      enabled: true
+      rank: 8
+      alpha: 16.0
+      dropout: 0.0
+      # Local nn.Linear names wrapped inside each DINOv3 block:
+      # attention (qkv, proj) and MLP (fc1, fc2).
+      target_modules: [qkv, proj, fc1, fc2]

--- a/src/tasks/ball_detection/configs/training/lora.yaml
+++ b/src/tasks/ball_detection/configs/training/lora.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - default
+  - _lora
+  - _self_

--- a/src/tasks/ball_detection/models/dinov3_rope.py
+++ b/src/tasks/ball_detection/models/dinov3_rope.py
@@ -20,12 +20,14 @@ from src.utils.models.components import (
 from src.utils.models.components.rope import RopeBaseLike
 from src.utils.models.loading import (
     DEFAULT_DINOV3_CHECKPOINT,
+    DEFAULT_DINOV3_LORA_TARGET_MODULES,
     DEFAULT_DINOV3_REPOSITORY,
     DINOv3BackboneAdapter,
     DINOv3TrainMode,
     configure_dinov3_trainability,
     load_dinov3_backbone,
 )
+from src.utils.models.lora import LoRAConfig
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -95,8 +97,7 @@ class FrameSharedHeatmapHead(nn.Module):
         """Map ``(B*T, C, Hp, Wp)`` patch grids to dense frame logits."""
         if features.ndim != 4:
             raise ValueError(
-                "Heatmap head expects (B*T, C, Hp, Wp), "
-                f"got {tuple(features.shape)}."
+                f"Heatmap head expects (B*T, C, Hp, Wp), got {tuple(features.shape)}."
             )
         return self.network(features)
 
@@ -117,6 +118,7 @@ class DINOv3RoPEBallDetector(nn.Module):
         backbone_strict: bool = True,
         backbone_train_mode: DINOv3TrainMode = "frozen",
         backbone_last_n_blocks: int = 0,
+        backbone_lora: LoRAConfig | None = None,
         decoder_dim: int = 256,
         decoder_layers: int = 4,
         decoder_heads: int = 8,
@@ -145,6 +147,10 @@ class DINOv3RoPEBallDetector(nn.Module):
         self.num_frames = int(num_frames)
         self.image_size = tuple(int(value) for value in image_size)
         self.backbone_train_mode = backbone_train_mode
+        self.backbone_lora = backbone_lora
+        self.backbone_lora_enabled = bool(
+            backbone_lora is not None and backbone_lora.enabled
+        )
         self.decoder_gradient_checkpointing = bool(decoder_gradient_checkpointing)
         self.decoder_rope_base = decoder_rope_base
 
@@ -158,6 +164,7 @@ class DINOv3RoPEBallDetector(nn.Module):
             self.backbone,
             train_mode=self.backbone_train_mode,
             last_n_blocks=backbone_last_n_blocks,
+            lora=backbone_lora,
         )
         self.patch_size = self.backbone.patch_size
         if any(size % self.patch_size != 0 for size in self.image_size):
@@ -256,6 +263,10 @@ class DINOv3RoPEBallDetector(nn.Module):
                 str(backbone_cfg.get("train_mode", "frozen")),
             ),
             backbone_last_n_blocks=int(backbone_cfg.get("last_n_blocks", 0)),
+            backbone_lora=LoRAConfig.from_mapping(
+                backbone_cfg.get("lora"),
+                default_target_modules=DEFAULT_DINOV3_LORA_TARGET_MODULES,
+            ),
             decoder_dim=int(decoder_cfg.get("dim", 256)),
             decoder_layers=int(decoder_cfg.get("num_layers", 4)),
             decoder_heads=int(decoder_cfg.get("num_heads", 8)),
@@ -272,7 +283,7 @@ class DINOv3RoPEBallDetector(nn.Module):
     def train(self, mode: bool = True) -> DINOv3RoPEBallDetector:
         """Keep a frozen backbone deterministic while training the decoder."""
         super().train(mode)
-        if self.backbone_train_mode == "frozen":
+        if self.backbone_train_mode == "frozen" and not self.backbone_lora_enabled:
             self.backbone.eval()
         return self
 
@@ -362,11 +373,9 @@ class DINOv3RoPEBallDetector(nn.Module):
         )
 
     def _extract_patch_tokens(self, flat_frames: torch.Tensor) -> torch.Tensor:
-        if self.backbone_train_mode == "frozen":
+        if self.backbone_train_mode == "frozen" and not self.backbone_lora_enabled:
             with torch.no_grad():
-                return self.backbone.forward_features(flat_frames)[
-                    "x_norm_patchtokens"
-                ]
+                return self.backbone.forward_features(flat_frames)["x_norm_patchtokens"]
         return self.backbone.forward_features(flat_frames)["x_norm_patchtokens"]
 
     def _validate_forward_input(self, frames: torch.Tensor) -> None:

--- a/src/tasks/court_detection/configs/model/court_seg_dinov3_detr.yaml
+++ b/src/tasks/court_detection/configs/model/court_seg_dinov3_detr.yaml
@@ -8,6 +8,15 @@ backbone:
   checkpoint_path: third_party/dinov3/checkpoints/dinov3_vitb16_pretrain_lvd1689m-73cec8be.pth
   strict: true
   freeze: true
+  # Low-rank adaptation of the frozen backbone. When `enabled: true` the base
+  # weights stay frozen and only the injected adapters train (overrides
+  # `freeze`). Enable conveniently with `training=lora`.
+  lora:
+    enabled: false
+    rank: 8
+    alpha: 16.0
+    dropout: 0.0
+    target_modules: [qkv, proj, fc1, fc2]
 
 decoder:
   hidden_dim: 256

--- a/src/tasks/court_detection/configs/training/_lora.yaml
+++ b/src/tasks/court_detection/configs/training/_lora.yaml
@@ -1,0 +1,22 @@
+# @package _global_
+#
+# LoRA fine-tuning override for the DINOv3 backbone.
+#
+# This fragment is packaged at the global root so it can inject the LoRA block
+# into `model.backbone.lora`, which is read by `DINOv3DETR.from_config`.
+# It only takes effect with the DINOv3 backbone model, e.g.:
+#
+#   python -m src.tasks.court_detection.scripts.train \
+#       model=court_seg_dinov3_detr training=lora
+#
+# The base backbone weights stay frozen; only the low-rank adapters train.
+model:
+  backbone:
+    lora:
+      enabled: true
+      rank: 8
+      alpha: 16.0
+      dropout: 0.0
+      # Local nn.Linear names wrapped inside each DINOv3 block:
+      # attention (qkv, proj) and MLP (fc1, fc2).
+      target_modules: [qkv, proj, fc1, fc2]

--- a/src/tasks/court_detection/configs/training/lora.yaml
+++ b/src/tasks/court_detection/configs/training/lora.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - default
+  - _lora
+  - _self_

--- a/src/tasks/court_detection/models/dinov3_detr.py
+++ b/src/tasks/court_detection/models/dinov3_detr.py
@@ -24,10 +24,13 @@ import torch.nn.functional as F
 
 from src.utils.models.loading import (
     DEFAULT_DINOV3_CHECKPOINT,
+    DEFAULT_DINOV3_LORA_TARGET_MODULES,
     DEFAULT_DINOV3_REPOSITORY,
     DINOv3BackboneAdapter,
+    apply_dinov3_lora,
     load_dinov3_backbone,
 )
+from src.utils.models.lora import LoRAConfig
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -198,6 +201,7 @@ class DINOv3DETR(nn.Module):
         backbone_name: str = "dinov3_vitb16",
         backbone_strict: bool = True,
         freeze_backbone: bool = True,
+        backbone_lora: LoRAConfig | None = None,
         hidden_dim: int = 256,
         num_queries: int = 100,
         num_decoder_layers: int = 6,
@@ -223,6 +227,10 @@ class DINOv3DETR(nn.Module):
         self.in_channels = int(in_channels)
         self.num_classes = int(num_classes)
         self.freeze_backbone = bool(freeze_backbone)
+        self.backbone_lora = backbone_lora
+        self.backbone_lora_enabled = bool(
+            backbone_lora is not None and backbone_lora.enabled
+        )
         self.backbone = load_dinov3_backbone(
             repository_path=backbone_repository_path,
             checkpoint_path=backbone_checkpoint_path,
@@ -232,7 +240,11 @@ class DINOv3DETR(nn.Module):
         backbone_dim = self.backbone.embed_dim
         self.patch_size = self.backbone.patch_size
 
-        if self.freeze_backbone:
+        if backbone_lora is not None and backbone_lora.enabled:
+            # LoRA freezes the base backbone and trains only the injected
+            # adapters; gradients must flow through the backbone forward pass.
+            apply_dinov3_lora(self.backbone, backbone_lora)
+        elif self.freeze_backbone:
             self.backbone.requires_grad_(False)
 
         self.memory_projection = nn.Conv2d(backbone_dim, hidden_dim, kernel_size=1)
@@ -333,6 +345,10 @@ class DINOv3DETR(nn.Module):
             backbone_name=str(backbone_cfg.get("name", "dinov3_vitb16")),
             backbone_strict=bool(backbone_cfg.get("strict", True)),
             freeze_backbone=bool(backbone_cfg.get("freeze", True)),
+            backbone_lora=LoRAConfig.from_mapping(
+                backbone_cfg.get("lora"),
+                default_target_modules=DEFAULT_DINOV3_LORA_TARGET_MODULES,
+            ),
             hidden_dim=int(decoder_cfg.get("hidden_dim", 256)),
             num_queries=int(decoder_cfg.get("num_queries", 100)),
             num_decoder_layers=int(decoder_cfg.get("num_layers", 6)),
@@ -377,7 +393,7 @@ class DINOv3DETR(nn.Module):
         return self.segmentation_head.semantic_logits(self.forward_query_outputs(x))
 
     def _extract_patch_features(self, x: torch.Tensor) -> torch.Tensor:
-        if self.freeze_backbone:
+        if self.freeze_backbone and not self.backbone_lora_enabled:
             with torch.no_grad():
                 backbone_outputs = self.backbone.forward_features(x)
         else:

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -46,6 +46,7 @@ types**, it belongs here (or should be promoted here), not in the task module.
 | Sample video frame indices | `sample_uniform_frame_indices()`, `sample_frame_indices_by_time_ranges()` | `from src.utils.video import ...` |
 | Download/transcode YouTube videos | `download_youtube_video()`, `transcode_h264_video()` | `from src.utils.video import ...` |
 | Transformer / MoE / RoPE blocks | `TransformerBlock`, `MoELayer`, RoPE helpers, `MLPHead` | `from src.utils.models import ...` |
+| LoRA-adapt a frozen backbone | `LoRAConfig`, `apply_lora()`, `apply_dinov3_lora()`, `configure_dinov3_trainability(..., lora=...)` | `from src.utils.models import ...` / `from src.utils.models.loading import ...` |
 
 ## Modules
 
@@ -88,7 +89,8 @@ types**, it belongs here (or should be promoted here), not in the task module.
 
 ### Other packages (pre-existing)
 - **`models/`** — DeepSeek-style Transformer blocks, MoE, RoPE, attention,
-  `MLPHead`, domain token embeddings, DINOv3 backbone loading.
+  `MLPHead`, domain token embeddings, DINOv3 backbone loading, LoRA adaptation
+  (`lora.py`).
 - **`projection/`** — pinhole `Camera`, `CameraProjector`, `make_look_at_camera`,
   `project_points`.
 - **`rendering/`** — `CourtRenderer`, `SkeletonRenderer`, `BallRenderer`.

--- a/src/utils/models/__init__.py
+++ b/src/utils/models/__init__.py
@@ -35,6 +35,13 @@ from src.utils.models.embeddings import (
     InvisibleTokenEmbedding,
     PlayerKPUVEmbedding,
 )
+from src.utils.models.lora import (
+    LoRAConfig,
+    LoRALinear,
+    apply_lora,
+    iter_lora_parameters,
+    mark_only_lora_as_trainable,
+)
 from src.utils.models.transformer_utils import (
     build_self_attn_mask,
     resolve_rope_bases,
@@ -73,6 +80,12 @@ __all__ = [
     "BallUVEmbedding",
     "Ball3DEmbedding",
     "TransformerSequenceDiscriminator",
+    # LoRA adaptation
+    "LoRAConfig",
+    "LoRALinear",
+    "apply_lora",
+    "iter_lora_parameters",
+    "mark_only_lora_as_trainable",
     # Shared transformer utilities
     "build_self_attn_mask",
     "resolve_rope_bases",

--- a/src/utils/models/loading/__init__.py
+++ b/src/utils/models/loading/__init__.py
@@ -9,20 +9,24 @@ from src.utils.models.loading.dino_backbone import (
 )
 from src.utils.models.loading.dinov3 import (
     DEFAULT_DINOV3_CHECKPOINT,
+    DEFAULT_DINOV3_LORA_TARGET_MODULES,
     DEFAULT_DINOV3_REPOSITORY,
     DINOv3BackboneAdapter,
     DINOv3TrainMode,
+    apply_dinov3_lora,
     configure_dinov3_trainability,
     load_dinov3_backbone,
 )
 
 __all__ = [
     "DEFAULT_DINOV3_CHECKPOINT",
+    "DEFAULT_DINOV3_LORA_TARGET_MODULES",
     "DEFAULT_DINOV3_REPOSITORY",
     "DINOBackboneMetadata",
     "DINOv3BackboneAdapter",
     "DINOv3TrainMode",
     "LoadedDINOBackbone",
+    "apply_dinov3_lora",
     "configure_dinov3_trainability",
     "get_dino_backbone_metadata",
     "load_dino_backbone",

--- a/src/utils/models/loading/dinov3.py
+++ b/src/utils/models/loading/dinov3.py
@@ -9,6 +9,7 @@ from typing import Any, Literal, cast
 import torch
 from torch import nn
 
+from src.utils.models.lora import LoRAConfig, apply_lora
 from src.utils.paths import resolve_project_path
 
 DEFAULT_DINOV3_REPOSITORY = Path("third_party/dinov3")
@@ -16,6 +17,8 @@ DEFAULT_DINOV3_CHECKPOINT = Path(
     "third_party/dinov3/checkpoints/dinov3_vitb16_pretrain_lvd1689m-73cec8be.pth"
 )
 DINOv3TrainMode = Literal["frozen", "last_n_blocks", "full"]
+# Attention (qkv/proj) and MLP (fc1/fc2) projections inside each DINOv3 block.
+DEFAULT_DINOV3_LORA_TARGET_MODULES: tuple[str, ...] = ("qkv", "proj", "fc1", "fc2")
 
 
 class DINOv3BackboneAdapter(nn.Module):
@@ -114,13 +117,43 @@ def load_dinov3_backbone(
     return DINOv3BackboneAdapter(backbone)
 
 
+def apply_dinov3_lora(
+    backbone: DINOv3BackboneAdapter,
+    lora: LoRAConfig,
+) -> list[str]:
+    """Freeze the backbone and attach trainable LoRA adapters to its blocks.
+
+    The base backbone weights are frozen; only the injected LoRA factors remain
+    trainable. Returns the qualified names of the wrapped linear layers.
+    """
+    if not lora.enabled:
+        raise ValueError("apply_dinov3_lora requires an enabled LoRAConfig.")
+    backbone.requires_grad_(False)
+    return apply_lora(
+        backbone.module,
+        rank=lora.rank,
+        alpha=lora.alpha,
+        dropout=lora.dropout,
+        target_modules=lora.target_modules,
+    )
+
+
 def configure_dinov3_trainability(
     backbone: DINOv3BackboneAdapter,
     *,
     train_mode: DINOv3TrainMode,
     last_n_blocks: int = 0,
+    lora: LoRAConfig | None = None,
 ) -> None:
-    """Configure ``frozen``, ``last_n_blocks``, or ``full`` backbone training."""
+    """Configure ``frozen``, ``last_n_blocks``, ``full``, or LoRA training.
+
+    When ``lora`` is provided and enabled, the base backbone is frozen and LoRA
+    adapters are injected regardless of ``train_mode`` (only the adapters train).
+    """
+    if lora is not None and lora.enabled:
+        apply_dinov3_lora(backbone, lora)
+        return
+
     if train_mode not in {"frozen", "last_n_blocks", "full"}:
         raise ValueError(
             "DINOv3 train_mode must be one of "
@@ -155,9 +188,11 @@ def configure_dinov3_trainability(
 
 __all__ = [
     "DEFAULT_DINOV3_CHECKPOINT",
+    "DEFAULT_DINOV3_LORA_TARGET_MODULES",
     "DEFAULT_DINOV3_REPOSITORY",
     "DINOv3BackboneAdapter",
     "DINOv3TrainMode",
+    "apply_dinov3_lora",
     "configure_dinov3_trainability",
     "load_dinov3_backbone",
 ]

--- a/src/utils/models/lora.py
+++ b/src/utils/models/lora.py
@@ -1,0 +1,210 @@
+"""Reusable Low-Rank Adaptation (LoRA) helpers for ``nn.Linear`` modules.
+
+LoRA (Hu et al., 2021) freezes a pretrained linear weight ``W`` and learns a
+low-rank update ``B @ A`` so that the effective transform becomes
+``W x + (alpha / rank) * B (A x)``. Only the small ``A`` and ``B`` factors are
+trained, which makes it a cheap way to adapt a frozen backbone such as DINOv3.
+
+This module is domain-agnostic: it wraps any ``torch.nn.Linear`` whose local
+attribute name matches the requested targets, leaving everything else untouched.
+Downstream tasks compose it through ``src.utils.models.loading.dinov3``.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from torch import nn
+
+DEFAULT_LORA_TARGET_MODULES: tuple[str, ...] = ("qkv", "proj")
+
+
+@dataclass(frozen=True)
+class LoRAConfig:
+    """Hyper-parameters that describe a LoRA adaptation.
+
+    Attributes:
+        enabled: Whether LoRA should be applied at all.
+        rank: Inner dimension ``r`` of the low-rank update. Must be positive.
+        alpha: Scaling numerator; the update is scaled by ``alpha / rank``.
+        dropout: Dropout probability applied to the LoRA input branch.
+        target_modules: Local attribute names of ``nn.Linear`` modules to wrap
+            (for example ``("qkv", "proj")`` for attention projections).
+    """
+
+    enabled: bool = False
+    rank: int = 8
+    alpha: float = 16.0
+    dropout: float = 0.0
+    target_modules: tuple[str, ...] = DEFAULT_LORA_TARGET_MODULES
+
+    def __post_init__(self) -> None:
+        if self.enabled:
+            if self.rank <= 0:
+                raise ValueError("LoRA rank must be positive when enabled.")
+            if self.alpha <= 0:
+                raise ValueError("LoRA alpha must be positive when enabled.")
+            if not 0.0 <= self.dropout < 1.0:
+                raise ValueError("LoRA dropout must be in [0, 1).")
+            if not self.target_modules:
+                raise ValueError("LoRA target_modules must be non-empty when enabled.")
+
+    @classmethod
+    def from_mapping(
+        cls,
+        mapping: Mapping[str, Any] | None,
+        *,
+        default_target_modules: Sequence[str] = DEFAULT_LORA_TARGET_MODULES,
+    ) -> LoRAConfig:
+        """Build a config from a (possibly ``None``) Hydra/OmegaConf mapping."""
+        if not mapping:
+            return cls(enabled=False, target_modules=tuple(default_target_modules))
+        raw_targets = mapping.get("target_modules")
+        if raw_targets is None:
+            target_modules = tuple(default_target_modules)
+        else:
+            target_modules = tuple(str(name) for name in raw_targets)
+        return cls(
+            enabled=bool(mapping.get("enabled", False)),
+            rank=int(mapping.get("rank", 8)),
+            alpha=float(mapping.get("alpha", 16.0)),
+            dropout=float(mapping.get("dropout", 0.0)),
+            target_modules=target_modules,
+        )
+
+
+class LoRALinear(nn.Module):
+    """Wrap a frozen ``nn.Linear`` with a trainable low-rank update."""
+
+    def __init__(
+        self,
+        base_linear: nn.Linear,
+        *,
+        rank: int,
+        alpha: float,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        if not isinstance(base_linear, nn.Linear):
+            raise TypeError("LoRALinear can only wrap nn.Linear modules.")
+        if rank <= 0:
+            raise ValueError("LoRA rank must be positive.")
+        if alpha <= 0:
+            raise ValueError("LoRA alpha must be positive.")
+        if not 0.0 <= dropout < 1.0:
+            raise ValueError("LoRA dropout must be in [0, 1).")
+
+        self.base = base_linear
+        self.base.requires_grad_(False)
+        self.in_features = base_linear.in_features
+        self.out_features = base_linear.out_features
+        self.rank = int(rank)
+        self.alpha = float(alpha)
+        self.scaling = self.alpha / self.rank
+
+        weight = base_linear.weight
+        self.lora_dropout: nn.Module = (
+            nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()
+        )
+        self.lora_a = nn.Parameter(
+            torch.empty(self.rank, self.in_features, dtype=weight.dtype)
+        )
+        self.lora_b = nn.Parameter(
+            torch.zeros(self.out_features, self.rank, dtype=weight.dtype)
+        )
+        # Kaiming init on A and zeros on B keep the initial update at zero, so
+        # the wrapped layer starts as an exact copy of the pretrained linear.
+        nn.init.kaiming_uniform_(self.lora_a, a=math.sqrt(5))
+        self._align_lora_to(weight.device)
+
+    def _align_lora_to(self, device: torch.device) -> None:
+        self.lora_a.data = self.lora_a.data.to(device)
+        self.lora_b.data = self.lora_b.data.to(device)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        base_output = self.base(inputs)
+        lora_input = self.lora_dropout(inputs)
+        update = torch.nn.functional.linear(lora_input, self.lora_a)
+        update = torch.nn.functional.linear(update, self.lora_b)
+        result: torch.Tensor = base_output + self.scaling * update
+        return result
+
+    def extra_repr(self) -> str:
+        return (
+            f"in_features={self.in_features}, out_features={self.out_features}, "
+            f"rank={self.rank}, alpha={self.alpha}"
+        )
+
+
+def apply_lora(
+    module: nn.Module,
+    *,
+    rank: int,
+    alpha: float,
+    dropout: float = 0.0,
+    target_modules: Sequence[str] = DEFAULT_LORA_TARGET_MODULES,
+) -> list[str]:
+    """Replace matching ``nn.Linear`` children with :class:`LoRALinear` in place.
+
+    A linear layer is wrapped when its local attribute name (the final
+    dotted component of its qualified name) appears in ``target_modules``.
+    Already-wrapped layers are skipped so the call is idempotent.
+
+    Returns the fully-qualified names of the wrapped linear layers.
+    """
+    targets = set(target_modules)
+    if not targets:
+        raise ValueError("target_modules must be non-empty.")
+
+    wrapped: list[str] = []
+    for parent_name, parent in module.named_modules():
+        for child_name, child in list(parent.named_children()):
+            if child_name not in targets:
+                continue
+            if isinstance(child, LoRALinear):
+                continue
+            if not isinstance(child, nn.Linear):
+                continue
+            setattr(
+                parent,
+                child_name,
+                LoRALinear(child, rank=rank, alpha=alpha, dropout=dropout),
+            )
+            qualified = f"{parent_name}.{child_name}" if parent_name else child_name
+            wrapped.append(qualified)
+
+    if not wrapped:
+        raise ValueError(
+            "apply_lora matched no nn.Linear modules for target_modules="
+            f"{sorted(targets)}."
+        )
+    return wrapped
+
+
+def iter_lora_parameters(module: nn.Module) -> Iterator[nn.Parameter]:
+    """Yield the trainable LoRA parameters contained in ``module``."""
+    for submodule in module.modules():
+        if isinstance(submodule, LoRALinear):
+            yield submodule.lora_a
+            yield submodule.lora_b
+
+
+def mark_only_lora_as_trainable(module: nn.Module) -> None:
+    """Freeze every parameter in ``module`` except the LoRA factors."""
+    module.requires_grad_(False)
+    for parameter in iter_lora_parameters(module):
+        parameter.requires_grad_(True)
+
+
+__all__ = [
+    "DEFAULT_LORA_TARGET_MODULES",
+    "LoRAConfig",
+    "LoRALinear",
+    "apply_lora",
+    "iter_lora_parameters",
+    "mark_only_lora_as_trainable",
+]

--- a/tests/unit/utils/models/test_dinov3_lora.py
+++ b/tests/unit/utils/models/test_dinov3_lora.py
@@ -1,0 +1,94 @@
+"""Tests for LoRA wiring in :mod:`src.utils.models.loading.dinov3`.
+
+These exercise the trainability/LoRA helpers against a tiny fake backbone so
+they stay fast and do not require the vendored DINOv3 weights.
+"""
+
+from __future__ import annotations
+
+import pytest
+from torch import nn
+
+from src.utils.models.loading.dinov3 import (
+    DINOv3BackboneAdapter,
+    apply_dinov3_lora,
+    configure_dinov3_trainability,
+)
+from src.utils.models.lora import LoRAConfig, LoRALinear
+
+
+class _FakeBlock(nn.Module):
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.attn = nn.Module()
+        self.attn.qkv = nn.Linear(dim, dim * 3)
+        self.attn.proj = nn.Linear(dim, dim)
+        self.mlp = nn.Module()
+        self.mlp.fc1 = nn.Linear(dim, dim * 2)
+        self.mlp.fc2 = nn.Linear(dim * 2, dim)
+
+
+class _FakeDINOv3(nn.Module):
+    """Mimic the attributes the adapter and LoRA helpers rely on."""
+
+    def __init__(self, dim: int = 16, depth: int = 2) -> None:
+        super().__init__()
+        self.embed_dim = dim
+        self.patch_size = 16
+        self.blocks = nn.ModuleList(_FakeBlock(dim) for _ in range(depth))
+        self.norm = nn.LayerNorm(dim)
+
+
+def _make_adapter(dim: int = 16, depth: int = 2) -> DINOv3BackboneAdapter:
+    return DINOv3BackboneAdapter(_FakeDINOv3(dim=dim, depth=depth))
+
+
+class TestApplyDINOv3LoRA:
+    def test_requires_enabled_config(self) -> None:
+        with pytest.raises(ValueError, match="enabled"):
+            apply_dinov3_lora(_make_adapter(), LoRAConfig(enabled=False))
+
+    def test_freezes_base_and_wraps_targets(self) -> None:
+        adapter = _make_adapter(depth=2)
+        wrapped = apply_dinov3_lora(
+            adapter,
+            LoRAConfig(
+                enabled=True,
+                rank=4,
+                alpha=8.0,
+                target_modules=("qkv", "proj", "fc1", "fc2"),
+            ),
+        )
+        assert len(wrapped) == 2 * 4  # 2 blocks * 4 target linears
+        assert isinstance(adapter.module.blocks[0].attn.qkv, LoRALinear)
+        assert isinstance(adapter.module.blocks[0].mlp.fc2, LoRALinear)
+
+        trainable = {name for name, p in adapter.named_parameters() if p.requires_grad}
+        assert trainable
+        assert all(name.endswith(("lora_a", "lora_b")) for name in trainable)
+
+
+class TestConfigureTrainabilityWithLoRA:
+    def test_lora_overrides_train_mode(self) -> None:
+        adapter = _make_adapter(depth=1)
+        configure_dinov3_trainability(
+            adapter,
+            train_mode="frozen",
+            lora=LoRAConfig(enabled=True, rank=2, alpha=4.0, target_modules=("qkv",)),
+        )
+        assert isinstance(adapter.module.blocks[0].attn.qkv, LoRALinear)
+        trainable = {name for name, p in adapter.named_parameters() if p.requires_grad}
+        assert trainable == {
+            "module.blocks.0.attn.qkv.lora_a",
+            "module.blocks.0.attn.qkv.lora_b",
+        }
+
+    def test_disabled_lora_falls_back_to_train_mode(self) -> None:
+        adapter = _make_adapter(depth=1)
+        configure_dinov3_trainability(
+            adapter,
+            train_mode="full",
+            lora=LoRAConfig(enabled=False),
+        )
+        assert not isinstance(adapter.module.blocks[0].attn.qkv, LoRALinear)
+        assert all(p.requires_grad for p in adapter.parameters())

--- a/tests/unit/utils/models/test_lora.py
+++ b/tests/unit/utils/models/test_lora.py
@@ -1,0 +1,162 @@
+"""Unit tests for :mod:`src.utils.models.lora`."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from src.utils.models.lora import (
+    LoRAConfig,
+    LoRALinear,
+    apply_lora,
+    iter_lora_parameters,
+    mark_only_lora_as_trainable,
+)
+
+
+class _TinyAttention(nn.Module):
+    """Minimal block exposing the DINOv3-style ``qkv``/``proj`` linears."""
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.qkv = nn.Linear(dim, dim * 3)
+        self.proj = nn.Linear(dim, dim)
+        self.norm = nn.LayerNorm(dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(self.qkv(self.norm(x))[..., : self.proj.in_features])
+
+
+class _TinyBackbone(nn.Module):
+    def __init__(self, dim: int = 16, depth: int = 2) -> None:
+        super().__init__()
+        self.blocks = nn.ModuleList(_TinyAttention(dim) for _ in range(depth))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for block in self.blocks:
+            x = block(x)
+        return x
+
+
+class TestLoRAConfig:
+    def test_disabled_skips_validation(self) -> None:
+        cfg = LoRAConfig(enabled=False, rank=0, alpha=0.0)
+        assert cfg.enabled is False
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"rank": 0}, "rank"),
+            ({"alpha": 0.0}, "alpha"),
+            ({"dropout": 1.0}, "dropout"),
+            ({"target_modules": ()}, "target_modules"),
+        ],
+    )
+    def test_enabled_validates(self, kwargs: dict, match: str) -> None:
+        with pytest.raises(ValueError, match=match):
+            LoRAConfig(enabled=True, **kwargs)
+
+    def test_from_mapping_none_is_disabled(self) -> None:
+        cfg = LoRAConfig.from_mapping(None, default_target_modules=("qkv",))
+        assert cfg.enabled is False
+        assert cfg.target_modules == ("qkv",)
+
+    def test_from_mapping_reads_values(self) -> None:
+        cfg = LoRAConfig.from_mapping(
+            {"enabled": True, "rank": 4, "alpha": 8.0, "dropout": 0.1}
+        )
+        assert cfg.enabled is True
+        assert cfg.rank == 4
+        assert cfg.alpha == 8.0
+        assert cfg.dropout == 0.1
+
+    def test_from_mapping_default_targets_used_when_absent(self) -> None:
+        cfg = LoRAConfig.from_mapping(
+            {"enabled": True}, default_target_modules=("qkv", "proj")
+        )
+        assert cfg.target_modules == ("qkv", "proj")
+
+
+class TestLoRALinear:
+    def test_initial_output_matches_base(self) -> None:
+        base = nn.Linear(8, 5)
+        wrapped = LoRALinear(base, rank=2, alpha=4.0)
+        x = torch.randn(3, 8)
+        torch.testing.assert_close(wrapped(x), base(x))
+
+    def test_exposes_linear_shape_attributes(self) -> None:
+        wrapped = LoRALinear(nn.Linear(8, 5), rank=2, alpha=4.0)
+        assert wrapped.in_features == 8
+        assert wrapped.out_features == 5
+        assert wrapped.scaling == pytest.approx(4.0 / 2)
+
+    def test_base_frozen_only_adapters_trainable(self) -> None:
+        wrapped = LoRALinear(nn.Linear(8, 5), rank=2, alpha=4.0)
+        assert wrapped.base.weight.requires_grad is False
+        assert wrapped.lora_a.requires_grad is True
+        assert wrapped.lora_b.requires_grad is True
+
+    def test_update_changes_output_after_training_step(self) -> None:
+        wrapped = LoRALinear(nn.Linear(8, 5), rank=2, alpha=4.0)
+        x = torch.randn(3, 8)
+        wrapped(x).sum().backward()
+        assert wrapped.lora_a.grad is not None
+        assert wrapped.lora_b.grad is not None
+        assert wrapped.base.weight.grad is None
+
+    def test_rejects_non_linear(self) -> None:
+        with pytest.raises(TypeError, match="nn.Linear"):
+            LoRALinear(nn.Conv2d(3, 3, 1), rank=2, alpha=4.0)  # type: ignore[arg-type]
+
+
+class TestApplyLoRA:
+    def test_wraps_only_target_modules(self) -> None:
+        model = _TinyBackbone(dim=16, depth=2)
+        wrapped = apply_lora(model, rank=4, alpha=8.0, target_modules=("qkv", "proj"))
+        assert wrapped == [
+            "blocks.0.qkv",
+            "blocks.0.proj",
+            "blocks.1.qkv",
+            "blocks.1.proj",
+        ]
+        assert isinstance(model.blocks[0].qkv, LoRALinear)
+        assert isinstance(model.blocks[0].proj, LoRALinear)
+        assert not isinstance(model.blocks[0].norm, LoRALinear)
+
+    def test_is_idempotent(self) -> None:
+        model = _TinyBackbone(dim=16, depth=1)
+        apply_lora(model, rank=4, alpha=8.0, target_modules=("qkv",))
+        # Second call must not re-wrap the existing adapter.
+        with pytest.raises(ValueError, match="matched no nn.Linear"):
+            apply_lora(model, rank=4, alpha=8.0, target_modules=("qkv",))
+
+    def test_preserves_forward_shape(self) -> None:
+        model = _TinyBackbone(dim=16, depth=2)
+        x = torch.randn(2, 7, 16)
+        before = model(x)
+        apply_lora(model, rank=4, alpha=8.0, target_modules=("qkv", "proj"))
+        after = model(x)
+        assert after.shape == before.shape
+        # B initialised to zero => identical output right after wrapping.
+        torch.testing.assert_close(after, before)
+
+    def test_raises_when_no_match(self) -> None:
+        model = _TinyBackbone(dim=16, depth=1)
+        with pytest.raises(ValueError, match="matched no nn.Linear"):
+            apply_lora(model, rank=4, alpha=8.0, target_modules=("does_not_exist",))
+
+
+class TestTrainableHelpers:
+    def test_iter_lora_parameters_yields_only_adapters(self) -> None:
+        model = _TinyBackbone(dim=16, depth=2)
+        apply_lora(model, rank=4, alpha=8.0, target_modules=("qkv", "proj"))
+        params = list(iter_lora_parameters(model))
+        assert len(params) == 2 * 2 * 2  # 2 blocks * 2 targets * (A, B)
+
+    def test_mark_only_lora_as_trainable(self) -> None:
+        model = _TinyBackbone(dim=16, depth=1)
+        apply_lora(model, rank=4, alpha=8.0, target_modules=("qkv",))
+        mark_only_lora_as_trainable(model)
+        trainable = {name for name, p in model.named_parameters() if p.requires_grad}
+        assert trainable == {"blocks.0.qkv.lora_a", "blocks.0.qkv.lora_b"}


### PR DESCRIPTION
## 概要

DINOv3 バックボーンを用いる `ball_detection` / `court_detection` の学習に **LoRA (Low-Rank Adaptation)** を追加します。実装は共通化して `src/utils/` に置き、下流タスクから設定で有効化できる形にしました。

## 変更点

### 共通実装 (`src/utils`)
- `src/utils/models/lora.py` (新規) — ドメイン非依存の LoRA ユーティリティ
  - `LoRAConfig` … `enabled / rank / alpha / dropout / target_modules`、`from_mapping()` で Hydra 設定から構築
  - `LoRALinear` … 既存 `nn.Linear` をラップし base を凍結。`B` をゼロ初期化するため**適用直後の出力は元の Linear と一致**
  - `apply_lora()` / `iter_lora_parameters()` / `mark_only_lora_as_trainable()`
- `src/utils/models/loading/dinov3.py` — `apply_dinov3_lora()` を追加し、`configure_dinov3_trainability(..., lora=...)` で LoRA を選択可能に（有効時は base 凍結＋アダプタのみ学習）
- `src/utils/models/__init__.py` / `loading/__init__.py` で re-export、`src/utils/README.md` のインデックス更新

### 下流タスク
- `DINOv3RoPEBallDetector` / `DINOv3DETR` が `model.backbone.lora` を読み、LoRA 有効時は base を凍結したままアダプタを注入。凍結時の `torch.no_grad()` / `backbone.eval()` ガードは LoRA 有効時のみ解除（勾配をアダプタへ流すため）
- `configs/training/_lora.yaml` + `lora.yaml`（両タスク）を追加。`# @package _global_` で `model.backbone.lora` に注入するため、`training=lora` で簡単に有効化可能
- 各 DINOv3 モデル設定にデフォルト無効の `lora` ブロックを追記（発見性向上）

## 使い方

```bash
# ball detection
python -m src.tasks.ball_detection.scripts.train model=dinov3_rope training=lora

# court detection
python -m src.tasks.court_detection.scripts.train model=court_seg_dinov3_detr training=lora
```

## 検証

- **ユニットテスト** (`tests/unit/utils/models/test_lora.py`, `test_dinov3_lora.py`) — 計 23 件 pass。初期出力一致 / base 凍結 / 勾配がアダプタのみに流れる / `apply_lora` のターゲット選択・冪等性・整合性 / DINOv3 配線を擬似バックボーンで検証
- **dry-run（CPU 1 step, `run.dry_run=true`）** — 両タスクとも成功
  - ball: Trainable 5.7M / Non-trainable 85.7M
  - court: Trainable 11.8M / Non-trainable 85.7M（非 LoRA は 10.6M で後方互換を確認）
- `tests/unit/utils/` 全 206 件 pass、ruff / mypy（変更ファイルに新規エラーなし、pre-commit pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
