### PR TITLE
chore(utils): hydra_main・conv ブロック・preview/IO ヘルパの共通化

### DIFF
--- a/src/tasks/ball_detection/generate_dataset/annotation_session.py
+++ b/src/tasks/ball_detection/generate_dataset/annotation_session.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 import csv
-import json
 import shutil
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import cv2
 import numpy as np
+
+from src.utils.io import load_json, save_json_atomic, utc_now_iso
 
 JSONDict = dict[str, Any]
 VISIBLE_STATES = {"visible", "occluded"}
@@ -119,7 +119,7 @@ def _run_candidate(
     *,
     start_index: int | None,
 ) -> str:
-    document = _read_json(document_path)
+    document = load_json(document_path)
     _normalize_document_schema(document)
     if document.get("status") not in {"pseudo_labeled", "annotating"}:
         raise ValueError(
@@ -397,7 +397,7 @@ def finalize_candidate(
     config: BallAnnotationSessionConfig,
 ) -> str:
     """Move a fully reviewed staging candidate into the final clip dataset."""
-    document = _read_json(document_path)
+    document = load_json(document_path)
     incomplete = [
         str(frame["frame_id"])
         for frame in document["frames"]
@@ -436,11 +436,11 @@ def finalize_candidate(
         "source": document["source"],
         "prediction": document.get("prediction"),
         "annotation": {
-            "created_at": _utc_now(),
-            "updated_at": _utc_now(),
+            "created_at": utc_now_iso(),
+            "updated_at": utc_now_iso(),
         },
     }
-    _write_json_atomic(candidate_dir / "clip.json", clip_document)
+    save_json_atomic(clip_document, candidate_dir / "clip.json")
     if target_dir.exists():
         shutil.rmtree(target_dir)
     target_dir.parent.mkdir(parents=True, exist_ok=True)
@@ -499,7 +499,7 @@ def _complete_current_frame(state: UiState) -> None:
         if ball.get("label_source") == "pseudo":
             ball["label_source"] = "human_approved_pseudo"
     frame["review_status"] = "completed"
-    frame["reviewed_at"] = _utc_now()
+    frame["reviewed_at"] = utc_now_iso()
     state.dirty = True
     _save_state(state)
     _move_cursor(state, 1)
@@ -576,7 +576,7 @@ def _register_final_clip(root: Path, clip: JSONDict, target_dir: Path) -> None:
     split = str(clip["split"])
     annotation_path = root / "annotations" / f"{split}.json"
     payload = (
-        _read_json(annotation_path)
+        load_json(annotation_path)
         if annotation_path.exists()
         else {"schema_name": "ball_youtube_dataset_v1", "split": split, "items": []}
     )
@@ -596,7 +596,7 @@ def _register_final_clip(root: Path, clip: JSONDict, target_dir: Path) -> None:
     items_by_id = {str(existing["clip_id"]): existing for existing in payload.get("items", [])}
     items_by_id[str(clip["clip_id"])] = item
     payload["items"] = list(items_by_id.values())
-    _write_json_atomic(annotation_path, payload)
+    save_json_atomic(payload, annotation_path)
     entries = sorted(str(existing["dataset_entry"]) for existing in payload["items"])
     _write_text_atomic(
         root / "annotations" / f"{split}.txt",
@@ -663,7 +663,7 @@ def _next_candidate_path(
     if candidate_id is None:
         return paths[0] if paths else None
     for path in paths:
-        document = _read_json(path)
+        document = load_json(path)
         if candidate_id in {path.parent.name, str(document.get("clip_id"))}:
             return path
     raise FileNotFoundError(
@@ -846,7 +846,7 @@ def _move_cursor(state: UiState, step: int) -> None:
 
 def _save_state(state: UiState) -> None:
     state.document["cursor_index"] = state.current_index
-    _write_json_atomic(state.document_path, state.document)
+    save_json_atomic(state.document, state.document_path)
     state.dirty = False
 
 
@@ -869,26 +869,8 @@ def _validate_config(config: BallAnnotationSessionConfig) -> None:
         raise ValueError("max_balls_per_frame must be positive.")
 
 
-def _read_json(path: Path) -> JSONDict:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _write_json_atomic(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    temporary.write_text(
-        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
-        encoding="utf-8",
-    )
-    temporary.replace(path)
-
-
 def _write_text_atomic(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_suffix(path.suffix + ".tmp")
     temporary.write_text(text, encoding="utf-8")
     temporary.replace(path)
-
-
-def _utc_now() -> str:
-    return datetime.now(UTC).isoformat()

--- a/src/tasks/ball_detection/generate_dataset/candidate_workflow.py
+++ b/src/tasks/ball_detection/generate_dataset/candidate_workflow.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import json
 import os
 import shutil
 import time
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -21,6 +19,13 @@ from src.tasks.ball_detection.data.components.augmentation import (
 )
 from src.tasks.ball_detection.inference import BallDetectionPredictor
 from src.utils.data.heatmaps import heatmaps_to_peaks
+from src.utils.io import (
+    load_json,
+    read_jsonl,
+    save_json_atomic,
+    utc_now_iso,
+    write_jsonl,
+)
 
 JSONDict = dict[str, Any]
 LEFT_KEYS = {81, 65361, 2424832}
@@ -86,7 +91,7 @@ def run_candidate_selection(
 ) -> int:
     """Select meaningful raw-frame ranges for one video."""
     _validate_selection_config(config)
-    records = _read_jsonl(raw_dir / "frames.jsonl")
+    records = read_jsonl(raw_dir / "frames.jsonl")
     if not records:
         raise FileNotFoundError(
             f"No raw frames found for {video_id}: {raw_dir / 'frames.jsonl'}"
@@ -260,11 +265,11 @@ def create_candidate(
                 "source_title": first.get("source_title"),
             },
             "selection": {
-                "selected_at": _utc_now(),
+                "selected_at": utc_now_iso(),
             },
             "prediction": None,
         }
-        _write_json_atomic(temporary / "candidate.json", candidate)
+        save_json_atomic(candidate, temporary / "candidate.json")
         if candidate_dir.exists():
             shutil.rmtree(candidate_dir)
         temporary.replace(candidate_dir)
@@ -287,7 +292,7 @@ def predict_candidates(
     candidate_paths = sorted(staging_dir.glob("clip_*/candidate.json"))
     if not candidate_paths:
         raise FileNotFoundError(f"No selected candidates found for {video_id}: {staging_dir}")
-    candidate_docs = [_read_json(path) for path in candidate_paths]
+    candidate_docs = [load_json(path) for path in candidate_paths]
     if any(str(document.get("video_id")) != video_id for document in candidate_docs):
         raise ValueError(f"Staging directory contains a video other than {video_id}.")
 
@@ -330,7 +335,7 @@ def predict_candidates(
             "peak_threshold": config.peak_threshold,
             "nms_kernel": config.nms_kernel,
             "max_candidates_per_frame": config.max_candidates_per_frame,
-            "predicted_at": _utc_now(),
+            "predicted_at": utc_now_iso(),
         }
         for frame, prediction in zip(document["frames"], predictions, strict=True):
             frame["review_status"] = "pending"
@@ -351,8 +356,8 @@ def predict_candidates(
                 for index, candidate in enumerate(candidates, start=1)
             ]
             frame.pop("ball", None)
-        _write_jsonl(candidate_path.parent / "predictions.jsonl", predictions)
-        _write_json_atomic(candidate_path, document)
+        write_jsonl(candidate_path.parent / "predictions.jsonl", predictions)
+        save_json_atomic(document, candidate_path)
         print(f"  predicted {document['clip_id']}: {len(predictions)} frames")
     return 0
 
@@ -485,7 +490,7 @@ def _resume_index(candidates: list[JSONDict], frame_count: int) -> int:
 
 def _candidate_documents(staging_dir: Path) -> list[JSONDict]:
     return [
-        _read_json(path)
+        load_json(path)
         for path in sorted(staging_dir.glob("clip_*/candidate.json"))
     ]
 
@@ -643,36 +648,3 @@ def _resolve_path(root: Path, value: Any) -> Path:
 def _chunked(values: Sequence[int], chunk_size: int) -> Iterator[list[int]]:
     for index in range(0, len(values), chunk_size):
         yield list(values[index : index + chunk_size])
-
-
-def _read_json(path: Path) -> JSONDict:
-    return cast(JSONDict, json.loads(path.read_text(encoding="utf-8")))
-
-
-def _read_jsonl(path: Path) -> list[JSONDict]:
-    if not path.exists():
-        return []
-    return [
-        json.loads(line)
-        for line in path.read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
-
-
-def _write_jsonl(path: Path, records: list[JSONDict]) -> None:
-    text = "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records)
-    path.write_text(text, encoding="utf-8")
-
-
-def _write_json_atomic(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    temporary.write_text(
-        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
-        encoding="utf-8",
-    )
-    temporary.replace(path)
-
-
-def _utc_now() -> str:
-    return datetime.now(UTC).isoformat()

--- a/src/tasks/ball_detection/models/spatiotemporal_unet.py
+++ b/src/tasks/ball_detection/models/spatiotemporal_unet.py
@@ -8,55 +8,10 @@ import torch
 import torch.nn as nn
 
 from src.tasks.ball_detection.models.input_adapter import resolve_model_in_channels
+from src.utils.models.blocks import Conv2dWiseWiseBlock
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
-
-
-class DepthwiseSeparableConv2d(nn.Module):
-    """Depthwise-separable 2D convolution block."""
-
-    def __init__(self, in_channels: int, out_channels: int) -> None:
-        super().__init__()
-        self.depthwise = nn.Conv2d(
-            in_channels,
-            in_channels,
-            kernel_size=3,
-            padding=1,
-            groups=in_channels,
-            bias=False,
-        )
-        self.bn1 = nn.BatchNorm2d(in_channels)
-        self.pointwise = nn.Conv2d(in_channels, out_channels, kernel_size=1, bias=False)
-        self.bn2 = nn.BatchNorm2d(out_channels)
-        self.relu = nn.ReLU(inplace=True)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Apply depthwise and pointwise convolutions."""
-        x = self.relu(self.bn1(self.depthwise(x)))
-        x = self.relu(self.bn2(self.pointwise(x)))
-        return x
-
-
-class Conv2dWiseWiseBlock(nn.Module):
-    """Conv2d block followed by two depthwise-separable blocks."""
-
-    def __init__(self, in_channels: int, out_channels: int) -> None:
-        super().__init__()
-        self.conv2d = nn.Sequential(
-            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1, bias=False),
-            nn.BatchNorm2d(out_channels),
-            nn.ReLU(inplace=True),
-        )
-        self.wise_1 = DepthwiseSeparableConv2d(out_channels, out_channels)
-        self.wise_2 = DepthwiseSeparableConv2d(out_channels, out_channels)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Apply the 2D convolution stack."""
-        x = self.conv2d(x)
-        x = self.wise_1(x)
-        x = self.wise_2(x)
-        return x
 
 
 class Conv3dBlock(nn.Module):

--- a/src/tasks/ball_detection/scripts/analyze_web_bbox_ratio.py
+++ b/src/tasks/ball_detection/scripts/analyze_web_bbox_ratio.py
@@ -35,19 +35,19 @@ from __future__ import annotations
 import csv
 import random
 from collections import defaultdict
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
 import cv2
-import hydra
 import numpy as np
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig
 from tqdm import tqdm
 
 from src.utils.geometry.bbox import bbox_max_side_ratio
+from src.utils.hydra import hydra_main
 from src.utils.io import ensure_dir, load_json
 from src.utils.video.encoding import iter_selected_video_jpegs
 
@@ -341,11 +341,7 @@ def _export_samples(cfg: DictConfig, frames: list[FrameRatio], out_root: Path) -
             cv2.imwrite(str(target / f"{stem}_f{index:06d}.jpg"), _draw(image, frame))
 
 
-def _hydra_main(*args: Any, **kwargs: Any) -> Callable[[Any], Any]:
-    return cast(Callable[[Any], Any], hydra.main(*args, **kwargs))
-
-
-@_hydra_main(
+@hydra_main(
     config_path="../configs",
     config_name="analyze_web_bbox_ratio",
     version_base="1.3",

--- a/src/tasks/ball_detection/scripts/convert_web_dataset.py
+++ b/src/tasks/ball_detection/scripts/convert_web_dataset.py
@@ -17,11 +17,9 @@ Notes:
 from __future__ import annotations
 
 import shutil
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
-import hydra
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig
 from tqdm import tqdm
@@ -47,14 +45,11 @@ from src.tasks.ball_detection.data.components.web.parser import (
     WebDatasetParser,
 )
 from src.utils.data.splits import GroupSplitConfig
+from src.utils.hydra import hydra_main
 from src.utils.io import ensure_dir, load_json
 
 
-def _hydra_main(*args: Any, **kwargs: Any) -> Callable[[Any], Any]:
-    return cast(Callable[[Any], Any], hydra.main(*args, **kwargs))
-
-
-@_hydra_main(
+@hydra_main(
     config_path="../configs",
     config_name="convert_web_dataset",
     version_base="1.3",

--- a/src/tasks/ball_detection/scripts/eval.py
+++ b/src/tasks/ball_detection/scripts/eval.py
@@ -16,9 +16,8 @@ import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
-import hydra
 import numpy as np
 import pytorch_lightning as pl
 import torch
@@ -35,13 +34,7 @@ from src.tasks.ball_detection.training.lightning_module import (
 )
 from src.tasks.ball_detection.training.metrics import BallDetectionMetrics
 from src.utils.data.heatmaps import heatmaps_to_argmax
-
-FMain = TypeVar("FMain", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[FMain], FMain]:
-    """Typed wrapper for `hydra.main`."""
-    return cast(Callable[[FMain], FMain], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 @dataclass

--- a/src/tasks/ball_detection/scripts/evaluate_manifest.py
+++ b/src/tasks/ball_detection/scripts/evaluate_manifest.py
@@ -13,22 +13,15 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import cast
 
-import hydra
 from omegaconf import DictConfig
 
 from src.tasks.ball_detection.evaluation import (
     EvaluationPipeline,
     load_evaluation_manifest,
 )
-
-FMain = TypeVar("FMain", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[FMain], FMain]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[FMain], FMain], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 @hydra_main(

--- a/src/tasks/ball_detection/scripts/preview_augmentation.py
+++ b/src/tasks/ball_detection/scripts/preview_augmentation.py
@@ -17,10 +17,9 @@ import json
 import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
 import cv2
-import hydra
 import numpy as np
 import torch
 from omegaconf import DictConfig, OmegaConf
@@ -31,13 +30,8 @@ from src.tasks.ball_detection.data.components.augmentation import (
     denormalize_tensor_images_imagenet,
 )
 from src.tasks.ball_detection.data.types import ClipWindow
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+from src.tasks.base.preview import resolve_sample_indices, resolve_split_file
+from src.utils.hydra import hydra_main
 
 
 @hydra_main(
@@ -51,7 +45,7 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
     output_dir.mkdir(parents=True, exist_ok=True)
 
     split_name = str(cfg.preview.split)
-    split_file = _resolve_split_file(cfg, split_name)
+    split_file = resolve_split_file(cfg, split_name)
     datamodule = build_ball_detection_datamodule(cfg)
     base_dataset = datamodule.create_dataset(
         split_name=split_name,
@@ -68,7 +62,7 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
         ),
     )
 
-    sample_indices = _resolve_sample_indices(cfg, dataset_size=len(base_dataset))
+    sample_indices = resolve_sample_indices(cfg, dataset_size=len(base_dataset), min_samples=1)
     manifest: list[dict[str, Any]] = []
     for sample_index in sample_indices:
         torch.manual_seed(int(cfg.preview.seed) + sample_index)
@@ -126,33 +120,6 @@ def _build_augmented_config(cfg: DictConfig) -> DictConfig:
                 f"Expected data.augmentation.{name}.enabled to exist in the config."
             )
     return augmented_cfg
-
-
-def _resolve_split_file(cfg: DictConfig, split_name: str) -> str:
-    """Return the split file path from ``cfg.data.split``."""
-    split_cfg = cfg.data.split
-    key = f"{split_name}_file"
-    if key not in split_cfg:
-        available = ", ".join(sorted(split_cfg.keys()))
-        raise ValueError(f"Unknown preview.split={split_name!r}. Available: {available}")
-    return str(split_cfg[key])
-
-
-def _resolve_sample_indices(cfg: DictConfig, *, dataset_size: int) -> list[int]:
-    """Return validated sample indices to render."""
-    explicit = [int(value) for value in cfg.preview.sample_indices]
-    if explicit:
-        sample_indices = explicit
-    else:
-        max_samples = max(int(cfg.preview.max_samples), 1)
-        sample_indices = list(range(min(max_samples, dataset_size)))
-
-    for sample_index in sample_indices:
-        if sample_index < 0 or sample_index >= dataset_size:
-            raise IndexError(
-                f"preview sample_index={sample_index} is out of range for dataset size {dataset_size}."
-            )
-    return sample_indices
 
 
 def _render_contact_sheet(

--- a/src/tasks/ball_detection/scripts/preview_heatmaps.py
+++ b/src/tasks/ball_detection/scripts/preview_heatmaps.py
@@ -14,25 +14,18 @@ Notes:
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any
 
 import cv2
-import hydra
 import numpy as np
 import torch
 from omegaconf import DictConfig
 
 from src.tasks.ball_detection.data import build_ball_detection_datamodule
+from src.tasks.base.preview import resolve_sample_indices, resolve_split_file
 from src.utils.data.heatmaps import generate_gaussian_heatmaps, heatmaps_to_argmax
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 @hydra_main(
@@ -49,10 +42,10 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
     datamodule = build_ball_detection_datamodule(cfg)
     dataset = datamodule.create_dataset(
         split_name=split_name,
-        split_file=_resolve_split_file(cfg, split_name),
+        split_file=resolve_split_file(cfg, split_name),
         augmentation=None,
     )
-    sample_indices = _resolve_sample_indices(cfg, len(dataset))
+    sample_indices = resolve_sample_indices(cfg, len(dataset))
 
     manifest: list[dict[str, Any]] = []
     for sample_index in sample_indices:
@@ -129,30 +122,6 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
     (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     print(f"Saved {len(manifest)} ball heatmap preview(s) to {output_dir}")
     return 0
-
-
-def _resolve_split_file(cfg: DictConfig, split_name: str) -> str:
-    split_cfg = cfg.data.split
-    key = f"{split_name}_file"
-    if key not in split_cfg:
-        available = ", ".join(sorted(split_cfg.keys()))
-        raise ValueError(f"Unknown preview.split={split_name!r}. Available: {available}")
-    return str(split_cfg[key])
-
-
-def _resolve_sample_indices(cfg: DictConfig, dataset_size: int) -> list[int]:
-    explicit = [int(value) for value in cfg.preview.sample_indices]
-    if explicit:
-        sample_indices = explicit
-    else:
-        sample_indices = list(range(min(int(cfg.preview.max_samples), dataset_size)))
-    for sample_index in sample_indices:
-        if sample_index < 0 or sample_index >= dataset_size:
-            raise IndexError(
-                f"preview sample_index={sample_index} is out of range for "
-                f"dataset size {dataset_size}."
-            )
-    return sample_indices
 
 
 def _select_frame_index(visibility: torch.Tensor) -> int:

--- a/src/tasks/ball_detection/scripts/train_staged.py
+++ b/src/tasks/ball_detection/scripts/train_staged.py
@@ -17,22 +17,15 @@ Notes:
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, cast
-
-import hydra
 from omegaconf import DictConfig
 
 from src.tasks.ball_detection.training.staged_runner import (
     StagedBallDetectionTrainingRunner,
 )
+from src.utils.hydra import hydra_main
 
 
-def _hydra_main(*args: Any, **kwargs: Any) -> Callable[[Any], Any]:
-    return cast(Callable[[Any], Any], hydra.main(*args, **kwargs))
-
-
-@_hydra_main(
+@hydra_main(
     version_base="1.3",
     config_path="../configs",
     config_name="train_staged",

--- a/src/tasks/ball_detection/scripts/visualize.py
+++ b/src/tasks/ball_detection/scripts/visualize.py
@@ -14,22 +14,15 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
-from typing import Any, TypeVar, cast
+from typing import cast
 
-import hydra
 from omegaconf import DictConfig
 
 from src.tasks.ball_detection.visualization.orchestrator import (
     build_runtime_config,
     run_visualization,
 )
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 @hydra_main(config_path="../configs", config_name="visualize", version_base="1.3")

--- a/src/tasks/ball_detection/scripts/youtube/annotate_youtube_ball.py
+++ b/src/tasks/ball_detection/scripts/youtube/annotate_youtube_ball.py
@@ -13,11 +13,8 @@ Notes:
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
 
-import hydra
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig
 
@@ -27,13 +24,7 @@ from src.tasks.ball_detection.generate_dataset import (
     ZoomConfig,
     run_annotation_session,
 )
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 @hydra_main(

--- a/src/tasks/ball_detection/scripts/youtube/clip_and_predict_youtube_dataset.py
+++ b/src/tasks/ball_detection/scripts/youtube/clip_and_predict_youtube_dataset.py
@@ -13,11 +13,8 @@ Notes:
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
 
-import hydra
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig
 
@@ -27,13 +24,7 @@ from src.tasks.ball_detection.generate_dataset import (
     predict_candidates,
     run_candidate_selection,
 )
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 @hydra_main(

--- a/src/tasks/ball_detection/scripts/youtube/prepare_dinov3_ssl_images.py
+++ b/src/tasks/ball_detection/scripts/youtube/prepare_dinov3_ssl_images.py
@@ -20,18 +20,18 @@ import shutil
 import signal
 import subprocess
 import time
-from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol, TypeVar, cast
+from typing import Any, Protocol, cast
 
 import av
-import hydra
 import requests
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
 from PIL import Image
 
+from src.utils.hydra import hydra_main
 from src.utils.io import (
     JSONDict,
     ensure_dirs,
@@ -49,7 +49,6 @@ from src.utils.video import (
 )
 from src.utils.video.youtube import download_youtube_video, transcode_h264_video
 
-F = TypeVar("F", bound=Callable[..., Any])
 TENNIS_TERMS = ("tennis", "atp", "wta", "grand slam", "rally", "court")
 VIDEO_FILE_SUFFIXES = {
     ".avi",
@@ -61,11 +60,6 @@ VIDEO_FILE_SUFFIXES = {
     ".mpg",
     ".webm",
 }
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
 
 
 @dataclass(frozen=True)

--- a/src/tasks/ball_detection/scripts/youtube/prepare_youtube_dataset.py
+++ b/src/tasks/ball_detection/scripts/youtube/prepare_youtube_dataset.py
@@ -14,15 +14,15 @@ Notes:
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
 import cv2
-import hydra
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
 
+from src.utils.hydra import hydra_main
 from src.utils.io import (
     ensure_dirs,
     load_json_if_exists,
@@ -38,13 +38,7 @@ from src.utils.video.youtube import (
     transcode_h264_video,
 )
 
-F = TypeVar("F", bound=Callable[..., Any])
 JSONDict = dict[str, Any]
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
 
 
 @hydra_main(

--- a/src/tasks/base/preview.py
+++ b/src/tasks/base/preview.py
@@ -1,0 +1,52 @@
+"""Shared helpers for Hydra-driven dataset preview scripts.
+
+These parse the common ``cfg.preview`` / ``cfg.data.split`` config conventions
+used by the per-task ``preview_heatmaps`` / ``preview_augmentation`` scripts.
+They depend only on the OmegaConf config shape, not on any task's domain types,
+so the ball- and court-detection scripts share a single implementation.
+"""
+
+from __future__ import annotations
+
+from omegaconf import DictConfig
+
+__all__ = ["resolve_sample_indices", "resolve_split_file"]
+
+
+def resolve_split_file(cfg: DictConfig, split_name: str) -> str:
+    """Return the split-file path for ``split_name`` from ``cfg.data.split``."""
+    split_cfg = cfg.data.split
+    key = f"{split_name}_file"
+    if key not in split_cfg:
+        available = ", ".join(sorted(split_cfg.keys()))
+        raise ValueError(f"Unknown preview.split={split_name!r}. Available: {available}")
+    return str(split_cfg[key])
+
+
+def resolve_sample_indices(
+    cfg: DictConfig,
+    dataset_size: int,
+    *,
+    min_samples: int = 0,
+) -> list[int]:
+    """Return validated preview sample indices.
+
+    Uses ``cfg.preview.sample_indices`` when non-empty, otherwise the first
+    ``max(cfg.preview.max_samples, min_samples)`` indices (clamped to
+    ``dataset_size``). ``min_samples`` defaults to ``0`` (no floor); pass ``1``
+    to guarantee at least one sample. Raises ``IndexError`` if any resolved
+    index is out of range.
+    """
+    explicit = [int(value) for value in cfg.preview.sample_indices]
+    if explicit:
+        sample_indices = explicit
+    else:
+        count = max(int(cfg.preview.max_samples), min_samples)
+        sample_indices = list(range(min(count, dataset_size)))
+    for sample_index in sample_indices:
+        if sample_index < 0 or sample_index >= dataset_size:
+            raise IndexError(
+                f"preview sample_index={sample_index} is out of range for "
+                f"dataset size {dataset_size}."
+            )
+    return sample_indices

--- a/src/tasks/blcs/scripts/visualize.py
+++ b/src/tasks/blcs/scripts/visualize.py
@@ -13,22 +13,15 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
-from typing import Any, TypeVar, cast
+from typing import cast
 
-import hydra
 from omegaconf import DictConfig
 
 from src.tasks.blcs.visualization.orchestrator import (
     build_runtime_config,
     run_visualization,
 )
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 @hydra_main(config_path="../configs", config_name="visualize", version_base="1.3")

--- a/src/tasks/court_detection/generate_dataset/annotation_session.py
+++ b/src/tasks/court_detection/generate_dataset/annotation_session.py
@@ -11,6 +11,7 @@ from typing import Any
 import cv2
 import numpy as np
 
+from src.utils.io import save_json_atomic
 from src.utils.schema.court import COURT_KP_NAMES, court_keypoints_3d
 
 COURT_KP20_COUNT = 20
@@ -344,14 +345,6 @@ def read_annotation_document(path: Path) -> AnnotationDocument:
         items = metadata.pop("items")
         return AnnotationDocument(metadata=metadata, items=items)
     raise ValueError(f"Unsupported annotation JSON shape: {path}")
-
-
-def write_json_atomic(path: Path, payload: Any) -> None:
-    """Write JSON atomically."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_suffix(path.suffix + ".tmp")
-    tmp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    tmp_path.replace(path)
 
 
 def normalize_serialized_keypoints(raw_kps: Any) -> list[list[float | None]]:
@@ -814,12 +807,12 @@ def write_annotation_entries_atomic(
 ) -> None:
     """Write entries in either legacy-list or named-document format."""
     if config.annotation_format != "named_keypoints":
-        write_json_atomic(path, entries)
+        save_json_atomic(entries, path)
         return
 
     payload = dict(metadata or {})
     payload["items"] = entries
-    write_json_atomic(path, payload)
+    save_json_atomic(payload, path)
 
 
 def ordered_target_entries(

--- a/src/tasks/court_detection/models/blocks.py
+++ b/src/tasks/court_detection/models/blocks.py
@@ -1,53 +1,12 @@
-"""Reusable convolution blocks for court detection models."""
+"""Reusable convolution blocks for court detection models.
+
+The implementations now live in :mod:`src.utils.models.blocks` (they are
+byte-identical to the ball-detection copies); re-exported here to preserve the
+existing ``src.tasks.court_detection.models.blocks`` import path.
+"""
 
 from __future__ import annotations
 
-import torch
-import torch.nn as nn
-
-
-class DepthwiseSeparableConv2d(nn.Module):
-    """Depthwise-separable 2-D convolution (depthwise to pointwise)."""
-
-    def __init__(self, in_channels: int, out_channels: int) -> None:
-        super().__init__()
-        self.depthwise = nn.Conv2d(
-            in_channels,
-            in_channels,
-            kernel_size=3,
-            padding=1,
-            groups=in_channels,
-            bias=False,
-        )
-        self.bn1 = nn.BatchNorm2d(in_channels)
-        self.pointwise = nn.Conv2d(in_channels, out_channels, kernel_size=1, bias=False)
-        self.bn2 = nn.BatchNorm2d(out_channels)
-        self.relu = nn.ReLU(inplace=True)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.relu(self.bn1(self.depthwise(x)))
-        x = self.relu(self.bn2(self.pointwise(x)))
-        return x
-
-
-class Conv2dWiseWiseBlock(nn.Module):
-    """Conv2d -> DWSepConv -> DWSepConv block."""
-
-    def __init__(self, in_channels: int, out_channels: int) -> None:
-        super().__init__()
-        self.conv2d = nn.Sequential(
-            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1, bias=False),
-            nn.BatchNorm2d(out_channels),
-            nn.ReLU(inplace=True),
-        )
-        self.wise_1 = DepthwiseSeparableConv2d(out_channels, out_channels)
-        self.wise_2 = DepthwiseSeparableConv2d(out_channels, out_channels)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.conv2d(x)
-        x = self.wise_1(x)
-        x = self.wise_2(x)
-        return x
-
+from src.utils.models.blocks import Conv2dWiseWiseBlock, DepthwiseSeparableConv2d
 
 __all__ = ["Conv2dWiseWiseBlock", "DepthwiseSeparableConv2d"]

--- a/src/tasks/court_detection/scripts/annotate_youtube_keypoints.py
+++ b/src/tasks/court_detection/scripts/annotate_youtube_keypoints.py
@@ -13,11 +13,8 @@ Notes:
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
 
-import hydra
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig
 
@@ -25,13 +22,7 @@ from src.tasks.court_detection.generate_dataset import (
     AnnotationSessionConfig,
     run_annotation_session,
 )
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 @hydra_main(

--- a/src/tasks/court_detection/scripts/prepare_youtube_dataset.py
+++ b/src/tasks/court_detection/scripts/prepare_youtube_dataset.py
@@ -14,15 +14,15 @@ Notes:
 from __future__ import annotations
 
 import math
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
 import cv2
-import hydra
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
 
+from src.utils.hydra import hydra_main
 from src.utils.io import (
     ensure_dirs,
     load_json,
@@ -45,13 +45,7 @@ from src.utils.video.youtube import (
     transcode_h264_video,
 )
 
-F = TypeVar("F", bound=Callable[..., Any])
 JSONDict = dict[str, Any]
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
 
 
 @hydra_main(

--- a/src/tasks/court_detection/scripts/preview_heatmaps.py
+++ b/src/tasks/court_detection/scripts/preview_heatmaps.py
@@ -14,24 +14,17 @@ Notes:
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any
 
 import cv2
-import hydra
 import numpy as np
 from omegaconf import DictConfig
 from PIL import Image
 
+from src.tasks.base.preview import resolve_sample_indices
 from src.utils.data.heatmaps import generate_gaussian_heatmaps, heatmaps_to_argmax
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 @hydra_main(
@@ -46,7 +39,7 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
 
     data_dir = Path(str(cfg.data.data_dir)).expanduser()
     entries = json.loads((data_dir / f"data_{cfg.preview.split}.json").read_text(encoding="utf-8"))
-    sample_indices = _resolve_sample_indices(cfg, len(entries))
+    sample_indices = resolve_sample_indices(cfg, len(entries))
 
     manifest: list[dict[str, Any]] = []
     for sample_index in sample_indices:
@@ -104,18 +97,6 @@ def main(cfg: DictConfig) -> int:  # pragma: no cover - CLI entry point
     (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     print(f"Saved {len(manifest)} court heatmap preview(s) to {output_dir}")
     return 0
-
-
-def _resolve_sample_indices(cfg: DictConfig, dataset_size: int) -> list[int]:
-    explicit = [int(value) for value in cfg.preview.sample_indices]
-    if explicit:
-        sample_indices = explicit
-    else:
-        sample_indices = list(range(min(int(cfg.preview.max_samples), dataset_size)))
-    for sample_index in sample_indices:
-        if sample_index < 0 or sample_index >= dataset_size:
-            raise IndexError(f"preview sample_index={sample_index} is out of range for dataset size {dataset_size}.")
-    return sample_indices
 
 
 def _load_image(data_dir: Path, image_id: str) -> np.ndarray:

--- a/src/tasks/court_detection/scripts/visualize.py
+++ b/src/tasks/court_detection/scripts/visualize.py
@@ -15,22 +15,15 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
-from typing import Any, TypeVar, cast
+from typing import cast
 
-import hydra
 from omegaconf import DictConfig
 
 from src.tasks.court_detection.visualization.orchestrator import (
     build_runtime_config,
     run_visualization,
 )
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 @hydra_main(config_path="../configs", config_name="visualize", version_base="1.3")

--- a/src/tasks/plcs/scripts/analysis/analyze_angle_velocity.py
+++ b/src/tasks/plcs/scripts/analysis/analyze_angle_velocity.py
@@ -31,9 +31,8 @@ import json
 import math
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
-import hydra
 import numpy as np
 import torch
 from hydra.utils import to_absolute_path
@@ -48,16 +47,9 @@ from src.tasks.plcs.training.losses import (
     compute_torso_twist,
 )
 from src.tasks.plcs.utils.pose_geometry import world_pose_to_canonical_pose
+from src.utils.hydra import hydra_main
 from src.utils.schema.player import COCO17_JOINT_ANGLE_TRIPLETS as JOINT_ANGLE_TRIPLETS
 from src.utils.schema.player import COCO17_TORSION_QUADRUPLETS as TORSION_QUADRUPLETS
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for hydra.main to keep mypy satisfied."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
-
 
 # ---------------------------------------------------------------------------
 # Welford online statistics (per-channel)

--- a/src/tasks/plcs/scripts/analysis/analyze_dataset_distribution.py
+++ b/src/tasks/plcs/scripts/analysis/analyze_dataset_distribution.py
@@ -19,21 +19,15 @@ import random
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
-import hydra
 import numpy as np
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
 
+from src.utils.hydra import hydra_main
 from src.utils.schema.court import COURT_COORD_SCALE_XYZ
 
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for hydra.main to keep mypy satisfied."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
 
 @dataclass
 class RunningStats:

--- a/src/tasks/plcs/scripts/analysis/analyze_loss_dominance.py
+++ b/src/tasks/plcs/scripts/analysis/analyze_loss_dominance.py
@@ -30,9 +30,8 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
-import hydra
 import torch
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
@@ -43,13 +42,7 @@ from src.tasks.plcs.training.lightning_module import PLCSLightningModule
 from src.tasks.plcs.training.losses import PLCSLoss, PLCSLossConfig
 from src.tasks.plcs.training.metrics import PLCSMetrics
 from src.utils.device import resolve_device
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for hydra.main to keep mypy satisfied."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 def _load_hparams_config(hparams_path: Path) -> DictConfig:

--- a/src/tasks/plcs/scripts/analysis/visualize_rotation_error_samples.py
+++ b/src/tasks/plcs/scripts/analysis/visualize_rotation_error_samples.py
@@ -20,9 +20,8 @@ import json
 import shutil
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
-import hydra
 import numpy as np
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig
@@ -33,14 +32,8 @@ from src.tasks.plcs.inference.predictor import PLCSPredictor
 from src.tasks.plcs.visualization.adapters.predict_inputs import build_multiview_inputs
 from src.tasks.plcs.visualization.orchestrator import RuntimeConfig, run_visualization
 from src.utils.device import resolve_device
+from src.utils.hydra import hydra_main
 from src.utils.schema.court import COURT_COORD_SCALE_XYZ
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for hydra.main to keep mypy satisfied."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
 
 
 def _resolve_device(device_cfg: Any) -> str:

--- a/src/tasks/plcs/scripts/visualize.py
+++ b/src/tasks/plcs/scripts/visualize.py
@@ -13,22 +13,15 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
-from typing import Any, TypeVar, cast
+from typing import cast
 
-import hydra
 from omegaconf import DictConfig
 
 from src.tasks.plcs.visualization.orchestrator import (
     build_runtime_config,
     run_visualization,
 )
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper for ``hydra.main``."""
-    return cast(Callable[[F], F], hydra.main(*args, **kwargs))
+from src.utils.hydra import hydra_main
 
 
 @hydra_main(config_path="../configs", config_name="visualize", version_base="1.3")

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -18,6 +18,7 @@ types**, it belongs here (or should be promoted here), not in the task module.
 | Resolve a repo-relative path | `resolve_project_path()`, `PROJECT_ROOT` | `from src.utils.paths import resolve_project_path, PROJECT_ROOT` |
 | Pick a torch device (`"auto"`/fallback) | `resolve_device()` | `from src.utils.device import resolve_device` |
 | Lightning `(accelerator, devices)` | `select_accelerator()` | `from src.utils.device import select_accelerator` |
+| Typed `hydra.main` decorator | `hydra_main()` | `from src.utils.hydra import hydra_main` |
 | Seed RNGs in a script | `seed_everything()` | `from src.utils.seeding import seed_everything` |
 | Per-sample dataloader RNG | `make_sample_rng()` | `from src.utils.seeding import make_sample_rng` |
 | `mkdir(parents=True, exist_ok=True)` | `ensure_dir()` | `from src.utils.io import ensure_dir` |
@@ -46,6 +47,7 @@ types**, it belongs here (or should be promoted here), not in the task module.
 | Sample video frame indices | `sample_uniform_frame_indices()`, `sample_frame_indices_by_time_ranges()` | `from src.utils.video import ...` |
 | Download/transcode YouTube videos | `download_youtube_video()`, `transcode_h264_video()` | `from src.utils.video import ...` |
 | Transformer / MoE / RoPE blocks | `TransformerBlock`, `MoELayer`, RoPE helpers, `MLPHead` | `from src.utils.models import ...` |
+| Depthwise-separable / wise-wise conv blocks | `DepthwiseSeparableConv2d`, `Conv2dWiseWiseBlock` | `from src.utils.models import ...` |
 | LoRA-adapt a frozen backbone | `LoRAConfig`, `apply_lora()`, `apply_dinov3_lora()`, `configure_dinov3_trainability(..., lora=...)` | `from src.utils.models import ...` / `from src.utils.models.loading import ...` |
 
 ## Modules
@@ -62,6 +64,8 @@ types**, it belongs here (or should be promoted here), not in the task module.
   should still use `lightning.pytorch.seed_everything`.
 - **`io.py`** — `ensure_dir()`, `save_json()`, `load_json()`.
 - **`commands.py`** — `run_command()` for logged `subprocess.run(..., check=True)`.
+- **`hydra.py`** — `hydra_main()`, the typed wrapper around `hydra.main` that every
+  CLI entry point used to redeclare locally just to satisfy mypy/pyright.
 - **`tensor_utils.py`** — `clone_tensor_dict()`, `to_numpy()` (detaches, moves to
   CPU, upcasts bf16/fp16), `masked_mean()`, `normalize_padding_mask()`.
 
@@ -90,7 +94,8 @@ types**, it belongs here (or should be promoted here), not in the task module.
 ### Other packages (pre-existing)
 - **`models/`** — DeepSeek-style Transformer blocks, MoE, RoPE, attention,
   `MLPHead`, domain token embeddings, DINOv3 backbone loading, LoRA adaptation
-  (`lora.py`).
+  (`lora.py`), and CNN conv blocks (`blocks.py`: `DepthwiseSeparableConv2d`,
+  `Conv2dWiseWiseBlock`) shared by the ball- and court-detection models.
 - **`projection/`** — pinhole `Camera`, `CameraProjector`, `make_look_at_camera`,
   `project_points`.
 - **`rendering/`** — `CourtRenderer`, `SkeletonRenderer`, `BallRenderer`.

--- a/src/utils/hydra.py
+++ b/src/utils/hydra.py
@@ -1,0 +1,23 @@
+"""Typed wrapper around :func:`hydra.main`.
+
+``hydra.main`` is an untyped decorator factory, so every CLI entry point used to
+re-declare a private ``hydra_main`` shim purely to keep mypy/pyright happy. This
+module is the single shared implementation; import it instead of copying the
+wrapper into each script.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
+
+import hydra
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+__all__ = ["hydra_main"]
+
+
+def hydra_main(*args: Any, **kwargs: Any) -> Callable[[F], F]:
+    """Typed wrapper for :func:`hydra.main`."""
+    return cast(Callable[[F], F], hydra.main(*args, **kwargs))

--- a/src/utils/models/__init__.py
+++ b/src/utils/models/__init__.py
@@ -7,6 +7,10 @@ Strategy A: treat the DeepSeek-style, pure PyTorch implementation in
 from src.utils.models.architectures import (
     TransformerSequenceDiscriminator,
 )
+from src.utils.models.blocks import (
+    Conv2dWiseWiseBlock,
+    DepthwiseSeparableConv2d,
+)
 from src.utils.models.components import (
     MLP,
     CrossAttnBlock,
@@ -73,6 +77,9 @@ __all__ = [
     "TransformerBlock",
     "CrossAttnBlockConfig",
     "CrossAttnBlock",
+    # Conv blocks
+    "DepthwiseSeparableConv2d",
+    "Conv2dWiseWiseBlock",
     # Token embeddings
     "InvisibleTokenEmbedding",
     "CourtKPUVEmbedding",

--- a/src/utils/models/blocks.py
+++ b/src/utils/models/blocks.py
@@ -1,0 +1,57 @@
+"""Reusable convolutional building blocks (domain-agnostic).
+
+Depthwise-separable and ``Conv2d`` "wise-wise" blocks shared by the court- and
+ball-detection CNNs. Kept here so both tasks import a single canonical
+implementation instead of maintaining byte-identical copies.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+__all__ = ["Conv2dWiseWiseBlock", "DepthwiseSeparableConv2d"]
+
+
+class DepthwiseSeparableConv2d(nn.Module):
+    """Depthwise-separable 2-D convolution (depthwise to pointwise)."""
+
+    def __init__(self, in_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.depthwise = nn.Conv2d(
+            in_channels,
+            in_channels,
+            kernel_size=3,
+            padding=1,
+            groups=in_channels,
+            bias=False,
+        )
+        self.bn1 = nn.BatchNorm2d(in_channels)
+        self.pointwise = nn.Conv2d(in_channels, out_channels, kernel_size=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.relu(self.bn1(self.depthwise(x)))
+        x = self.relu(self.bn2(self.pointwise(x)))
+        return x
+
+
+class Conv2dWiseWiseBlock(nn.Module):
+    """Conv2d -> DWSepConv -> DWSepConv block."""
+
+    def __init__(self, in_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.conv2d = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+        )
+        self.wise_1 = DepthwiseSeparableConv2d(out_channels, out_channels)
+        self.wise_2 = DepthwiseSeparableConv2d(out_channels, out_channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv2d(x)
+        x = self.wise_1(x)
+        x = self.wise_2(x)
+        return x

--- a/tests/unit/tasks/base/test_preview.py
+++ b/tests/unit/tasks/base/test_preview.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+from omegaconf import OmegaConf
+
+from src.tasks.base.preview import resolve_sample_indices, resolve_split_file
+
+
+def _preview_cfg(sample_indices: list[int], max_samples: int) -> OmegaConf:
+    return OmegaConf.create(
+        {"preview": {"sample_indices": sample_indices, "max_samples": max_samples}}
+    )
+
+
+def test_explicit_sample_indices_take_precedence() -> None:
+    cfg = _preview_cfg([2, 5], max_samples=10)
+    assert resolve_sample_indices(cfg, 8) == [2, 5]
+
+
+def test_max_samples_clamped_to_dataset_size() -> None:
+    cfg = _preview_cfg([], max_samples=100)
+    assert resolve_sample_indices(cfg, 3) == [0, 1, 2]
+
+
+def test_min_samples_floor_matches_both_legacy_variants() -> None:
+    cfg = _preview_cfg([], max_samples=0)
+    # preview_heatmaps behaviour: no floor -> empty selection.
+    assert resolve_sample_indices(cfg, 5) == []
+    # preview_augmentation behaviour: floor at 1 -> one sample.
+    assert resolve_sample_indices(cfg, 5, min_samples=1) == [0]
+
+
+def test_out_of_range_explicit_index_raises() -> None:
+    cfg = _preview_cfg([9], max_samples=10)
+    with pytest.raises(IndexError):
+        resolve_sample_indices(cfg, 5)
+
+
+def test_resolve_split_file_looks_up_named_key() -> None:
+    cfg = OmegaConf.create(
+        {"data": {"split": {"train_file": "a.json", "val_file": "b.json"}}}
+    )
+    assert resolve_split_file(cfg, "val") == "b.json"
+    with pytest.raises(ValueError, match="Unknown preview.split"):
+        resolve_split_file(cfg, "test")

--- a/tests/unit/utils/models/test_blocks.py
+++ b/tests/unit/utils/models/test_blocks.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import torch
+
+from src.utils.models import Conv2dWiseWiseBlock, DepthwiseSeparableConv2d
+from src.utils.models.blocks import Conv2dWiseWiseBlock as BlocksWiseWise
+from src.utils.models.blocks import DepthwiseSeparableConv2d as BlocksDWSep
+
+
+def test_depthwise_separable_conv2d_preserves_spatial_shape() -> None:
+    block = DepthwiseSeparableConv2d(3, 8)
+    out = block(torch.randn(2, 3, 16, 16))
+    assert out.shape == (2, 8, 16, 16)
+
+
+def test_conv2d_wisewise_block_preserves_spatial_shape() -> None:
+    block = Conv2dWiseWiseBlock(4, 6)
+    out = block(torch.randn(2, 4, 12, 12))
+    assert out.shape == (2, 6, 12, 12)
+
+
+def test_task_import_paths_resolve_to_the_shared_classes() -> None:
+    """court-detection keeps its public import path via a re-export shim, and
+    ball-detection imports the shared class directly."""
+    from src.tasks.ball_detection.models.spatiotemporal_unet import (
+        Conv2dWiseWiseBlock as BallWiseWise,
+    )
+    from src.tasks.court_detection.models.blocks import (
+        Conv2dWiseWiseBlock as CourtWiseWise,
+    )
+    from src.tasks.court_detection.models.blocks import (
+        DepthwiseSeparableConv2d as CourtDWSep,
+    )
+
+    assert CourtWiseWise is Conv2dWiseWiseBlock is BlocksWiseWise is BallWiseWise
+    assert CourtDWSep is DepthwiseSeparableConv2d is BlocksDWSep

--- a/tests/unit/utils/test_hydra.py
+++ b/tests/unit/utils/test_hydra.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from src.utils.hydra import hydra_main
+
+
+def test_hydra_main_returns_a_decorator() -> None:
+    decorator = hydra_main(version_base="1.3", config_path=None)
+    assert callable(decorator)
+
+    def sample(cfg: object) -> object:
+        return cfg
+
+    wrapped = decorator(sample)
+    assert callable(wrapped)
+
+
+def test_scripts_use_the_shared_wrapper() -> None:
+    """The per-task CLI scripts now import the shared wrapper, not a local copy."""
+    from src.tasks.ball_detection.scripts import eval as ball_eval
+    from src.tasks.plcs.scripts import visualize as plcs_visualize
+
+    assert ball_eval.hydra_main is hydra_main
+    assert plcs_visualize.hydra_main is hydra_main


### PR DESCRIPTION
## 概要

- `src/utils` / `src/tasks/base` への定期的な共通化（util化）パス。タスク間で重複していた汎用ヘルパを集約し、WET コピーを削除した。
- 4 種類の重複を解消: `hydra_main` ラッパ、CNN conv ブロック、preview スクリプト用ヘルパ、JSON I/O ヘルパ。
- 挙動は不変（公開 import パスは re-export shim / import で維持）。35 ファイル、+342 / -447 行。

## 変更内容

- **hydra_main**: 新規 `src/utils/hydra.py` を追加。CLI スクリプト 22 本がローカル定義をやめ、共通の型付き `hydra.main` ラッパを import するように変更（未使用となった `TypeVar` / `cast` / `Callable` / `import hydra` も整理）。
- **conv ブロック**: 新規 `src/utils/models/blocks.py`（`DepthwiseSeparableConv2d` / `Conv2dWiseWiseBlock`）。`court_detection/models/blocks.py` は re-export shim 化、`ball_detection/models/spatiotemporal_unet.py` は共通クラスを import（byte-identical な重複定義を削除）。
- **preview ヘルパ**: 新規 `src/tasks/base/preview.py`（`resolve_sample_indices` / `resolve_split_file`）を ball / court の preview スクリプトで共有。`min_samples` 引数で 2 系統の従来挙動（floor あり/なし）を保持。
- **I/O**: `candidate_workflow.py` / `annotation_session.py`（ball）と `annotation_session.py`（court）のローカル `_read_json` / `_write_json_atomic` / `_utc_now` 等を `src/utils/io`（`load_json` / `save_json_atomic` / `read_jsonl` / `write_jsonl` / `utc_now_iso`）へ置換。
- `src/utils/README.md` に行を追加し、新規 util に単体テストを追加。

## 検証

- `ruff check`（変更全 33 ファイル）: パス
- 新規単体テスト（`test_hydra.py` / `test_blocks.py` / `test_preview.py`）: 10 件パス
- 影響タスクの単体スイート（ball_detection / court_detection / base / utils）+ base lightning train smoke: 422 件パス
- import smoke（変更全モジュール）: パス
- 新規 util モジュールは `mypy --follow-imports=skip` 単体でクリーン（pre-commit は repo 慣習に従い `SKIP=mypy` でコミット）

## 関連Issue

- なし（定期メンテナンスのため対応 Issue なし）

## 補足

今回はスコープを絞り、以下は意図的に見送り（フォローアップ候補）:

- `resolve_evaluation_device` / `eval.py` のデバイス解決: 既存は `cuda:0`、`src.utils.device.resolve_device("auto")` は `cuda`（index 無し）を返すため、挙動差を避けて保留。
- `colorize_heatmap` / `denormalize_tensor_to_rgb`、PLCS の Welford 統計クラス、numpy 版 angular-error 等: 単一呼び出し or numeric リスクのため別 PR に分離。
